### PR TITLE
Linux Mint/Ubuntu desktop fixes + plugin-API extensions + NEN 1414 stamp fix (v1.46.0)

### DIFF
--- a/open-pdf-studio/js/annotations/handles.js
+++ b/open-pdf-studio/js/annotations/handles.js
@@ -287,6 +287,27 @@ export function getAnnotationHandles(annotation, scale = 1) {
         annotation.points.forEach((p, i) => {
           handles.push({ type: HANDLE_TYPES.POLYLINE_NODE, x: p.x - hs/2, y: p.y - hs/2, nodeIndex: i });
         });
+      } else if (
+        typeof annotation.x === 'number'
+        && typeof annotation.y === 'number'
+        && typeof annotation.w === 'number'
+        && typeof annotation.h === 'number'
+      ) {
+        // Plugin rect/oval-area types (symitech.doorvoer.rect-area,
+        // symitech.doorvoer.oval-area, symitech.niet-onderzocht.rect-area,
+        // symitech.niet-onderzocht.oval-area) store geometry as
+        // {x, y, w, h} (not width/height). Emit the same 4 corner + 4 edge
+        // handles built-in box/circle types use, so users can resize after
+        // placement by dragging any handle.
+        const ax = annotation.x, ay = annotation.y, aw = annotation.w, ah = annotation.h;
+        handles.push({ type: HANDLE_TYPES.TOP_LEFT, x: ax - hs/2, y: ay - hs/2 });
+        handles.push({ type: HANDLE_TYPES.TOP_RIGHT, x: ax + aw - hs/2, y: ay - hs/2 });
+        handles.push({ type: HANDLE_TYPES.BOTTOM_LEFT, x: ax - hs/2, y: ay + ah - hs/2 });
+        handles.push({ type: HANDLE_TYPES.BOTTOM_RIGHT, x: ax + aw - hs/2, y: ay + ah - hs/2 });
+        handles.push({ type: HANDLE_TYPES.TOP, x: ax + aw/2 - hs/2, y: ay - hs/2 });
+        handles.push({ type: HANDLE_TYPES.BOTTOM, x: ax + aw/2 - hs/2, y: ay + ah - hs/2 });
+        handles.push({ type: HANDLE_TYPES.LEFT, x: ax - hs/2, y: ay + ah/2 - hs/2 });
+        handles.push({ type: HANDLE_TYPES.RIGHT, x: ax + aw - hs/2, y: ay + ah/2 - hs/2 });
       }
       break;
   }

--- a/open-pdf-studio/js/annotations/handles.js
+++ b/open-pdf-studio/js/annotations/handles.js
@@ -277,6 +277,18 @@ export function getAnnotationHandles(annotation, scale = 1) {
       // Text markup annotations use per-rect selection outlines (drawn in selection.js)
       // No bounding-box handles — they can only be moved or deleted
       break;
+
+    default:
+      // Fallback for plugin annotation types (e.g. symitech.scheur, symitech.vloer-contour,
+      // symitech.doorvoer-polyline-closed, symitech.doorvoer-line-contour,
+      // symitech.niet-onderzocht-polyline-closed): any annotation that exposes a
+      // points: Array<{x,y}> field gets per-vertex polyline_node handles automatically.
+      if (annotation.points && Array.isArray(annotation.points) && annotation.points.length > 0) {
+        annotation.points.forEach((p, i) => {
+          handles.push({ type: HANDLE_TYPES.POLYLINE_NODE, x: p.x - hs/2, y: p.y - hs/2, nodeIndex: i });
+        });
+      }
+      break;
   }
 
   // If the annotation is rotated, rotate all handle positions around the annotation center

--- a/open-pdf-studio/js/annotations/transforms.js
+++ b/open-pdf-studio/js/annotations/transforms.js
@@ -844,6 +844,59 @@ export function applyResize(annotation, handleType, deltaX, deltaY, originalAnn,
       break;
 
     default:
+      // Plugin rect/oval-area resize: types that use {x, y, w, h} (not
+      // width/height) get corner/edge resize support here. Mirrors the
+      // built-in 'box' case but writes to `w`/`h` instead.
+      if (
+        typeof originalAnn.x === 'number'
+        && typeof originalAnn.y === 'number'
+        && typeof originalAnn.w === 'number'
+        && typeof originalAnn.h === 'number'
+        && typeof handleType === 'string'
+        && !handleType.startsWith('polyline_node_')
+      ) {
+        switch (handleType) {
+          case HANDLE_TYPES.TOP_LEFT:
+            annotation.x = originalAnn.x + deltaX;
+            annotation.y = originalAnn.y + deltaY;
+            annotation.w = originalAnn.w - deltaX;
+            annotation.h = originalAnn.h - deltaY;
+            break;
+          case HANDLE_TYPES.TOP_RIGHT:
+            annotation.y = originalAnn.y + deltaY;
+            annotation.w = originalAnn.w + deltaX;
+            annotation.h = originalAnn.h - deltaY;
+            break;
+          case HANDLE_TYPES.BOTTOM_LEFT:
+            annotation.x = originalAnn.x + deltaX;
+            annotation.w = originalAnn.w - deltaX;
+            annotation.h = originalAnn.h + deltaY;
+            break;
+          case HANDLE_TYPES.BOTTOM_RIGHT:
+            annotation.w = originalAnn.w + deltaX;
+            annotation.h = originalAnn.h + deltaY;
+            break;
+          case HANDLE_TYPES.TOP:
+            annotation.y = originalAnn.y + deltaY;
+            annotation.h = originalAnn.h - deltaY;
+            break;
+          case HANDLE_TYPES.BOTTOM:
+            annotation.h = originalAnn.h + deltaY;
+            break;
+          case HANDLE_TYPES.LEFT:
+            annotation.x = originalAnn.x + deltaX;
+            annotation.w = originalAnn.w - deltaX;
+            break;
+          case HANDLE_TYPES.RIGHT:
+            annotation.w = originalAnn.w + deltaX;
+            break;
+        }
+        // Minimum-size guard: collapsing below 10 px makes the shape
+        // unreachable. Mirror the box-case minimum.
+        if (annotation.w < 10) annotation.w = 10;
+        if (annotation.h < 10) annotation.h = 10;
+        break;
+      }
       // Plugin polyline fallback: any annotation-type with a points array supports
       // polyline_node_<i> handle-drag identically to the builtin polyline case.
       if (typeof handleType === 'string' && handleType.startsWith('polyline_node_') &&

--- a/open-pdf-studio/js/annotations/transforms.js
+++ b/open-pdf-studio/js/annotations/transforms.js
@@ -1028,6 +1028,16 @@ export function applyMove(annotation, deltaX, deltaY) {
       if (typeof annotation.startY === 'number') annotation.startY += deltaY;
       if (typeof annotation.endX === 'number') annotation.endX += deltaX;
       if (typeof annotation.endY === 'number') annotation.endY += deltaY;
+      // Nested position-bearing fields used by point-marker plugin types
+      // (symitech.schade, symitech.reeks, symitech.doorvoer.point-marker store
+      // their coordinate as `at: {x, y}` rather than top-level x/y).
+      if (annotation.at && typeof annotation.at === 'object') {
+        if (typeof annotation.at.x === 'number') annotation.at.x += deltaX;
+        if (typeof annotation.at.y === 'number') annotation.at.y += deltaY;
+      }
+      // Center-coordinate variants (e.g. circle/ellipse-shaped plugin types).
+      if (typeof annotation.cx === 'number') annotation.cx += deltaX;
+      if (typeof annotation.cy === 'number') annotation.cy += deltaY;
       if (Array.isArray(annotation.points)) {
         annotation.points = annotation.points.map(p => ({
           ...p,

--- a/open-pdf-studio/js/annotations/transforms.js
+++ b/open-pdf-studio/js/annotations/transforms.js
@@ -842,6 +842,41 @@ export function applyResize(annotation, handleType, deltaX, deltaY, originalAnn,
       if (annotation.width < 20) annotation.width = 20;
       if (annotation.height < 20) annotation.height = 20;
       break;
+
+    default:
+      // Plugin polyline fallback: any annotation-type with a points array supports
+      // polyline_node_<i> handle-drag identically to the builtin polyline case.
+      if (typeof handleType === 'string' && handleType.startsWith('polyline_node_') &&
+          originalAnn.points && Array.isArray(originalAnn.points)) {
+        const nodeIdx = parseInt(handleType.split('_').pop(), 10);
+        if (!isNaN(nodeIdx) && nodeIdx < originalAnn.points.length) {
+          annotation.points = originalAnn.points.map((p, i) => {
+            if (i === nodeIdx) {
+              let nx = p.x + deltaX, ny = p.y + deltaY;
+              if (shiftKey) {
+                const len = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+                if (len > 0) {
+                  const ang = snapAngle(Math.atan2(deltaY, deltaX) * (180 / Math.PI), 45) * (Math.PI / 180);
+                  nx = p.x + len * Math.cos(ang);
+                  ny = p.y + len * Math.sin(ang);
+                }
+              }
+              return { x: nx, y: ny };
+            }
+            return { x: p.x, y: p.y };
+          });
+          // Recalculate bounding box if annotation tracks x/y/width/height
+          if (typeof annotation.x === 'number') {
+            const xs = annotation.points.map(p => p.x);
+            const ys = annotation.points.map(p => p.y);
+            annotation.x = Math.min(...xs);
+            annotation.y = Math.min(...ys);
+            annotation.width = Math.max(...xs) - annotation.x;
+            annotation.height = Math.max(...ys) - annotation.y;
+          }
+        }
+      }
+      break;
   }
 
   annotation.modifiedAt = new Date().toISOString();

--- a/open-pdf-studio/js/annotations/transforms.js
+++ b/open-pdf-studio/js/annotations/transforms.js
@@ -1012,6 +1012,37 @@ export function applyMove(annotation, deltaX, deltaY) {
         });
       }
       break;
+
+    default:
+      // Generic move for plugin-registered types (e.g. symitech.schade,
+      // symitech.scheur, symitech.vloer-contour). Without this branch any
+      // annotation whose type isn't in the built-in switch would silently
+      // refuse to move when dragged with the hand-tool.
+      // Strategy: shift any of the well-known position-bearing fields that
+      // are present on the annotation. Plugins that need custom semantics
+      // can still opt out by setting `annotation.locked = true` (handled
+      // at the top of this function).
+      if (typeof annotation.x === 'number') annotation.x += deltaX;
+      if (typeof annotation.y === 'number') annotation.y += deltaY;
+      if (typeof annotation.startX === 'number') annotation.startX += deltaX;
+      if (typeof annotation.startY === 'number') annotation.startY += deltaY;
+      if (typeof annotation.endX === 'number') annotation.endX += deltaX;
+      if (typeof annotation.endY === 'number') annotation.endY += deltaY;
+      if (Array.isArray(annotation.points)) {
+        annotation.points = annotation.points.map(p => ({
+          ...p,
+          x: typeof p.x === 'number' ? p.x + deltaX : p.x,
+          y: typeof p.y === 'number' ? p.y + deltaY : p.y,
+        }));
+      }
+      if (Array.isArray(annotation.path)) {
+        annotation.path = annotation.path.map(p => ({
+          ...p,
+          x: typeof p.x === 'number' ? p.x + deltaX : p.x,
+          y: typeof p.y === 'number' ? p.y + deltaY : p.y,
+        }));
+      }
+      break;
   }
 
   annotation.modifiedAt = new Date().toISOString();

--- a/open-pdf-studio/js/main.js
+++ b/open-pdf-studio/js/main.js
@@ -182,19 +182,14 @@ async function init() {
   // Load installed plugins (extension palettes, custom annotation types, etc.)
   initPlugins();
 
-  // Show the window after the browser has painted the first frame.
-  // Double requestAnimationFrame ensures layout + paint have completed.
+  // Show the window after frontend init. The previous double-rAF paint-wait
+  // gate permanently hides the window on WebKitGTK builds where accelerated
+  // compositing stalls before the first paint (observed on Linux Mint 22.3 +
+  // Mesa + Intel CML iGPU); rAF never resolves so show() is never called.
   if (isTauri() && window.__TAURI__?.window) {
-    await new Promise(resolve => {
-      requestAnimationFrame(() => requestAnimationFrame(resolve));
-    });
-    try {
-      const appWindow = window.__TAURI__.window.getCurrentWindow();
-      await appWindow.show();
-      await appWindow.setFocus();
-    } catch (e) {
-      console.warn('Failed to show window:', e);
-    }
+    const appWindow = window.__TAURI__.window.getCurrentWindow();
+    await appWindow.show();
+    await appWindow.setFocus();
   }
 
   // Now that Solid has rendered, grab canvas and container refs

--- a/open-pdf-studio/js/pdf/loader.js
+++ b/open-pdf-studio/js/pdf/loader.js
@@ -365,6 +365,13 @@ export async function createBlankPDF(widthPt, heightPt, numPages) {
     const doc = state.documents[index];
     doc.fileName = fileName;
 
+    // Pre-populate pageDims so plugins reading dimensions at click time
+    // don't depend on the first renderPage having completed.
+    doc.pageDims = {};
+    for (let i = 1; i <= numPages; i++) {
+      doc.pageDims[i] = { widthPt, heightPt };
+    }
+
     // Cache bytes under a memory key for saving later
     const memoryKey = `__memory__${doc.id}`;
     originalBytesCache.set(memoryKey, typedArray.slice());

--- a/open-pdf-studio/js/pdf/renderer.js
+++ b/open-pdf-studio/js/pdf/renderer.js
@@ -186,6 +186,16 @@ export async function renderPage(pageNum) {
   }
   const viewport = page.getViewport(viewportOpts);
 
+  // Sync the pdf-viewport singleton with current page dimensions for
+  // blank ("Nieuw") docs. The vector path further below already calls
+  // setPage() for docs with a real filePath; for filePath-less docs the
+  // gate skips that path and the singleton stays at pageW=0.
+  if (!doc.filePath) {
+    const [vx0, vy0, vx1, vy1] = page.view;
+    const { setPage: _setPageVp } = await import('./pdf-viewport.js');
+    _setPageVp(`__memory__${doc.id}`, pageNum, vx1 - vx0, vy1 - vy0, vx0, vy0, extraRotation);
+  }
+
   const pdfCanvas = getPdfCanvas();
   const annotationCanvas = getAnnotationCanvas();
   if (!pdfCanvas || !annotationCanvas) return;

--- a/open-pdf-studio/js/pdf/renderer.js
+++ b/open-pdf-studio/js/pdf/renderer.js
@@ -186,15 +186,13 @@ export async function renderPage(pageNum) {
   }
   const viewport = page.getViewport(viewportOpts);
 
-  // Sync the pdf-viewport singleton with current page dimensions for
-  // blank ("Nieuw") docs. The vector path further below already calls
-  // setPage() for docs with a real filePath; for filePath-less docs the
-  // gate skips that path and the singleton stays at pageW=0.
-  if (!doc.filePath) {
-    const [vx0, vy0, vx1, vy1] = page.view;
-    const { setPage: _setPageVp } = await import('./pdf-viewport.js');
-    _setPageVp(`__memory__${doc.id}`, pageNum, vx1 - vx0, vy1 - vy0, vx0, vy0, extraRotation);
-  }
+  // Cache page dimensions in PDF points on the doc so plugin annotation
+  // handlers can read them synchronously at click time without depending
+  // on the pdf-viewport singleton (which is a noop for blank docs whose
+  // vector path is gated off by the filePath check).
+  if (!doc.pageDims) doc.pageDims = {};
+  const [vx0, vy0, vx1, vy1] = page.view;
+  doc.pageDims[pageNum] = { widthPt: vx1 - vx0, heightPt: vy1 - vy0 };
 
   const pdfCanvas = getPdfCanvas();
   const annotationCanvas = getAnnotationCanvas();
@@ -985,7 +983,7 @@ export async function zoomIn() {
   if (doc.viewMode === 'continuous') {
     await renderContinuous();
   } else {
-    await renderPageOffscreen(doc.currentPage);
+    await renderPage(doc.currentPage);
   }
 }
 
@@ -1003,7 +1001,7 @@ export async function zoomOut() {
     if (doc.viewMode === 'continuous') {
       await renderContinuous();
     } else {
-      await renderPageOffscreen(doc.currentPage);
+      await renderPage(doc.currentPage);
     }
   }
 }
@@ -1025,7 +1023,7 @@ export async function setZoom(newScale) {
   if (doc.viewMode === 'continuous') {
     await renderContinuous();
   } else {
-    await renderPageOffscreen(doc.currentPage);
+    await renderPage(doc.currentPage);
   }
 }
 
@@ -1086,7 +1084,7 @@ async function _applyZoom(fitInputs, newZoom) {
   if (doc.viewMode === 'continuous') {
     await renderContinuous();
   } else {
-    await renderPageOffscreen(doc.currentPage);
+    await renderPage(doc.currentPage);
   }
 }
 
@@ -1127,7 +1125,7 @@ export async function actualSize() {
     if (doc.viewMode === 'continuous') {
       await renderContinuous();
     } else {
-      await renderPageOffscreen(doc.currentPage);
+      await renderPage(doc.currentPage);
     }
   }
 }

--- a/open-pdf-studio/js/pdf/saver.js
+++ b/open-pdf-studio/js/pdf/saver.js
@@ -7,6 +7,7 @@ import { getCachedPdfBytes, setCachedPdfBytes, hidePdfABar } from './loader.js';
 import { PDFDocument, PDFString, PDFName, PDFArray, PDFStream, degrees,
   PDFTextField, PDFCheckBox, PDFDropdown, PDFRadioGroup, PDFOptionList } from 'pdf-lib';
 import { getAnnotationStorage, getAnnotIdToFieldName } from './form-layer.js';
+import { getAnnotationType } from '../plugins/annotation-type-registry.js';
 import i18next from '../i18n/config.js';
 import { showMessage } from '../bridge.js';
 
@@ -1394,6 +1395,27 @@ export async function savePDF(saveAsPath = null) {
             if (ann.headSize && ann.headSize !== 12) mpDict.OPS_HeadSize = ann.headSize;
             annotDict = context.obj(mpDict);
             annotDict.set(PDFName.of('BS'), buildBorderStyle(context, borderWidth, ann.borderStyle));
+            break;
+          }
+
+          default: {
+            // Plugin-registered annotation types: delegate to the handler's
+            // optional serializeToPdf method. Unknown types without a handler
+            // remain dropped (legacy behavior).
+            const pluginHandler = getAnnotationType(ann.type);
+            if (pluginHandler && typeof pluginHandler.serializeToPdf === 'function') {
+              try {
+                await pluginHandler.serializeToPdf({
+                  pdfDoc: pdfDocLib,
+                  page,
+                  annotation: ann,
+                  convertX,
+                  convertY,
+                });
+              } catch (err) {
+                console.warn(`[saver] plugin serializeToPdf failed for type "${ann.type}":`, err);
+              }
+            }
             break;
           }
         }

--- a/open-pdf-studio/js/plugins/annotation-type-registry.js
+++ b/open-pdf-studio/js/plugins/annotation-type-registry.js
@@ -12,6 +12,14 @@
  *     preview(ctx, startX, startY, currentX, currentY, state, e) => void,
  *     hitTest(x, y, annotation, tolerance) => boolean,
  *     getBounds(annotation) => { x, y, width, height } | null,
+ *     serializeToPdf({ pdfDoc, page, annotation, convertX, convertY }) =>
+ *       Promise<void>   // optional. Called by saver for unknown types so the
+ *                       // plugin can bake content into the PDF page using its
+ *                       // own pdf-lib draw calls. Without this, plugin
+ *                       // annotations are not persisted in saved PDFs.
+ *                       // pdfDoc/page are pdf-lib instances; convertX/Y map
+ *                       // viewport coords (top-left, y-down) to pdf-lib
+ *                       // page coords (bottom-left, y-up).
  *     drawMode: 'drag' | 'click' | 'polyline',
  *     cursor: string   // CSS cursor, default 'crosshair'
  *   }

--- a/open-pdf-studio/js/plugins/palette-registry.js
+++ b/open-pdf-studio/js/plugins/palette-registry.js
@@ -25,8 +25,22 @@
  *     translationKey: string | null,
  *     icon: string,           // SVG string
  *     group: number,
- *     overrides: object | null
+ *     overrides: object | null,
+ *     subTools?: ToolDefinition[]   // optional: turns this entry into a "tool group"
  *   }
+ *
+ * Tool groups (subTools):
+ *   When a ToolDefinition has a non-empty `subTools` array, the host renders
+ *   it as a "tool group" rather than a single tool button. The main palette
+ *   button then shows the icon (and label) of the *currently active* sub-tool —
+ *   i.e. the button "morphs" to reflect the last choice — and clicking it opens
+ *   a sub-menu pop-out listing all sub-tools. Picking a sub-tool from the
+ *   pop-out activates that tool and persists the choice as the group's new
+ *   active sub-tool for the rest of the session (in-memory only; not
+ *   persisted across app restarts).
+ *
+ *   The active-sub-tool state lives in `tool-group-state.js`. Plugins can
+ *   feature-detect support via `api.features?.toolGroups === true`.
  */
 
 import { createSignal } from 'solid-js';

--- a/open-pdf-studio/js/plugins/palette-registry.js
+++ b/open-pdf-studio/js/plugins/palette-registry.js
@@ -12,7 +12,9 @@
  *     translationKey: string | null,
  *     tools: ToolDefinition[],
  *     defaultVisible: boolean,
- *     defaultMode: 'docked-left' | 'docked-right' | 'float'
+ *     defaultMode: 'docked-left' | 'docked-right' | 'float',
+ *     cssClass?: string         // extra class added to the palette root (.tp-docked / .tp-float)
+ *                               // so plugin-CSS can target without DOM scraping
  *   }
  *
  * ToolDefinition:

--- a/open-pdf-studio/js/plugins/plugin-api.js
+++ b/open-pdf-studio/js/plugins/plugin-api.js
@@ -12,6 +12,7 @@ import {
   registerSelectionListener as _registerSelectionListener,
   unregisterSelectionListener as _unregisterSelectionListener,
 } from './selection-listener-registry.js';
+import { clearAllToolGroups } from './tool-group-state.js';
 import { setNativePanelHidden } from '../solid/stores/propertiesStore.js';
 import { state, getActiveDocument } from '../core/state.js';
 import { setTool } from '../tools/manager.js';
@@ -26,6 +27,15 @@ export function createPluginApi(pluginId) {
 
   return {
     pluginId,
+
+    // --- Feature flags ---
+    // Plugins can feature-detect optional fork capabilities, e.g.:
+    //   if (api.features?.toolGroups === true) { ... }
+    // Adding a flag here is the contract for opting plugins into a feature
+    // without breaking older OPPS builds that lack it.
+    features: {
+      toolGroups: true,
+    },
 
     // --- Annotation type registration ---
     registerAnnotationType(typeName, handler) {
@@ -126,6 +136,8 @@ export function createPluginApi(pluginId) {
       registeredSelectionListeners.forEach(({ typeName, fn }) => _unregisterSelectionListener(typeName, fn));
       // Restore native panel visibility on plugin-deactivate so the host UI returns to default.
       setNativePanelHidden(false);
+      // Reset tool-group sub-tool selections so a fresh activate starts clean.
+      clearAllToolGroups();
       registeredTypes.length = 0;
       registeredPalettes.length = 0;
       registeredPanels.length = 0;

--- a/open-pdf-studio/js/plugins/plugin-api.js
+++ b/open-pdf-studio/js/plugins/plugin-api.js
@@ -7,6 +7,7 @@
 
 import { registerAnnotationType, unregisterAnnotationType } from './annotation-type-registry.js';
 import { registerToolPalette, unregisterToolPalette } from './palette-registry.js';
+import { registerPropertyPanel as _registerPropertyPanel, unregisterPropertyPanel as _unregisterPropertyPanel } from './property-panel-registry.js';
 import { state, getActiveDocument } from '../core/state.js';
 import { setTool } from '../tools/manager.js';
 import { createAnnotation } from '../annotations/factory.js';
@@ -15,6 +16,7 @@ import { redrawAnnotations } from '../annotations/rendering.js';
 export function createPluginApi(pluginId) {
   const registeredTypes = [];
   const registeredPalettes = [];
+  const registeredPanels = [];
 
   return {
     pluginId,
@@ -42,6 +44,18 @@ export function createPluginApi(pluginId) {
       unregisterToolPalette(id);
       const idx = registeredPalettes.indexOf(id);
       if (idx >= 0) registeredPalettes.splice(idx, 1);
+    },
+
+    // --- Property panel registration (custom edit-form for plugin annotations) ---
+    registerPropertyPanel(typeName, renderFn) {
+      _registerPropertyPanel(typeName, renderFn);
+      registeredPanels.push(typeName);
+    },
+
+    unregisterPropertyPanel(typeName) {
+      _unregisterPropertyPanel(typeName);
+      const idx = registeredPanels.indexOf(typeName);
+      if (idx >= 0) registeredPanels.splice(idx, 1);
     },
 
     // --- Tool management ---
@@ -80,8 +94,10 @@ export function createPluginApi(pluginId) {
     _cleanup() {
       registeredTypes.forEach(t => unregisterAnnotationType(t));
       registeredPalettes.forEach(id => unregisterToolPalette(id));
+      registeredPanels.forEach(t => _unregisterPropertyPanel(t));
       registeredTypes.length = 0;
       registeredPalettes.length = 0;
+      registeredPanels.length = 0;
     }
   };
 }

--- a/open-pdf-studio/js/plugins/plugin-api.js
+++ b/open-pdf-studio/js/plugins/plugin-api.js
@@ -8,6 +8,11 @@
 import { registerAnnotationType, unregisterAnnotationType } from './annotation-type-registry.js';
 import { registerToolPalette, unregisterToolPalette } from './palette-registry.js';
 import { registerPropertyPanel as _registerPropertyPanel, unregisterPropertyPanel as _unregisterPropertyPanel } from './property-panel-registry.js';
+import {
+  registerSelectionListener as _registerSelectionListener,
+  unregisterSelectionListener as _unregisterSelectionListener,
+} from './selection-listener-registry.js';
+import { setNativePanelHidden } from '../solid/stores/propertiesStore.js';
 import { state, getActiveDocument } from '../core/state.js';
 import { setTool } from '../tools/manager.js';
 import { createAnnotation } from '../annotations/factory.js';
@@ -17,6 +22,7 @@ export function createPluginApi(pluginId) {
   const registeredTypes = [];
   const registeredPalettes = [];
   const registeredPanels = [];
+  const registeredSelectionListeners = []; // [{typeName, fn}]
 
   return {
     pluginId,
@@ -58,6 +64,28 @@ export function createPluginApi(pluginId) {
       if (idx >= 0) registeredPanels.splice(idx, 1);
     },
 
+    // --- Selection listener (direct selection-event channel for plugin annotations) ---
+    // Listener fires with `annotation` on select and `null` on deselect. Plugins
+    // should compare by stable id (not ref) since OPPS may reload annotation refs.
+    registerSelectionListener(typeName, fn) {
+      _registerSelectionListener(typeName, fn);
+      registeredSelectionListeners.push({ typeName, fn });
+    },
+
+    unregisterSelectionListener(typeName, fn) {
+      _unregisterSelectionListener(typeName, fn);
+      const idx = registeredSelectionListeners.findIndex(e => e.typeName === typeName && e.fn === fn);
+      if (idx >= 0) registeredSelectionListeners.splice(idx, 1);
+    },
+
+    // --- Native property-panel visibility ---
+    // Plugin can hide OPPS' native eigenschappen-paneel during plugin-annotation
+    // editing so all controls live in the plugin's own palette/UI.
+    // Pass false to hide, true to restore. Caller is responsible for restoring on deselect.
+    setNativePanelVisible(visible) {
+      setNativePanelHidden(!visible);
+    },
+
     // --- Tool management ---
     setTool(toolName) {
       setTool(toolName);
@@ -95,9 +123,13 @@ export function createPluginApi(pluginId) {
       registeredTypes.forEach(t => unregisterAnnotationType(t));
       registeredPalettes.forEach(id => unregisterToolPalette(id));
       registeredPanels.forEach(t => _unregisterPropertyPanel(t));
+      registeredSelectionListeners.forEach(({ typeName, fn }) => _unregisterSelectionListener(typeName, fn));
+      // Restore native panel visibility on plugin-deactivate so the host UI returns to default.
+      setNativePanelHidden(false);
       registeredTypes.length = 0;
       registeredPalettes.length = 0;
       registeredPanels.length = 0;
+      registeredSelectionListeners.length = 0;
     }
   };
 }

--- a/open-pdf-studio/js/plugins/plugin-api.js
+++ b/open-pdf-studio/js/plugins/plugin-api.js
@@ -119,6 +119,39 @@ export function createPluginApi(pluginId) {
       return doc ? doc.currentPage : 1;
     },
 
+    /**
+     * Returns the active document's annotation array (read-only snapshot).
+     * Plugins use this for analytics-style widgets (counts, dashboards) that
+     * need to inspect existing annotations without subscribing to every
+     * mutation. Polling is expected — the returned array is the live store
+     * reference, so plugins must not mutate it.
+     *
+     * Each annotation has a `page` field (1-indexed). When no document is
+     * open, returns []. The activeDocument's `numPages` (page-count) can be
+     * derived via `getPageCount()`.
+     */
+    getAnnotations() {
+      const doc = getActiveDocument();
+      return doc && Array.isArray(doc.annotations) ? doc.annotations : [];
+    },
+
+    /**
+     * Returns the active document's total page-count (>= 1) or 0 if no
+     * document is open. Combined with `getAnnotations()` and `getCurrentPage()`
+     * this gives plugins everything they need for per-page analytics.
+     */
+    getPageCount() {
+      const doc = getActiveDocument();
+      if (!doc) return 0;
+      // Prefer numPages (canonical), fallback to pdfDoc.numPages, otherwise 0.
+      if (typeof doc.numPages === 'number' && doc.numPages > 0) return doc.numPages;
+      const pdfDoc = doc.pdfDoc;
+      if (pdfDoc && typeof pdfDoc.numPages === 'number' && pdfDoc.numPages > 0) {
+        return pdfDoc.numPages;
+      }
+      return 0;
+    },
+
     // --- Annotation helpers ---
     createAnnotation(props) {
       return createAnnotation(props);

--- a/open-pdf-studio/js/plugins/property-panel-registry.js
+++ b/open-pdf-studio/js/plugins/property-panel-registry.js
@@ -1,0 +1,43 @@
+/**
+ * Property Panel Registry
+ *
+ * Plugins can register a custom property-panel renderer for their own
+ * annotation types. When a user selects a plugin-annotation, OPPS looks
+ * up the renderer by annotation.type and mounts the returned DOM into
+ * the right-hand Eigenschappen panel.
+ *
+ * Renderer contract:
+ *   renderFn(annotation, updateAnnotProp, onCommit, onCancel) -> HTMLElement | DocumentFragment
+ *
+ *   - annotation: the selected annotation object
+ *   - updateAnnotProp(key, value): setter that mutates annotation in-place
+ *     and triggers redrawAnnotations(). Use dot-paths for nested fields:
+ *     "data.project" or "data.address.email".
+ *   - onCommit(): optional auto-save trigger (default: handled by OPPS
+ *     selection-clear flow, no explicit commit needed)
+ *   - onCancel(): optional revert trigger
+ */
+
+const registry = new Map();
+
+export function registerPropertyPanel(typeName, renderFn) {
+  if (typeof typeName !== 'string' || !typeName) {
+    throw new Error('registerPropertyPanel: typeName must be a non-empty string');
+  }
+  if (typeof renderFn !== 'function') {
+    throw new Error(`registerPropertyPanel: renderFn must be a function for type "${typeName}"`);
+  }
+  registry.set(typeName, renderFn);
+}
+
+export function getPropertyPanel(typeName) {
+  return registry.get(typeName) || null;
+}
+
+export function unregisterPropertyPanel(typeName) {
+  registry.delete(typeName);
+}
+
+export function hasPropertyPanel(typeName) {
+  return registry.has(typeName);
+}

--- a/open-pdf-studio/js/plugins/selection-listener-registry.js
+++ b/open-pdf-studio/js/plugins/selection-listener-registry.js
@@ -1,0 +1,65 @@
+/**
+ * Selection Listener Registry
+ *
+ * Plugins can register a listener that fires when an annotation of a specific
+ * type is selected or deselected. This is a direct selection-event channel
+ * (separate from registerPropertyPanel) so plugins can mount UI outside the
+ * property-panel without scraping DOM internals.
+ *
+ * Listener contract:
+ *   listener(annotation | null)
+ *
+ *   - annotation = a selected annotation matching typeName
+ *   - null       = the selection was cleared (deselect, close, multi-select)
+ *
+ * Idempotency: listeners are called on every selection change, including
+ * re-selecting the same annotation (object-ref may differ across renders).
+ * The plugin should compare by stable id, not by reference.
+ *
+ * Lifecycle: listeners are NOT auto-cleaned. Plugin-manager._cleanup() must
+ * call unregisterSelectionListener for each registered (typeName, fn) pair.
+ */
+
+const listeners = new Map(); // typeName -> Set<fn>
+
+export function registerSelectionListener(typeName, fn) {
+  if (typeof typeName !== 'string' || !typeName) {
+    throw new Error('registerSelectionListener: typeName must be a non-empty string');
+  }
+  if (typeof fn !== 'function') {
+    throw new Error(`registerSelectionListener: fn must be a function for type "${typeName}"`);
+  }
+  let set = listeners.get(typeName);
+  if (!set) {
+    set = new Set();
+    listeners.set(typeName, set);
+  }
+  set.add(fn);
+}
+
+export function unregisterSelectionListener(typeName, fn) {
+  const set = listeners.get(typeName);
+  if (!set) return;
+  set.delete(fn);
+  if (set.size === 0) listeners.delete(typeName);
+}
+
+/**
+ * Fire all listeners for the matching typeName. annotation=null fires for ALL
+ * registered types (deselect signal — plugins don't know which type was active).
+ */
+export function fireSelectionChange(annotation) {
+  if (annotation == null) {
+    for (const set of listeners.values()) {
+      for (const fn of set) {
+        try { fn(null); } catch (err) { console.error('[selection-listener] threw on null', err); }
+      }
+    }
+    return;
+  }
+  const set = listeners.get(annotation.type);
+  if (!set) return;
+  for (const fn of set) {
+    try { fn(annotation); } catch (err) { console.error(`[selection-listener] threw for ${annotation.type}`, err); }
+  }
+}

--- a/open-pdf-studio/js/plugins/tool-group-state.js
+++ b/open-pdf-studio/js/plugins/tool-group-state.js
@@ -1,0 +1,89 @@
+/**
+ * Tool Group State
+ *
+ * In-memory, session-only state for "tool groups" — ToolDefinitions that
+ * declare a `subTools` array. The host renders such a tool as a single
+ * palette button that opens a sub-menu pop-out. The currently active
+ * sub-tool per group is persisted here so the main button can morph to
+ * show that sub-tool's icon between clicks.
+ *
+ * State shape: Map<groupId, currentSubToolId>
+ *
+ * Reactive: backed by a Solid signal, so consumers (palette renderer,
+ * etc.) can subscribe via the imported getters and re-run on change.
+ *
+ * Lifetime: in-memory only. Cleared on plugin-deactivate via
+ * `clearAllToolGroups()`. NO localStorage; choice does not survive
+ * an app restart by design.
+ */
+
+import { createSignal } from 'solid-js';
+
+const [groupState, setGroupState] = createSignal(new Map());
+
+/**
+ * Returns the active sub-tool id for a given group, or null if the user
+ * has not made a choice yet in this session.
+ *
+ * @param {string} groupId
+ * @returns {string | null}
+ */
+export function getActiveSubToolId(groupId) {
+  const map = groupState();
+  return map.has(groupId) ? map.get(groupId) : null;
+}
+
+/**
+ * Returns the currently active sub-tool ToolDefinition for a group.
+ * Falls back to `groupDef.subTools[0]` if no choice has been made yet
+ * or if the stored id no longer matches any sub-tool (e.g. plugin
+ * re-registered with a different sub-tool set).
+ *
+ * @param {object} groupDef ToolDefinition with a non-empty `subTools` array
+ * @returns {object} a ToolDefinition from groupDef.subTools
+ */
+export function getActiveSubTool(groupDef) {
+  const subTools = groupDef && groupDef.subTools;
+  if (!subTools || subTools.length === 0) {
+    throw new Error('getActiveSubTool: groupDef has no subTools');
+  }
+  const activeId = getActiveSubToolId(groupDef.id);
+  if (activeId !== null) {
+    const found = subTools.find(t => t.id === activeId);
+    if (found) return found;
+  }
+  return subTools[0];
+}
+
+/**
+ * Set the active sub-tool for a group. Triggers reactive consumers.
+ *
+ * @param {string} groupId
+ * @param {string} subToolId
+ */
+export function setActiveSubTool(groupId, subToolId) {
+  setGroupState(prev => {
+    const next = new Map(prev);
+    next.set(groupId, subToolId);
+    return next;
+  });
+}
+
+/**
+ * Reset all tool-group state. Called on plugin deactivate so a fresh
+ * activate starts with no stale per-group selections.
+ */
+export function clearAllToolGroups() {
+  setGroupState(new Map());
+}
+
+/**
+ * Direct access to the underlying signal getter for consumers that need
+ * the full Map (e.g. devtools, debug panels). Most callers should use
+ * `getActiveSubToolId` / `getActiveSubTool` instead.
+ *
+ * @returns {Map<string, string>}
+ */
+export function getToolGroupStateSnapshot() {
+  return groupState();
+}

--- a/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
+++ b/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
@@ -5,7 +5,7 @@
  * with independent docking, floating, visibility, and drag state.
  */
 
-import { createSignal, Show, For, onMount } from 'solid-js';
+import { createSignal, createEffect, Show, For, onMount, onCleanup } from 'solid-js';
 
 import { state, noPdf } from '../../core/state.js';
 import { setTool } from '../../tools/manager.js';
@@ -15,6 +15,10 @@ import { savePreferences } from '../../core/preferences.js';
 import { registerPaletteDock, unregisterPaletteDock } from '../stores/paletteOrder.js';
 import { hasAnnotationType } from '../../plugins/annotation-type-registry.js';
 import { paletteIconSize, showPaletteCtxMenu } from './ToolPalette.jsx';
+import { getActiveSubTool, setActiveSubTool } from '../../plugins/tool-group-state.js';
+
+// Single-active-group open-state across the whole app (only one sub-menu open at a time).
+const [openGroupId, setOpenGroupId] = createSignal(null);
 
 const DOCK_SNAP = 60;
 
@@ -192,6 +196,131 @@ function ExtToolBtn(props) {
   );
 }
 
+// --- Tool-group button (B1+P1: morphing main + pop-out sub-menu) ---
+function ExtToolGroupBtn(props) {
+  const { t } = useTranslation('ribbon');
+  const toolDisabled = () => noPdf() || isPdfAReadOnly();
+
+  const groupDef = () => props.groupDef;
+  const activeSub = () => getActiveSubTool(groupDef());
+
+  const subOverridesEqual = (a, b) => {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    const ka = Object.keys(a);
+    const kb = Object.keys(b);
+    return ka.length === kb.length && ka.every(k => a[k] === b[k]);
+  };
+
+  // Main button is "active" when current tool/overrides match the active sub-tool.
+  const isActive = () => {
+    const sub = activeSub();
+    if (state.currentTool !== sub.tool) return false;
+    return subOverridesEqual(sub.overrides || null, state.toolOverrides || null);
+  };
+
+  const isOpen = () => openGroupId() === groupDef().id;
+
+  // Activate sub-tool: fire setTool + apply overrides.
+  const activateSub = (sub) => {
+    setTool(sub.tool);
+    state.toolOverrides = sub.overrides || null;
+  };
+
+  const onMainClick = () => {
+    const sub = activeSub();
+    activateSub(sub);
+    setOpenGroupId(isOpen() ? null : groupDef().id);
+  };
+
+  const onSubClick = (sub) => {
+    setActiveSubTool(groupDef().id, sub.id);
+    activateSub(sub);
+    setOpenGroupId(null);
+  };
+
+  // Outside-click + Escape handling, mounted only while the menu is open.
+  let menuRef;
+  const onDocMouseDown = (e) => {
+    if (!menuRef) return;
+    if (menuRef.contains(e.target)) return;
+    // Also ignore clicks on the main button itself; its onClick handles toggle.
+    if (e.target.closest && e.target.closest(`[data-tool-group-id="${groupDef().id}"]`)) return;
+    setOpenGroupId(null);
+  };
+  const onDocKey = (e) => {
+    if (e.key === 'Escape') setOpenGroupId(null);
+  };
+  let listenersAttached = false;
+  const ensureListeners = () => {
+    if (listenersAttached) return;
+    document.addEventListener('mousedown', onDocMouseDown);
+    document.addEventListener('keydown', onDocKey);
+    listenersAttached = true;
+  };
+  const removeListeners = () => {
+    if (!listenersAttached) return;
+    document.removeEventListener('mousedown', onDocMouseDown);
+    document.removeEventListener('keydown', onDocKey);
+    listenersAttached = false;
+  };
+  // Reactively attach/detach listeners when the menu opens/closes.
+  createEffect(() => {
+    if (isOpen()) ensureListeners();
+    else removeListeners();
+  });
+  onCleanup(removeListeners);
+
+  // Sub-menu position class based on palette docked side.
+  const sideClass = () => {
+    const s = props.side;
+    if (s === 'left') return 'from-docked-left';
+    if (s === 'right') return 'from-docked-right';
+    return 'from-float';
+  };
+
+  const subTitle = (sub) => {
+    if (sub.translationKey) {
+      const tr = t(sub.translationKey);
+      if (tr && tr !== sub.translationKey) return tr;
+    }
+    return sub.label || sub.id;
+  };
+
+  return (
+    <div class="tp-btn-group-wrap" data-tool-group-id={groupDef().id} style="position:relative; display:inline-flex;">
+      <button
+        class={`tp-btn has-sub ${isActive() ? 'active' : ''}`}
+        disabled={toolDisabled()}
+        onClick={onMainClick}
+        title={props.title}
+        innerHTML={activeSub().icon}
+      />
+      <span class="tp-btn-chevron" aria-hidden="true">▸</span>
+      <Show when={isOpen()}>
+        <div ref={menuRef} class={`tp-submenu ${sideClass()}`}>
+          <For each={groupDef().subTools}>
+            {(sub) => {
+              const subActive = () =>
+                state.currentTool === sub.tool &&
+                subOverridesEqual(sub.overrides || null, state.toolOverrides || null);
+              return (
+                <button
+                  class={`tp-btn ${subActive() ? 'active' : ''}`}
+                  disabled={toolDisabled()}
+                  onClick={() => onSubClick(sub)}
+                  title={subTitle(sub)}
+                  innerHTML={sub.icon}
+                />
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
 // --- Tool list with separators ---
 function ExtToolList(props) {
   const { t } = useTranslation('ribbon');
@@ -203,10 +332,18 @@ function ExtToolList(props) {
         lastGroup = item.group;
         const translated = item.translationKey ? t(item.translationKey) : null;
         const title = (translated && translated !== item.translationKey) ? translated : item.label;
+        const isGroup = Array.isArray(item.subTools) && item.subTools.length > 0;
         return (
           <>
             {showSep && <div class="tp-sep" />}
-            <ExtToolBtn tool={item.tool} title={title} icon={item.icon} overrides={item.overrides || null} />
+            <Show
+              when={isGroup}
+              fallback={
+                <ExtToolBtn tool={item.tool} title={title} icon={item.icon} overrides={item.overrides || null} />
+              }
+            >
+              <ExtToolGroupBtn groupDef={item} title={title} side={props.side} />
+            </Show>
           </>
         );
       }}
@@ -255,7 +392,7 @@ export function DockedExtPalette(props) {
           <div class="tp-logo" innerHTML={props.descriptor.logo} />
         </Show>
         <div class="tp-docked-tools">
-          <ExtToolList tools={props.descriptor.tools} />
+          <ExtToolList tools={props.descriptor.tools} side={side()} />
         </div>
         <button class="tp-close" onClick={() => {
           ps().visible[1](false);
@@ -311,7 +448,7 @@ export function FloatingExtPalette(props) {
           <div class="tp-logo" innerHTML={props.descriptor.logo} />
         </Show>
         <div class="tp-float-body">
-          <ExtToolList tools={props.descriptor.tools} />
+          <ExtToolList tools={props.descriptor.tools} side="float" />
         </div>
       </div>
     </Show>

--- a/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
+++ b/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
@@ -6,6 +6,7 @@
  */
 
 import { createSignal, createEffect, Show, For, onMount, onCleanup } from 'solid-js';
+import { Portal } from 'solid-js/web';
 
 import { state, noPdf } from '../../core/state.js';
 import { setTool } from '../../tools/manager.js';
@@ -174,16 +175,21 @@ function startExtDrag(id, e, fromDocked) {
   document.addEventListener('mouseup', onUp);
 }
 
+// Compare two override-objects for shallow equality. Treats null/undefined as
+// equivalent to "no overrides" so an absent map equals an empty/null map.
+function overridesEqual(a, b) {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  const ka = Object.keys(a);
+  return ka.length === Object.keys(b).length && ka.every(k => a[k] === b[k]);
+}
+
 // --- Tool button ---
 function ExtToolBtn(props) {
   const toolDisabled = () => noPdf() || isPdfAReadOnly();
   const isActive = () => {
     if (state.currentTool !== props.tool) return false;
-    if (!props.overrides && !state.toolOverrides) return true;
-    if (!props.overrides || !state.toolOverrides) return false;
-    const keys = Object.keys(props.overrides);
-    return keys.length === Object.keys(state.toolOverrides).length &&
-      keys.every(k => state.toolOverrides[k] === props.overrides[k]);
+    return overridesEqual(props.overrides || null, state.toolOverrides || null);
   };
   return (
     <button
@@ -204,19 +210,11 @@ function ExtToolGroupBtn(props) {
   const groupDef = () => props.groupDef;
   const activeSub = () => getActiveSubTool(groupDef());
 
-  const subOverridesEqual = (a, b) => {
-    if (!a && !b) return true;
-    if (!a || !b) return false;
-    const ka = Object.keys(a);
-    const kb = Object.keys(b);
-    return ka.length === kb.length && ka.every(k => a[k] === b[k]);
-  };
-
   // Main button is "active" when current tool/overrides match the active sub-tool.
   const isActive = () => {
     const sub = activeSub();
     if (state.currentTool !== sub.tool) return false;
-    return subOverridesEqual(sub.overrides || null, state.toolOverrides || null);
+    return overridesEqual(sub.overrides || null, state.toolOverrides || null);
   };
 
   const isOpen = () => openGroupId() === groupDef().id;
@@ -227,9 +225,29 @@ function ExtToolGroupBtn(props) {
     state.toolOverrides = sub.overrides || null;
   };
 
+  // Sub-menu lives in a Portal (escapes docked-palette overflow:hidden), so we
+  // compute viewport-fixed coordinates from the wrap's bounding rect on open.
+  let wrapRef;
+  let menuRef;
+  const [pos, setPos] = createSignal({ top: 0, left: 0 });
+
+  const recomputePos = () => {
+    if (!wrapRef) return;
+    const rect = wrapRef.getBoundingClientRect();
+    if (props.side === 'right') {
+      // Docked-right palette: anchor menu to the right of the viewport so it
+      // grows leftward from the wrap's left edge. Menu width is unknown here.
+      setPos({ top: rect.top, right: window.innerWidth - rect.left + 6 });
+    } else {
+      // Docked-left or float: pop out to the right of the wrap.
+      setPos({ top: rect.top, left: rect.right + 6 });
+    }
+  };
+
   const onMainClick = () => {
     const sub = activeSub();
     activateSub(sub);
+    if (!isOpen()) recomputePos();
     setOpenGroupId(isOpen() ? null : groupDef().id);
   };
 
@@ -240,12 +258,11 @@ function ExtToolGroupBtn(props) {
   };
 
   // Outside-click + Escape handling, mounted only while the menu is open.
-  let menuRef;
   const onDocMouseDown = (e) => {
-    if (!menuRef) return;
-    if (menuRef.contains(e.target)) return;
-    // Also ignore clicks on the main button itself; its onClick handles toggle.
-    if (e.target.closest && e.target.closest(`[data-tool-group-id="${groupDef().id}"]`)) return;
+    // Click inside the portal'd menu: keep open.
+    if (menuRef && menuRef.contains(e.target)) return;
+    // Click on main button (inside the wrap): its own onClick handles toggle.
+    if (wrapRef && wrapRef.contains(e.target)) return;
     setOpenGroupId(null);
   };
   const onDocKey = (e) => {
@@ -264,14 +281,22 @@ function ExtToolGroupBtn(props) {
     document.removeEventListener('keydown', onDocKey);
     listenersAttached = false;
   };
-  // Reactively attach/detach listeners when the menu opens/closes.
+  // Reactively attach/detach listeners when the menu opens/closes. Also
+  // re-compute position on window resize while the menu is open.
   createEffect(() => {
-    if (isOpen()) ensureListeners();
-    else removeListeners();
+    if (isOpen()) {
+      ensureListeners();
+      const onResize = () => recomputePos();
+      window.addEventListener('resize', onResize);
+      onCleanup(() => window.removeEventListener('resize', onResize));
+    } else {
+      removeListeners();
+    }
   });
   onCleanup(removeListeners);
 
-  // Sub-menu position class based on palette docked side.
+  // Sub-menu position class based on palette docked side (kept for any
+  // future side-specific visual tweaks; positioning itself is now inline).
   const sideClass = () => {
     const s = props.side;
     if (s === 'left') return 'from-docked-left';
@@ -287,35 +312,47 @@ function ExtToolGroupBtn(props) {
     return sub.label || sub.id;
   };
 
+  const submenuStyle = () => {
+    const p = pos();
+    const s = { position: 'fixed', top: `${p.top}px` };
+    if (p.left !== undefined) s.left = `${p.left}px`;
+    if (p.right !== undefined) s.right = `${p.right}px`;
+    return s;
+  };
+
   return (
-    <div class="tp-btn-group-wrap" data-tool-group-id={groupDef().id} style="position:relative; display:inline-flex;">
+    <div ref={wrapRef} class="tp-btn-group-wrap">
       <button
         class={`tp-btn has-sub ${isActive() ? 'active' : ''}`}
         disabled={toolDisabled()}
         onClick={onMainClick}
         title={props.title}
+        aria-haspopup="menu"
+        aria-expanded={isOpen() ? 'true' : 'false'}
         innerHTML={activeSub().icon}
       />
       <span class="tp-btn-chevron" aria-hidden="true">▸</span>
       <Show when={isOpen()}>
-        <div ref={menuRef} class={`tp-submenu ${sideClass()}`}>
-          <For each={groupDef().subTools}>
-            {(sub) => {
-              const subActive = () =>
-                state.currentTool === sub.tool &&
-                subOverridesEqual(sub.overrides || null, state.toolOverrides || null);
-              return (
-                <button
-                  class={`tp-btn ${subActive() ? 'active' : ''}`}
-                  disabled={toolDisabled()}
-                  onClick={() => onSubClick(sub)}
-                  title={subTitle(sub)}
-                  innerHTML={sub.icon}
-                />
-              );
-            }}
-          </For>
-        </div>
+        <Portal>
+          <div ref={menuRef} class={`tp-submenu ${sideClass()}`} style={submenuStyle()}>
+            <For each={groupDef().subTools}>
+              {(sub) => {
+                const subActive = () =>
+                  state.currentTool === sub.tool &&
+                  overridesEqual(sub.overrides || null, state.toolOverrides || null);
+                return (
+                  <button
+                    class={`tp-btn ${subActive() ? 'active' : ''}`}
+                    disabled={toolDisabled()}
+                    onClick={() => onSubClick(sub)}
+                    title={subTitle(sub)}
+                    innerHTML={sub.icon}
+                  />
+                );
+              }}
+            </For>
+          </div>
+        </Portal>
       </Show>
     </div>
   );

--- a/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
+++ b/open-pdf-studio/js/solid/components/ExtensionToolPalette.jsx
@@ -247,7 +247,7 @@ export function DockedExtPalette(props) {
 
   return (
     <Show when={shouldShow()}>
-      <div class={`tp-docked tp-ext tp-docked-${side()}${paletteIconSize() === 'large' ? ' tp-large' : ''}`} onContextMenu={showPaletteCtxMenu}>
+      <div class={`tp-docked tp-ext tp-docked-${side()}${paletteIconSize() === 'large' ? ' tp-large' : ''}${props.descriptor.cssClass ? ' ' + props.descriptor.cssClass : ''}`} onContextMenu={showPaletteCtxMenu}>
         <div class="tp-grip" onMouseDown={(e) => startExtDrag(id(), e, true)}>
           <GripIcon />
         </div>
@@ -287,7 +287,7 @@ export function FloatingExtPalette(props) {
   return (
     <Show when={shouldShow()}>
       <div
-        class={`tp-float tp-ext${paletteIconSize() === 'large' ? ' tp-large' : ''}`}
+        class={`tp-float tp-ext${paletteIconSize() === 'large' ? ' tp-large' : ''}${props.descriptor.cssClass ? ' ' + props.descriptor.cssClass : ''}`}
         style={`left:${ps().floatPos[0]().x}px; top:${ps().floatPos[0]().y}px`}
         onContextMenu={showPaletteCtxMenu}
       >

--- a/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
@@ -1,5 +1,5 @@
 import { Show, createEffect, onCleanup } from 'solid-js';
-import { customPanelRender, updateAnnotProp, getCurrentAnnotation, storeHideProperties } from '../../stores/propertiesStore.js';
+import { customPanelRender, updateAnnotProp, getCurrentAnnotation, storeHideProperties, annotProps } from '../../stores/propertiesStore.js';
 
 /**
  * Mounts a plugin-provided custom property-panel renderer when the selected
@@ -20,6 +20,12 @@ export default function CustomPluginPanel() {
 
   createEffect(() => {
     const renderFn = customPanelRender();
+    // Track annotProps.id reactively so the effect re-runs when the selected
+    // annotation changes, even if customPanelRender stays the same renderFn
+    // reference. getCurrentAnnotation() is a plain getter (not a signal); reading
+    // it alone would lose tracking and the panel would stay stale on selection
+    // swaps within the same plugin type.
+    const trackedId = annotProps.id; // eslint-disable-line @typescript-eslint/no-unused-vars
     const annotation = getCurrentAnnotation();
     if (!containerRef || !renderFn || !annotation) {
       if (containerRef) containerRef.innerHTML = '';

--- a/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
@@ -13,11 +13,22 @@ import { customPanelRender, updateAnnotProp, getCurrentAnnotation, storeHideProp
 export default function CustomPluginPanel() {
   let containerRef;
 
+  // Track last-active renderFn so we can fire a deselect-signal (renderFn(null))
+  // when annotation goes away. Plugins that mount DOM elsewhere (e.g. into a
+  // tool-palette) need this to know when to clean up.
+  let lastRenderFn = null;
+
   createEffect(() => {
     const renderFn = customPanelRender();
     const annotation = getCurrentAnnotation();
     if (!containerRef || !renderFn || !annotation) {
       if (containerRef) containerRef.innerHTML = '';
+      // Deselect-signal: fire renderFn(null) so plugin can unmount external DOM.
+      if (lastRenderFn) {
+        try { lastRenderFn(null, updateAnnotProp, () => {}, storeHideProperties); }
+        catch (err) { console.error('[CustomPluginPanel] deselect signal threw', err); }
+      }
+      lastRenderFn = renderFn;
       return;
     }
     containerRef.innerHTML = '';
@@ -27,10 +38,16 @@ export default function CustomPluginPanel() {
     } catch (err) {
       console.error('[CustomPluginPanel] renderFn threw', err);
     }
+    lastRenderFn = renderFn;
   });
 
   onCleanup(() => {
     if (containerRef) containerRef.innerHTML = '';
+    if (lastRenderFn) {
+      try { lastRenderFn(null, updateAnnotProp, () => {}, storeHideProperties); }
+      catch (err) { console.error('[CustomPluginPanel] cleanup signal threw', err); }
+      lastRenderFn = null;
+    }
   });
 
   return (

--- a/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/CustomPluginPanel.jsx
@@ -1,0 +1,41 @@
+import { Show, createEffect, onCleanup } from 'solid-js';
+import { customPanelRender, updateAnnotProp, getCurrentAnnotation, storeHideProperties } from '../../stores/propertiesStore.js';
+
+/**
+ * Mounts a plugin-provided custom property-panel renderer when the selected
+ * annotation type has one registered via api.registerPropertyPanel(). The
+ * plugin renderer returns plain DOM (HTMLElement | DocumentFragment) which we
+ * append to the panel-body.
+ *
+ * Renderer signature:
+ *   renderFn(annotation, updateAnnotProp, onCommit, onCancel) -> DOM
+ */
+export default function CustomPluginPanel() {
+  let containerRef;
+
+  createEffect(() => {
+    const renderFn = customPanelRender();
+    const annotation = getCurrentAnnotation();
+    if (!containerRef || !renderFn || !annotation) {
+      if (containerRef) containerRef.innerHTML = '';
+      return;
+    }
+    containerRef.innerHTML = '';
+    try {
+      const dom = renderFn(annotation, updateAnnotProp, () => {}, storeHideProperties);
+      if (dom) containerRef.appendChild(dom);
+    } catch (err) {
+      console.error('[CustomPluginPanel] renderFn threw', err);
+    }
+  });
+
+  onCleanup(() => {
+    if (containerRef) containerRef.innerHTML = '';
+  });
+
+  return (
+    <Show when={customPanelRender()}>
+      <div class="custom-plugin-panel" ref={containerRef} />
+    </Show>
+  );
+}

--- a/open-pdf-studio/js/solid/components/properties-panel/PropertiesPanel.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/PropertiesPanel.jsx
@@ -16,6 +16,7 @@ import ContentSection from './ContentSection.jsx';
 import ImageSection from './ImageSection.jsx';
 import ActionsSection from './ActionsSection.jsx';
 import CustomFieldsSection from './CustomFieldsSection.jsx';
+import CustomPluginPanel from './CustomPluginPanel.jsx';
 import CollapsibleSection from './CollapsibleSection.jsx';
 
 export default function PropertiesPanel() {
@@ -130,6 +131,7 @@ export default function PropertiesPanel() {
             <ContentSection />
             <ImageSection />
             <CustomFieldsSection />
+            <CustomPluginPanel />
             <ActionsSection />
           </div>
         </Show>

--- a/open-pdf-studio/js/solid/components/properties-panel/PropertiesPanel.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/PropertiesPanel.jsx
@@ -1,5 +1,5 @@
 import { Show } from 'solid-js';
-import { panelVisible, panelCollapsed, setPanelCollapsed, annotProps, sectionVis, updateAnnotProp, cycleSelectNext } from '../../stores/propertiesStore.js';
+import { panelVisible, panelCollapsed, setPanelCollapsed, annotProps, sectionVis, updateAnnotProp, cycleSelectNext, nativePanelHidden } from '../../stores/propertiesStore.js';
 import { useTranslation } from '../../../i18n/useTranslation.js';
 import PanelHeader from './PanelHeader.jsx';
 import DocInfoView from './DocInfoView.jsx';
@@ -27,7 +27,7 @@ export default function PropertiesPanel() {
   }
 
   return (
-    <Show when={panelVisible()}>
+    <Show when={panelVisible() && !nativePanelHidden()}>
       <div class={`properties-panel-outer ${panelCollapsed() ? 'collapsed' : ''}`}
         onMouseDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}>

--- a/open-pdf-studio/js/solid/data/nen1414Library.js
+++ b/open-pdf-studio/js/solid/data/nen1414Library.js
@@ -3,7 +3,7 @@
 // Categories by prefix: Tb=Brandbeveiliging, Td=Deuren, Tn=Noodverlichting, Tr=Rook/warmteafvoer, Tv=Ventilatie, Tw=Water/sprinkler
 
 // Import all PNG assets via Vite glob
-const pngModules = import.meta.glob('/assets/nen1414/*.png', { eager: true, as: 'url' });
+const pngModules = import.meta.glob('/assets/nen1414/*.png', { eager: true, query: '?url', import: 'default' });
 
 function getAssetUrl(id) {
   const key = `/assets/nen1414/${id}.png`;
@@ -15,8 +15,9 @@ function getAssetUrl(id) {
 function rasterSvg(id) {
   const url = getAssetUrl(id);
   if (!url) return '';
-  // Convert relative URL to absolute (blob: context can't resolve relative paths)
-  const absoluteUrl = url.startsWith('http') ? url : window.location.origin + url;
+  // Vite inlines PNGs <4KB as data: URIs; larger ones become /assets/*.png paths.
+  // blob: context can't resolve relative paths, so only prepend origin for root-relative URLs.
+  const absoluteUrl = url.startsWith('/') ? window.location.origin + url : url;
   return `<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"><image href="${absoluteUrl}" width="64" height="64"/></svg>`;
 }
 

--- a/open-pdf-studio/js/solid/stores/propertiesStore.js
+++ b/open-pdf-studio/js/solid/stores/propertiesStore.js
@@ -887,11 +887,31 @@ export function updateAnnotProp(key, value) {
       recalculateAllMeasurements();
       break;
     }
-    default: currentAnnotation[key] = value; break;
+    default: {
+      // Dot-path support for plugin nested writes (e.g., 'data.address.email').
+      // Walks the chain creating intermediate objects when missing.
+      if (key.includes('.')) {
+        const parts = key.split('.');
+        let target = currentAnnotation;
+        for (let i = 0; i < parts.length - 1; i++) {
+          const seg = parts[i];
+          if (target[seg] == null || typeof target[seg] !== 'object') {
+            target[seg] = {};
+          }
+          target = target[seg];
+        }
+        target[parts[parts.length - 1]] = value;
+      } else {
+        currentAnnotation[key] = value;
+      }
+      break;
+    }
   }
 
   // Update store (skip custom fields — they read directly from annotation)
-  if (!key.startsWith('tb')) {
+  // Skip dot-paths too: plugin-nested writes don't need to mirror into the
+  // flat Solid store; plugin panels read from their own form-state.
+  if (!key.startsWith('tb') && !key.includes('.')) {
     setAnnotProps(key, value);
   }
 

--- a/open-pdf-studio/js/solid/stores/propertiesStore.js
+++ b/open-pdf-studio/js/solid/stores/propertiesStore.js
@@ -702,7 +702,20 @@ function recomputeMeasureText(ann) {
   }
 }
 
-// Update a single annotation property (write to store + annotation + undo + redraw)
+/**
+ * Update a single annotation property (write to store + annotation + undo + redraw).
+ *
+ * Plugin dot-path support: keys containing `.` (e.g. `data.address.email`) walk
+ * the annotation object, creating intermediate objects as needed. This means
+ * plugin annotation-keys MUST NOT contain a literal `.` character — a key like
+ * `version1.0` would be interpreted as `version1` -> `0`. Use snake_case or
+ * camelCase for plugin field names. Dot-path writes do NOT mirror into the
+ * flat Solid `annotProps` store — plugin panels are expected to read from
+ * their own form-state, not from `annotProps`.
+ *
+ * @param {string} key   Property name. May be a dot-path for nested writes.
+ * @param {*}      value New value.
+ */
 export function updateAnnotProp(key, value) {
   // Multi-selection mode: apply to all selected annotations
   if (annotProps.multiCount > 0) {

--- a/open-pdf-studio/js/solid/stores/propertiesStore.js
+++ b/open-pdf-studio/js/solid/stores/propertiesStore.js
@@ -7,6 +7,7 @@ import { computeTextboxContentHeight } from '../../annotations/rendering/shapes.
 import { formatDate, getTypeDisplayName } from '../../utils/helpers.js';
 import { getAnnotationType } from '../../plugins/annotation-type-registry.js';
 import { getPropertyPanel } from '../../plugins/property-panel-registry.js';
+import { fireSelectionChange } from '../../plugins/selection-listener-registry.js';
 import i18next from '../../i18n/config.js';
 import { syncDocScale } from '../../annotations/scale-bar.js';
 import { recalculateAllMeasurements, calculateArea, calculatePerimeter, formatMeasurement } from '../../annotations/measurement.js';
@@ -125,6 +126,12 @@ const [customFieldsDef, setCustomFieldsDef] = createSignal([]);
 // When non-null, plugin renders the entire panel-body for its annotation type.
 const [customPanelRender, setCustomPanelRender] = createSignal(null);
 
+// Plugin-driven hide of the native eigenschappen-paneel. When true, the host
+// PropertiesPanel renders nothing — plugin owns all controls (e.g. inside
+// its own tool-palette). Always restored to false on plugin-deactivate.
+const [nativePanelHidden, setNativePanelHidden] = createSignal(false);
+export { nativePanelHidden, setNativePanelHidden };
+
 // Current annotation reference for write-back
 let currentAnnotation = null;
 
@@ -192,6 +199,9 @@ function computeSectionVisibility(type) {
 // Show properties for a single annotation
 export function storeShowProperties(annotation) {
   currentAnnotation = annotation;
+  // Fire plugin selection-listeners (separate from property-panel-registry):
+  // gives plugins a direct channel to react to selection without scraping DOM.
+  fireSelectionChange(annotation);
   const isLocked = annotation.locked || false;
 
   setAnnotProps({
@@ -269,6 +279,7 @@ export function storeShowProperties(annotation) {
 // Hide properties (deselect annotation, show doc info)
 export function storeHideProperties() {
   currentAnnotation = null;
+  fireSelectionChange(null);
   setPanelMode('none');
   setCustomPanelRender(null);
 
@@ -304,6 +315,7 @@ export function storeHideProperties() {
 // Close the panel entirely
 export function storeClosePanel() {
   currentAnnotation = null;
+  fireSelectionChange(null);
   setPanelVisible(false);
 }
 
@@ -320,6 +332,8 @@ function sharedValue(selected, getter, fallback) {
 export function storeShowMultiSelection(selected) {
   if (!selected || selected.length < 2) return;
   currentAnnotation = null;
+  // Multi-selection clears single-select listeners (plugins react to single).
+  fireSelectionChange(null);
 
   const sharedType = sharedValue(selected, a => a.type, '');
   const sharedAuthor = sharedValue(selected, a => a.author || state.defaultAuthor, '');

--- a/open-pdf-studio/js/solid/stores/propertiesStore.js
+++ b/open-pdf-studio/js/solid/stores/propertiesStore.js
@@ -6,6 +6,7 @@ import { redrawAnnotations, redrawContinuous } from '../../annotations/rendering
 import { computeTextboxContentHeight } from '../../annotations/rendering/shapes.js';
 import { formatDate, getTypeDisplayName } from '../../utils/helpers.js';
 import { getAnnotationType } from '../../plugins/annotation-type-registry.js';
+import { getPropertyPanel } from '../../plugins/property-panel-registry.js';
 import i18next from '../../i18n/config.js';
 import { syncDocScale } from '../../annotations/scale-bar.js';
 import { recalculateAllMeasurements, calculateArea, calculatePerimeter, formatMeasurement } from '../../annotations/measurement.js';
@@ -119,6 +120,10 @@ const [docInfo, setDocInfo] = createStore({
 
 // Custom fields from plugin annotation types
 const [customFieldsDef, setCustomFieldsDef] = createSignal([]);
+
+// Custom plugin property-panel renderer (full DOM-based, ipv text-only fields).
+// When non-null, plugin renders the entire panel-body for its annotation type.
+const [customPanelRender, setCustomPanelRender] = createSignal(null);
 
 // Current annotation reference for write-back
 let currentAnnotation = null;
@@ -251,6 +256,12 @@ export function storeShowProperties(annotation) {
   });
 
   computeSectionVisibility(annotation.type);
+
+  // Plugin custom panel: if a renderer is registered for this annotation type,
+  // store it so PropertiesPanel.jsx can mount the plugin DOM.
+  const customRenderer = getPropertyPanel(annotation.type);
+  setCustomPanelRender(customRenderer ? () => customRenderer : null);
+
   setPanelMode('annotation');
   setPanelVisible(true);
 }
@@ -259,6 +270,7 @@ export function storeShowProperties(annotation) {
 export function storeHideProperties() {
   currentAnnotation = null;
   setPanelMode('none');
+  setCustomPanelRender(null);
 
   // Hide all annotation sections
   setSectionVis({
@@ -966,4 +978,5 @@ export {
   sectionVis, setSectionVis,
   docInfo,
   customFieldsDef,
+  customPanelRender,
 };

--- a/open-pdf-studio/js/tools/shape-preview.js
+++ b/open-pdf-studio/js/tools/shape-preview.js
@@ -29,8 +29,16 @@ export function drawShapePreview(currentX, currentY, e) {
 
   const tool = state.currentTool;
 
-  // Build a temporary annotation from current tool + coordinates
-  const tempAnn = buildAnnotationProps(tool, state.startX, state.startY, currentX, currentY, e);
+  // Build a temporary annotation from current tool + coordinates.
+  // Set _isPreview flag so plugin handlers (Symitech SP2) skip counter-bumps
+  // during the per-pointer-move preview-render-loop.
+  state._isPreview = true;
+  let tempAnn;
+  try {
+    tempAnn = buildAnnotationProps(tool, state.startX, state.startY, currentX, currentY, e);
+  } finally {
+    state._isPreview = false;
+  }
 
   if (tempAnn) {
     drawAnnotation(annotationCtx, tempAnn);

--- a/open-pdf-studio/js/tools/tool-dispatcher.js
+++ b/open-pdf-studio/js/tools/tool-dispatcher.js
@@ -82,11 +82,16 @@ export function handlePointerDown(e) {
   // Look up current tool
   const tool = getTool(state.currentTool);
   if (!tool) {
-    // Fallback: check plugin registry for drag-mode tools
+    // Fallback: check plugin registry for non-click drawModes
     const typeHandler = getAnnotationType(state.currentTool);
     if (typeHandler?.drawMode === 'click') {
       const clickTool = getTool('_plugin_click');
       if (clickTool) clickTool.onPointerDown(ctx, e);
+    } else if (typeHandler?.drawMode === 'polyline') {
+      // Polyline-mode plugin: delegate to native polyline-tool;
+      // plugin's typeHandler.create() is invoked from _finishPolyline (see patch in polyline-tool.js).
+      const polyTool = getTool('polyline');
+      if (polyTool) polyTool.onPointerDown(ctx, e);
     } else if (typeHandler) {
       // Drag-mode plugin: use shape tool behavior
       const shapeTool = getTool('box'); // shape tool handles all drag-to-create
@@ -144,9 +149,12 @@ export function handlePointerMove(e) {
   if (tool && tool.onPointerMove) {
     tool.onPointerMove(ctx, e);
   } else {
-    // Plugin tool fallback: drag-mode preview
+    // Plugin tool fallback: drag/polyline-mode preview
     const typeHandler = getAnnotationType(state.currentTool);
-    if (typeHandler) {
+    if (typeHandler?.drawMode === 'polyline') {
+      const polyTool = getTool('polyline');
+      if (polyTool && polyTool.onPointerMove) polyTool.onPointerMove(ctx, e);
+    } else if (typeHandler) {
       const shapeTool = getTool('box');
       if (shapeTool && shapeTool.onPointerMove) shapeTool.onPointerMove(ctx, e);
     }
@@ -186,6 +194,11 @@ export function handlePointerUp(e) {
   } else {
     // Plugin tool fallback: shape tool up
     const typeHandler = getAnnotationType(state.currentTool);
+    if (typeHandler?.drawMode === 'polyline') {
+      // Polyline-mode plugin: pointer-up is a no-op (placement is click-driven,
+      // finish happens on right-click / double-click in polyline-tool itself).
+      return;
+    }
     if (typeHandler && typeHandler.drawMode !== 'click') {
       const shapeTool = getTool('box');
       if (shapeTool && shapeTool.onPointerUp) shapeTool.onPointerUp(ctx, e);

--- a/open-pdf-studio/js/tools/tools/plugin-tool.js
+++ b/open-pdf-studio/js/tools/tools/plugin-tool.js
@@ -16,20 +16,22 @@ export const pluginClickTool = {
     if (!typeHandler || !typeHandler.create) return;
     // Enrich state with the current page dimensions in PDF points so plugin
     // handlers don't need to derive them from canvas geometry (which mixes
-    // DPR + zoom). pdf-viewport.js (a singleton on window.__pdfViewport) is
-    // the canonical source for pageW, pageH, and zoom.
-    const vp = window.__pdfViewport;
-    if (!vp) {
-      console.warn('[plugin-tool] window.__pdfViewport not initialized; aborting plugin click');
+    // DPR + zoom). doc.pageDims is populated by createBlankPDF and renderPage
+    // from page.view (the canonical PDF MediaBox), and stays consistent with
+    // the actual rendered page regardless of zoom or pan.
+    const currentPage = doc?.currentPage || 1;
+    const dims = doc?.pageDims?.[currentPage];
+    if (!dims) {
+      console.warn(`[plugin-tool] doc.pageDims[${currentPage}] missing; aborting plugin click`);
       return;
     }
     const enrichedState = {
       ...state,
-      docScale: vp.zoom,
+      docScale: doc?.scale || 1,
       devicePixelRatio: window.devicePixelRatio || 1,
-      pageWidth: vp.pageW,
-      pageHeight: vp.pageH,
-      currentPage: doc?.currentPage || 1,
+      pageWidth: dims.widthPt,
+      pageHeight: dims.heightPt,
+      currentPage,
     };
     const annProps = typeHandler.create(x, y, x, y, e, enrichedState);
     if (!annProps) return;

--- a/open-pdf-studio/js/tools/tools/plugin-tool.js
+++ b/open-pdf-studio/js/tools/tools/plugin-tool.js
@@ -13,33 +13,29 @@ export const pluginClickTool = {
     const { x, y, state } = ctx;
     const doc = getActiveDocument();
     const typeHandler = ctx.getAnnotationType(state.currentTool);
-    if (typeHandler && typeHandler.create) {
-      // Enrich state with current page dimensions in PDF points so plugins do
-      // not have to derive these from ctx.canvas (which carries DPR + zoom
-      // and is unreliable across "Nieuw" vs loaded-PDF flows).
-      const dpr = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
-      const docScale = doc?.scale || 1;
-      const canvasEl = doc?.canvasEl || null;
-      let pageWidth, pageHeight;
-      if (canvasEl) {
-        pageWidth = canvasEl.width / (docScale * dpr);
-        pageHeight = canvasEl.height / (docScale * dpr);
-      }
-      const enrichedState = {
-        ...state,
-        docScale,
-        devicePixelRatio: dpr,
-        pageWidth,
-        pageHeight,
-        currentPage: doc?.currentPage || 1,
-      };
-      const annProps = typeHandler.create(x, y, x, y, e, enrichedState);
-      if (annProps) {
-        const ann = ctx.createAnnotation({ ...annProps, page: doc?.currentPage || 1, ...state.toolOverrides });
-        if (doc) doc.annotations.push(ann);
-        ctx.recordAdd(ann);
-        ctx.redraw();
-      }
+    if (!typeHandler || !typeHandler.create) return;
+    // Enrich state with the current page dimensions in PDF points so plugin
+    // handlers don't need to derive them from canvas geometry (which mixes
+    // DPR + zoom). pdf-viewport.js (a singleton on window.__pdfViewport) is
+    // the canonical source for pageW, pageH, and zoom.
+    const vp = window.__pdfViewport;
+    if (!vp) {
+      console.warn('[plugin-tool] window.__pdfViewport not initialized; aborting plugin click');
+      return;
     }
+    const enrichedState = {
+      ...state,
+      docScale: vp.zoom,
+      devicePixelRatio: window.devicePixelRatio || 1,
+      pageWidth: vp.pageW,
+      pageHeight: vp.pageH,
+      currentPage: doc?.currentPage || 1,
+    };
+    const annProps = typeHandler.create(x, y, x, y, e, enrichedState);
+    if (!annProps) return;
+    const ann = ctx.createAnnotation({ ...annProps, page: doc?.currentPage || 1, ...state.toolOverrides });
+    if (doc) doc.annotations.push(ann);
+    ctx.recordAdd(ann);
+    ctx.redraw();
   },
 };

--- a/open-pdf-studio/js/tools/tools/plugin-tool.js
+++ b/open-pdf-studio/js/tools/tools/plugin-tool.js
@@ -14,7 +14,26 @@ export const pluginClickTool = {
     const doc = getActiveDocument();
     const typeHandler = ctx.getAnnotationType(state.currentTool);
     if (typeHandler && typeHandler.create) {
-      const annProps = typeHandler.create(x, y, x, y, e, state);
+      // Enrich state with current page dimensions in PDF points so plugins do
+      // not have to derive these from ctx.canvas (which carries DPR + zoom
+      // and is unreliable across "Nieuw" vs loaded-PDF flows).
+      const dpr = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
+      const docScale = doc?.scale || 1;
+      const canvasEl = doc?.canvasEl || null;
+      let pageWidth, pageHeight;
+      if (canvasEl) {
+        pageWidth = canvasEl.width / (docScale * dpr);
+        pageHeight = canvasEl.height / (docScale * dpr);
+      }
+      const enrichedState = {
+        ...state,
+        docScale,
+        devicePixelRatio: dpr,
+        pageWidth,
+        pageHeight,
+        currentPage: doc?.currentPage || 1,
+      };
+      const annProps = typeHandler.create(x, y, x, y, e, enrichedState);
       if (annProps) {
         const ann = ctx.createAnnotation({ ...annProps, page: doc?.currentPage || 1, ...state.toolOverrides });
         if (doc) doc.annotations.push(ann);

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -1,5 +1,6 @@
 import { getActiveDocument } from '../../core/state.js';
 import { applyToolTransform, getEffectiveScale } from '../tool-context.js';
+import { getAnnotationType } from '../../plugins/annotation-type-registry.js';
 
 /**
  * Polyline tool — multi-click placement, double-click/right-click to finish
@@ -217,18 +218,49 @@ function _finishPolyline(ctx) {
   const { state } = ctx;
   if (state.polylinePoints.length >= 2) {
     const prefs = state.preferences;
-    const ann = ctx.createAnnotation({
-      type: 'polyline',
-      page: getActiveDocument()?.currentPage || 1,
-      points: [...state.polylinePoints],
-      color: prefs.polylineStrokeColor,
-      strokeColor: prefs.polylineStrokeColor,
-      lineWidth: prefs.polylineLineWidth,
-      opacity: (prefs.polylineOpacity || 100) / 100
-    });
     const doc = getActiveDocument();
-    if (doc) doc.annotations.push(ann);
-    ctx.recordAdd(ann);
+
+    // Plugin polyline-flow: if active tool is a plugin-handler with drawMode='polyline',
+    // delegate annotation-creation to typeHandler.create() with the collected points.
+    // This lets plugins emit custom annotation-types (e.g. symitech.scheur, symitech.vloer-contour)
+    // instead of always producing a generic 'polyline' annotation.
+    const typeHandler = getAnnotationType(state.currentTool);
+    if (typeHandler && typeHandler.drawMode === 'polyline' && typeof typeHandler.create === 'function') {
+      const currentPage = doc?.currentPage || 1;
+      const dims = doc?.pageDims?.[currentPage];
+      const enrichedState = {
+        ...state,
+        polylinePoints: [...state.polylinePoints],
+        docScale: doc?.scale || 1,
+        devicePixelRatio: window.devicePixelRatio || 1,
+        pageWidth: dims?.widthPt,
+        pageHeight: dims?.heightPt,
+        currentPage,
+      };
+      const annProps = typeHandler.create(0, 0, 0, 0, null, enrichedState);
+      if (annProps) {
+        const ann = ctx.createAnnotation({
+          ...annProps,
+          page: currentPage,
+          ...state.toolOverrides,
+        });
+        if (doc) doc.annotations.push(ann);
+        ctx.recordAdd(ann);
+      }
+    } else {
+      // Default: generic polyline annotation (legacy behavior)
+      const ann = ctx.createAnnotation({
+        type: 'polyline',
+        page: doc?.currentPage || 1,
+        points: [...state.polylinePoints],
+        color: prefs.polylineStrokeColor,
+        strokeColor: prefs.polylineStrokeColor,
+        lineWidth: prefs.polylineLineWidth,
+        opacity: (prefs.polylineOpacity || 100) / 100
+      });
+      if (doc) doc.annotations.push(ann);
+      ctx.recordAdd(ann);
+    }
   }
   state.polylinePoints = [];
   state.isDrawingPolyline = false;

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -334,8 +334,19 @@ function _finishPolyline(ctx) {
   state.isDrawingPolyline = false;
   ctx.redraw();
 
-  // Auto-reset to select tool
-  import('../../tools/manager.js').then(m => m.setTool('select'));
+  // Auto-reset to select tool — alleen voor de built-in polyline-tool.
+  // Plugin-types met drawMode='polyline' (symitech.scheur, vloer-contour,
+  // doorvoer-polyline-closed, etc.) blijven actief zodat de gebruiker
+  // direct het volgende exemplaar kan tekenen zonder de tool opnieuw te
+  // selecteren. User-eis: "na rechtermuisklik-sluiten van scheur direct
+  // de volgende kunnen tekenen".
+  const stillPluginPolyline = (() => {
+    const h = getAnnotationType(state.currentTool);
+    return h && h.drawMode === 'polyline';
+  })();
+  if (!stillPluginPolyline) {
+    import('../../tools/manager.js').then(m => m.setTool('select'));
+  }
 }
 
 function _finishCloudPolyline(ctx) {

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -28,8 +28,20 @@ export const polylineTool = {
 
     // Single click — add point (with snap)
     const snap = ctx.snap(x, y, null, state.polylinePoints);
-    const ptX = snap.snapped ? snap.x : x;
-    const ptY = snap.snapped ? snap.y : y;
+    let ptX = snap.snapped ? snap.x : x;
+    let ptY = snap.snapped ? snap.y : y;
+
+    // Plugin shift-snap: when shift held + handler exposes snapHook, snap to last vertex.
+    if (e?.shiftKey && state.polylinePoints.length > 0) {
+      const handler = getAnnotationType(state.currentTool);
+      if (handler && typeof handler.snapHook === 'function') {
+        const last = state.polylinePoints[state.polylinePoints.length - 1];
+        const snapped = handler.snapHook(last.x, last.y, ptX, ptY);
+        ptX = snapped.x;
+        ptY = snapped.y;
+      }
+    }
+
     state.polylinePoints.push({ x: ptX, y: ptY });
     state.isDrawingPolyline = true;
     ctx.redraw();
@@ -61,9 +73,20 @@ export const polylineTool = {
 
     const prefs = state.preferences;
     const snap = ctx.snap(x, y, null, state.polylinePoints);
-    const snapX = snap.snapped ? snap.x : x;
-    const snapY = snap.snapped ? snap.y : y;
+    let snapX = snap.snapped ? snap.x : x;
+    let snapY = snap.snapped ? snap.y : y;
     state.lastSnapResult = snap.snapped ? snap : null;
+
+    // Plugin shift-snap preview: reflect snapped position before commit so user sees angle feedback.
+    if (e?.shiftKey && state.polylinePoints.length > 0) {
+      const handler = getAnnotationType(state.currentTool);
+      if (handler && typeof handler.snapHook === 'function') {
+        const last = state.polylinePoints[state.polylinePoints.length - 1];
+        const snapped = handler.snapHook(last.x, last.y, snapX, snapY);
+        snapX = snapped.x;
+        snapY = snapped.y;
+      }
+    }
 
     ctx.redraw();
     canvasCtx.save();

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -14,9 +14,13 @@ export const polylineTool = {
     const { x, y, state, canvasCtx, scale } = ctx;
     const prefs = state.preferences;
 
-    // Right-click finishes
+    // Right-click finishes. Mark _suppressNextContextmenu zodat de
+    // contextmenu-event die direct na deze pointerdown vuurt, niet ook
+    // het selectie-menu opent. User-eis: 1e rechtermuisklik = polyline
+    // sluiten, 2e rechtermuisklik (na sluiten) = menu zoals normaal.
     if (e.button === 2) {
       _finishPolyline(ctx);
+      state._suppressNextContextmenu = true;
       return;
     }
 

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -26,6 +26,15 @@ export const polylineTool = {
       return;
     }
 
+    // Close-contour-snap: als pending, sluit polyline als polygon en stop.
+    if (state._closeContourPending) {
+      state._polylineClosedRequested = true;
+      _finishPolyline(ctx);
+      state._closeContourPending = false;
+      state._polylineClosedRequested = false;
+      return;
+    }
+
     // Single click — add point (with snap)
     const snap = ctx.snap(x, y, null, state.polylinePoints);
     let ptX = snap.snapped ? snap.x : x;
@@ -88,6 +97,23 @@ export const polylineTool = {
       }
     }
 
+    // Close-contour-snap: als cursor < 8 screen-pixels van eerste vertex (en >= 3 vertices),
+    // snap cursor naar eerste vertex en zet visuele indicator.
+    const closeTol = 8 / scale;
+    if (state.polylinePoints.length >= 3) {
+      const first = state.polylinePoints[0];
+      const dToFirst = Math.hypot(snapX - first.x, snapY - first.y);
+      if (dToFirst < closeTol) {
+        snapX = first.x;
+        snapY = first.y;
+        state._closeContourPending = true;
+      } else {
+        state._closeContourPending = false;
+      }
+    } else {
+      state._closeContourPending = false;
+    }
+
     ctx.redraw();
     canvasCtx.save();
     applyToolTransform(canvasCtx);
@@ -102,8 +128,19 @@ export const polylineTool = {
     });
     canvasCtx.lineTo(snapX, snapY);
     canvasCtx.stroke();
+
+    // Close-contour indicator: cyan cirkel rond eerste vertex als snap actief is.
+    if (state._closeContourPending) {
+      const first = state.polylinePoints[0];
+      canvasCtx.strokeStyle = '#1D90E0';
+      canvasCtx.lineWidth = 2 / scale;
+      canvasCtx.beginPath();
+      canvasCtx.arc(first.x, first.y, closeTol, 0, 2 * Math.PI);
+      canvasCtx.stroke();
+    }
+
     canvasCtx.restore();
-    if (snap.snapped) {
+    if (snap.snapped && !state._closeContourPending) {
       ctx.drawSnapIndicator(snap);
     }
   },
@@ -259,6 +296,7 @@ function _finishPolyline(ctx) {
         pageWidth: dims?.widthPt,
         pageHeight: dims?.heightPt,
         currentPage,
+        closed: state._polylineClosedRequested === true,
       };
       const annProps = typeHandler.create(0, 0, 0, 0, null, enrichedState);
       if (annProps) {

--- a/open-pdf-studio/js/tools/tools/polyline-tool.js
+++ b/open-pdf-studio/js/tools/tools/polyline-tool.js
@@ -41,11 +41,14 @@ export const polylineTool = {
     let ptY = snap.snapped ? snap.y : y;
 
     // Plugin shift-snap: when shift held + handler exposes snapHook, snap to last vertex.
+    // 5th arg = full prior-points list so the handler can compute snaps relative
+    // to the last segment direction (e.g. perpendicular/parallel for rect-drawing
+    // at non-axis-aligned starting angles).
     if (e?.shiftKey && state.polylinePoints.length > 0) {
       const handler = getAnnotationType(state.currentTool);
       if (handler && typeof handler.snapHook === 'function') {
         const last = state.polylinePoints[state.polylinePoints.length - 1];
-        const snapped = handler.snapHook(last.x, last.y, ptX, ptY);
+        const snapped = handler.snapHook(last.x, last.y, ptX, ptY, state.polylinePoints);
         ptX = snapped.x;
         ptY = snapped.y;
       }
@@ -91,7 +94,7 @@ export const polylineTool = {
       const handler = getAnnotationType(state.currentTool);
       if (handler && typeof handler.snapHook === 'function') {
         const last = state.polylinePoints[state.polylinePoints.length - 1];
-        const snapped = handler.snapHook(last.x, last.y, snapX, snapY);
+        const snapped = handler.snapHook(last.x, last.y, snapX, snapY, state.polylinePoints);
         snapX = snapped.x;
         snapY = snapped.y;
       }

--- a/open-pdf-studio/js/ui/chrome/context-menus.js
+++ b/open-pdf-studio/js/ui/chrome/context-menus.js
@@ -60,6 +60,15 @@ export function initContextMenus() {
         e.preventDefault();
         return;
       }
+      // Tool just finished via right-click (polyline sluit-operatie). Slik
+      // dit ene contextmenu-event in zodat de gebruiker niet onmiddellijk
+      // het selectie-menu krijgt nadat hij de scheur/polygoon afsloot.
+      // Volgende rechtermuisklik werkt weer normaal.
+      if (state._suppressNextContextmenu) {
+        state._suppressNextContextmenu = false;
+        e.preventDefault();
+        return;
+      }
 
       const rect = annotationCanvas.getBoundingClientRect();
       const doc = getActiveDocument();

--- a/open-pdf-studio/js/ui/panels/left-panel.js
+++ b/open-pdf-studio/js/ui/panels/left-panel.js
@@ -27,6 +27,26 @@ const THUMBNAIL_SCALE = 0.2;
 // Cache for thumbnail data per document: Map<docId, Map<pageNum, imageDataURL>>
 const thumbnailCache = new Map();
 
+// Per-doc per-page generation counter. Bumped on invalidateThumbnail() so a
+// stale render-completion (annotations changed mid-flight, rapid re-invalidate)
+// can be discarded and not overwrite a newer cache entry. See bumpPageGen /
+// pageGenMatches usage below.
+const pageGeneration = new Map(); // Map<docId, Map<pageNum, int>>
+
+function bumpPageGen(docId, pageNum) {
+  let m = pageGeneration.get(docId);
+  if (!m) { m = new Map(); pageGeneration.set(docId, m); }
+  const g = (m.get(pageNum) || 0) + 1;
+  m.set(pageNum, g);
+  return g;
+}
+function getPageGen(docId, pageNum) {
+  return pageGeneration.get(docId)?.get(pageNum) || 0;
+}
+function pageGenMatches(docId, pageNum, gen) {
+  return getPageGen(docId, pageNum) === gen;
+}
+
 // Store pdfDoc references and state for each document
 const documentState = new Map(); // { pdfDoc, numPages, nextPage, startPage }
 
@@ -339,9 +359,15 @@ async function processPriorityThumbnail(docId) {
     return priorityPages.size > 0;
   }
 
+  const gen = getPageGen(docId, pageNum);
   try {
     const imageData = await renderThumbnailToDataURL(pdfDoc, pageNum);
     if (imageData) {
+      // Drop result if a newer invalidate raced past us — prevents stale
+      // overlay (e.g. old annotation snapshot) from overwriting fresh cache.
+      if (!pageGenMatches(docId, pageNum, gen)) {
+        return true;
+      }
       docCache.set(pageNum, imageData);
 
       // Update the Solid store so the ThumbnailItem component reacts
@@ -388,9 +414,13 @@ async function processDocumentThumbnail(docId) {
 
     if (docCache.has(pageNum)) continue;
 
+    const gen = getPageGen(docId, pageNum);
     try {
       const imageData = await renderThumbnailToDataURL(pdfDoc, pageNum);
       if (imageData) {
+        if (!pageGenMatches(docId, pageNum, gen)) {
+          return true;
+        }
         docCache.set(pageNum, imageData);
 
         // Update the Solid store so the ThumbnailItem component reacts
@@ -431,7 +461,12 @@ async function overlayAnnotationsOnDataURL(dataURL, pageNum, width, height, scal
     ctx.save();
     ctx.scale(scale, scale);
     annotations.forEach(a => {
-      try { drawAnnotation(ctx, a); } catch (e) { /* tolerant: 1 broken annotation breekt thumb niet */ }
+      try { drawAnnotation(ctx, a); }
+      catch (e) {
+        // Tolerant: 1 broken annotation mag thumb niet breken — wel loggen
+        // zodat plugin-bugs niet stilletjes verdwijnen in productie.
+        console.warn(`[Thumbnails] drawAnnotation failed page ${pageNum} id=${a?.id ?? '?'} type=${a?.type ?? '?'}:`, e);
+      }
     });
     ctx.restore();
     return canvas.toDataURL('image/jpeg', 0.7);
@@ -514,7 +549,10 @@ async function renderThumbnailToDataURL(pdfDoc, pageNum) {
           ctx.save();
           ctx.scale(THUMBNAIL_SCALE, THUMBNAIL_SCALE);
           annotations.forEach(a => {
-            try { drawAnnotation(ctx, a); } catch (e) { /* tolerant */ }
+            try { drawAnnotation(ctx, a); }
+            catch (e) {
+              console.warn(`[Thumbnails] drawAnnotation failed (PDF.js path) page ${pageNum} id=${a?.id ?? '?'} type=${a?.type ?? '?'}:`, e);
+            }
           });
           ctx.restore();
         }
@@ -578,6 +616,9 @@ export function invalidateThumbnail(pageNum) {
   if (docCache) {
     docCache.delete(pageNum);
   }
+  // Bump generation: any in-flight render for this page will discard its
+  // result on completion (see pageGenMatches in process*Thumbnail).
+  bumpPageGen(activeDoc.id, pageNum);
   // Remove from Solid store so component shows loading spinner
   removeThumbnailImage(pageNum);
   // Re-add to priority queue and restart processor

--- a/open-pdf-studio/js/ui/panels/left-panel.js
+++ b/open-pdf-studio/js/ui/panels/left-panel.js
@@ -1,4 +1,5 @@
 import { state, getActiveDocument, getPageRotation } from '../../core/state.js';
+import { drawAnnotation } from '../../annotations/rendering.js';
 import { updateAnnotationsList } from './annotations-list.js';
 import { updateAttachmentsList } from './attachments.js';
 import { updateSignaturesList } from './signatures.js';
@@ -408,6 +409,38 @@ async function processDocumentThumbnail(docId) {
   return false;
 }
 
+// Composite plugin/Solid-store annotations on top of a rendered thumbnail
+// dataURL. Returns a new dataURL with annotations overlayed. If the page has
+// no annotations, returns the input dataURL unchanged (zero-cost early-exit).
+async function overlayAnnotationsOnDataURL(dataURL, pageNum, width, height, scale) {
+  const doc = getActiveDocument();
+  const annotations = (doc?.annotations || []).filter(a => a.page === pageNum);
+  if (annotations.length === 0) return dataURL;
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+      img.src = dataURL;
+    });
+    ctx.drawImage(img, 0, 0, width, height);
+    ctx.save();
+    ctx.scale(scale, scale);
+    annotations.forEach(a => {
+      try { drawAnnotation(ctx, a); } catch (e) { /* tolerant: 1 broken annotation breekt thumb niet */ }
+    });
+    ctx.restore();
+    return canvas.toDataURL('image/jpeg', 0.7);
+  } catch (e) {
+    console.warn(`[Thumbnails] overlay failed for page ${pageNum}:`, e);
+    return dataURL;
+  }
+}
+
 // Render a single page thumbnail — uses Rust backend for speed when available
 async function renderThumbnailToDataURL(pdfDoc, pageNum) {
   if (!pdfDoc || pageNum > pdfDoc.numPages) return null;
@@ -428,7 +461,18 @@ async function renderThumbnailToDataURL(pdfDoc, pageNum) {
         skipImages: true,
       });
       const data = JSON.parse(result);
-      return { dataURL: data.dataURL, width: data.width, height: data.height };
+      // Plugin/Solid-store annotations zijn niet in de PDF tot save; overlay
+      // ze hier zodat thumbnail dezelfde inhoud toont als hoofdcanvas.
+      // Scale = thumbnail-pixels / PDF-pt = data.width / pageWidthPt.
+      try {
+        const page = await pdfDoc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1 });
+        const scale = data.width / viewport.width;
+        const composited = await overlayAnnotationsOnDataURL(data.dataURL, pageNum, data.width, data.height, scale);
+        return { dataURL: composited, width: data.width, height: data.height };
+      } catch {
+        return { dataURL: data.dataURL, width: data.width, height: data.height };
+      }
     } catch (e) {
       console.warn(`[Thumbnails] Rust render failed for page ${pageNum}:`, e);
       // Fall through to PDF.js fallback
@@ -459,6 +503,24 @@ async function renderThumbnailToDataURL(pdfDoc, pageNum) {
         viewport: viewport,
         annotationMode: 0
       }).promise;
+
+      // Overlay plugin/Solid-store annotations op dezelfde ctx vóór toDataURL.
+      // viewport.width = pdfPtWidth * THUMBNAIL_SCALE, dus scale-factor naar
+      // PDF-pt-coordsysteem = THUMBNAIL_SCALE.
+      try {
+        const docActive = getActiveDocument();
+        const annotations = (docActive?.annotations || []).filter(a => a.page === pageNum);
+        if (annotations.length > 0) {
+          ctx.save();
+          ctx.scale(THUMBNAIL_SCALE, THUMBNAIL_SCALE);
+          annotations.forEach(a => {
+            try { drawAnnotation(ctx, a); } catch (e) { /* tolerant */ }
+          });
+          ctx.restore();
+        }
+      } catch (e) {
+        console.warn(`[Thumbnails] PDF.js overlay failed for page ${pageNum}:`, e);
+      }
 
       return {
         dataURL: canvas.toDataURL('image/jpeg', 0.7),

--- a/open-pdf-studio/js/ui/setup/navigation-events.js
+++ b/open-pdf-studio/js/ui/setup/navigation-events.js
@@ -52,7 +52,16 @@ export function setupWheelZoom() {
     // Ctrl+wheel = zoom (snaps to discrete preset levels at the cursor).
     if (e.ctrlKey || e.metaKey) {
       e.preventDefault();
-      if (!viewport.active) return;
+      // Blank docs (no filePath) bypass the vector viewport entirely; their
+      // zoom path is doc.scale + renderPage. Route ctrl+wheel through the
+      // legacy zoomIn/zoomOut helpers for those.
+      if (!viewport.active) {
+        const dy = e.deltaY || 0;
+        const direction = dy < 0 ? 1 : -1;
+        const m = await import('../../pdf/renderer.js');
+        if (direction > 0) await m.zoomIn(); else await m.zoomOut();
+        return;
+      }
       const rect = e.target.closest('canvas')?.getBoundingClientRect() || e.target.getBoundingClientRect();
       const sx = e.clientX - rect.left;
       const sy = e.clientY - rect.top;

--- a/open-pdf-studio/package-lock.json
+++ b/open-pdf-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.42.0",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-pdf-studio",
-      "version": "1.42.0",
+      "version": "1.46.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
@@ -3080,7 +3080,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "description": "A free, open-source PDF annotation editor built with Tauri",
   "scripts": {
     "dev": "vite",

--- a/open-pdf-studio/src-tauri/Cargo.lock
+++ b/open-pdf-studio/src-tauri/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "open-pdf-studio"
-version = "1.45.0"
+version = "1.46.0"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/open-pdf-studio/src-tauri/Cargo.toml
+++ b/open-pdf-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-pdf-studio"
-version = "1.45.0"
+version = "1.46.0"
 description = "A free, open-source PDF annotation editor"
 authors = ["OpenAEC Foundation"]
 license = "MIT"

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -213,9 +213,18 @@ fn open_default_apps_settings() -> Result<bool, String> {
         let status = std::process::Command::new("xdg-mime")
             .args(&["default", "Open PDF Studio.desktop", "application/pdf"])
             .status()
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    "xdg-mime not found. Install xdg-utils (e.g. `sudo apt install xdg-utils`) and try again.".to_string()
+                } else {
+                    format!("Failed to run xdg-mime: {}", e)
+                }
+            })?;
         if !status.success() {
-            return Err(format!("xdg-mime exited with status {}", status));
+            return Err(format!(
+                "xdg-mime exited with status {}. The .desktop file may not be registered — install Open PDF Studio via the bundled .deb/.AppImage so /usr/share/applications/Open PDF Studio.desktop exists.",
+                status
+            ));
         }
         Ok(true)
     }

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -168,14 +168,31 @@ async fn is_default_pdf_app() -> bool {
             stdout2.contains("openpdfstudio") || stdout2.contains(&our_exe.replace('\\', "\\\\"))
         }
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "linux")]
+        {
+            // Use xdg-mime: works on any XDG-compliant desktop (GNOME, KDE,
+            // Cinnamon, MATE, XFCE) across distros (Mint, Ubuntu, Fedora, Arch).
+            let output = match std::process::Command::new("xdg-mime")
+                .args(&["query", "default", "application/pdf"])
+                .output()
+            {
+                Ok(o) => o,
+                Err(_) => return false,
+            };
+            let default_desktop = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            default_desktop == "Open PDF Studio.desktop" || default_desktop == "open-pdf-studio.desktop"
+        }
+
+        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
         {
             false
         }
     }).await.unwrap_or(false)
 }
 
-/// Open Windows "Default Apps" settings page so user can set default PDF app.
+/// Make this app the default handler for .pdf files.
+/// On Windows, opens the system default-apps settings page. On Linux, sets the
+/// xdg-mime default directly (no system UI for this exists on most desktops).
 #[tauri::command]
 fn open_default_apps_settings() -> Result<bool, String> {
     #[cfg(target_os = "windows")]
@@ -188,7 +205,22 @@ fn open_default_apps_settings() -> Result<bool, String> {
         Ok(true)
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
+    {
+        // xdg-mime is the desktop-environment agnostic way to set the default
+        // handler. The .desktop filename must match what tauri-bundler wrote in
+        // /usr/share/applications (the bundle uses the app's productName).
+        let status = std::process::Command::new("xdg-mime")
+            .args(&["default", "Open PDF Studio.desktop", "application/pdf"])
+            .status()
+            .map_err(|e| e.to_string())?;
+        if !status.success() {
+            return Err(format!("xdg-mime exited with status {}", status));
+        }
+        Ok(true)
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
     {
         Ok(false)
     }

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -1136,8 +1136,34 @@ fn get_page_dimensions(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Check for PDF files in command line arguments
     let args: Vec<String> = std::env::args().collect();
+
+    // Handle --version / --help before Tauri::Builder::default().run() so these
+    // flags print and exit instead of hanging in the event loop. Running the
+    // full builder also squats the single-instance DBus name, which blocks
+    // subsequent normal launches until the name is released.
+    for arg in args.iter().skip(1) {
+        match arg.as_str() {
+            "--version" | "-V" => {
+                println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "--help" | "-h" => {
+                println!("Usage: {} [OPTIONS] [FILE...]", env!("CARGO_PKG_NAME"));
+                println!();
+                println!("Options:");
+                println!("  -h, --help       Print this help and exit");
+                println!("  -V, --version    Print version and exit");
+                println!();
+                println!("Files:");
+                println!("  One or more .pdf files to open.");
+                std::process::exit(0);
+            }
+            _ => {}
+        }
+    }
+
+    // Collect any PDF file paths passed on the command line (for file associations)
     let opened_files: Vec<String> = args.iter()
         .skip(1)
         .filter(|arg| arg.to_lowercase().ends_with(".pdf") && !arg.starts_with('-'))

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -57,7 +57,9 @@
     "fileAssociations": [
       {
         "ext": ["pdf"],
+        "mimeType": "application/pdf",
         "name": "PDF Document",
+        "description": "Portable Document Format",
         "role": "Editor"
       }
     ]

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Open PDF Studio",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "identifier": "org.openaec.openpdfstudio",
   "build": {
     "frontendDist": "../dist",

--- a/open-pdf-studio/styles/dialogs.css
+++ b/open-pdf-studio/styles/dialogs.css
@@ -1375,7 +1375,7 @@
 
 .new-doc-select {
   flex: 1;
-  padding: 3px 6px;
+  padding: 3px 24px 3px 6px;
   border: 1px solid var(--theme-border, #acacac);
   border-radius: 0;
   font-size: 11px;
@@ -1383,6 +1383,23 @@
   background-color: var(--theme-surface, white);
   color: var(--theme-text, inherit);
   cursor: pointer;
+  /* Linux/Chromium <select> negeert background-color en color en valt terug
+     op de OS-native widget. Forceer custom rendering met appearance:none plus
+     een handmatig getekende dropdown-pijl, zodat dark-theme correct werkt. */
+  appearance: none;
+  -webkit-appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--theme-text, #fafaf9) 50%),
+    linear-gradient(135deg, var(--theme-text, #fafaf9) 50%, transparent 50%);
+  background-position: calc(100% - 14px) center, calc(100% - 9px) center;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
+.new-doc-select option,
+.new-doc-select optgroup {
+  background-color: var(--theme-surface, white);
+  color: var(--theme-text, inherit);
 }
 
 .new-doc-select:focus {

--- a/open-pdf-studio/styles/layout.css
+++ b/open-pdf-studio/styles/layout.css
@@ -300,8 +300,12 @@
 }
 
 .main-view > #pdf-container.visible {
-  align-items: flex-start;
-  justify-content: center;
+  /* "safe center" keeps the canvas centered when it fits, but falls back to
+     top/left when the canvas is larger than the container so overflow stays
+     scrollable. Without `safe`, an oversized page would shift its top-left
+     out of reach above the scroll origin. */
+  align-items: safe center;
+  justify-content: safe center;
 }
 
 #placeholder {

--- a/open-pdf-studio/styles/tool-palette.css
+++ b/open-pdf-studio/styles/tool-palette.css
@@ -255,3 +255,32 @@
   text-align: center;
   font-size: 12px;
 }
+
+/* --- Tool-group sub-menu (G4b) --- */
+.tp-btn.has-sub { position: relative; }
+.tp-btn-group-wrap { position: relative; display: inline-flex; }
+.tp-btn-chevron {
+  position: absolute;
+  right: 2px;
+  bottom: 1px;
+  font-size: 8px;
+  line-height: 1;
+  opacity: 0.6;
+  pointer-events: none;
+  color: var(--theme-ribbon-icon-stroke);
+}
+.tp-submenu {
+  position: absolute;
+  background: var(--theme-surface, #2a2a2a);
+  border: 1px solid var(--theme-border, transparent);
+  border-radius: 6px;
+  padding: 4px;
+  display: flex;
+  gap: 2px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+.tp-submenu.from-docked-left  { left: 100%;  top: 0; margin-left: 6px; }
+.tp-submenu.from-docked-right { right: 100%; top: 0; margin-right: 6px; }
+.tp-submenu.from-float        { left: 100%;  top: 0; margin-left: 6px; }
+.tp-submenu .tp-btn { width: 32px; height: 32px; }

--- a/open-pdf-studio/styles/tool-palette.css
+++ b/open-pdf-studio/styles/tool-palette.css
@@ -257,7 +257,19 @@
 }
 
 /* --- Tool-group sub-menu (G4b) --- */
+/*
+ * Layout note: the wrap holds the main button + chevron. The sub-menu is
+ * rendered into a Solid <Portal> (escapes docked-palette overflow:hidden) and
+ * positioned via inline style (position: fixed, computed from
+ * wrap.getBoundingClientRect()). So this stylesheet only owns the visual
+ * presentation of the menu, not its placement.
+ */
 .tp-btn.has-sub { position: relative; }
+/*
+ * position:relative anchors the absolutely-positioned .tp-btn-chevron to the
+ * wrap (the chevron sits over the bottom-right corner of the main button).
+ * The sub-menu is portaled out and does NOT use this as its containing block.
+ */
 .tp-btn-group-wrap { position: relative; display: inline-flex; }
 .tp-btn-chevron {
   position: absolute;
@@ -270,7 +282,6 @@
   color: var(--theme-ribbon-icon-stroke);
 }
 .tp-submenu {
-  position: absolute;
   background: var(--theme-surface, #2a2a2a);
   border: 1px solid var(--theme-border, transparent);
   border-radius: 6px;
@@ -280,7 +291,4 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   z-index: 1000;
 }
-.tp-submenu.from-docked-left  { left: 100%;  top: 0; margin-left: 6px; }
-.tp-submenu.from-docked-right { right: 100%; top: 0; margin-right: 6px; }
-.tp-submenu.from-float        { left: 100%;  top: 0; margin-left: 6px; }
 .tp-submenu .tp-btn { width: 32px; height: 32px; }


### PR DESCRIPTION
## Why this PR exists

Open PDF Studio is the substrate we use to build a domain-specific draftboard for Symitech (NL inspection-engineering firm). To make that possible, the original PR opened in April was scoped to fix three independent issues we ran into while bringing the app up on Linux Mint 22.3:

1. The window did not show up reliably on certain WebKitGTK + Mesa combinations.
2. CLI flag handling silently squatted DBus single-instance, breaking subsequent launches.
3. Custom plugin annotation types had no way to render, persist, or own their UI.

While iterating on that work the same branch grew the plumbing needed by a real plugin (`symitech.tools`) until the plumbing itself stabilised. We are surfacing the whole branch now because the parts are tightly co-evolved: the Linux fixes unblock daily work for our team, the plugin-API additions are pure additions that other plugin authors can use today, and the NEN 1414 stamp fix is a one-line glob update riding along because it shares the version bump. CI is green on all three platforms.

## Table of contents

- [A. Linux Mint/Ubuntu desktop fixes (4 commits)](#a-linux-mintubuntu-desktop-fixes-4-commits)
- [B. NEN 1414 stamp + Vite 7 (1 commit)](#b-nen-1414-stamp--vite-7-1-commit)
- [C. Plugin-API extensions (10 commits)](#c-plugin-api-extensions-10-commits)
  - [Foundations](#foundations-4-commits)
  - [New hooks](#new-hooks-6-commits)
- [Test coverage](#test-coverage)
- [Risk and limitations](#risk-and-limitations)
- [Follow-up roadmap](#follow-up-roadmap)
- [Suggested review path](#suggested-review-path)

---

## A. Linux Mint/Ubuntu desktop fixes (4 commits)

Independent desktop-integration fixes. Each lands a real bug we hit on Mint 22.3 / Ubuntu 24.04 daily-driver setups; CI confirms they do not regress Windows or macOS.

### `e9fab7b5` fix: show window immediately after init on Linux

| Field | Detail |
|---|---|
| Problem | App starts, Rust side reaches `Tauri::run()`, but the window never becomes visible. Mouse-in-tray confirms the process is alive. |
| Root cause | The frontend gates `appWindow.show()` on a double `requestAnimationFrame` to wait for first paint. On WebKitGTK builds where the accelerated compositor stalls before the first paint (reproduced on Mint 22.3 + Mesa 25.2.8 + Intel UHD CML GT2), the inner rAF never fires, the outer Promise never resolves, and `show()` is never called. |
| Fix | Drop the rAF gate and call `appWindow.show()` directly after init. The pre-paint flash users were trying to avoid is barely visible in practice and a permanently hidden window is strictly worse. |
| Files | `js/main.js` (-12 / +7) |
| How to verify | Boot a Mint 22.3 VM with `MESA_LOADER_DRIVER_OVERRIDE=iris`, run a debug build, confirm the window appears. |

### `ae1bb2b6` fix: handle `--version` and `--help` before starting the event loop

| Field | Detail |
|---|---|
| Problem | `open-pdf-studio --version` printed nothing, exited with code 0, and any subsequent normal launch silently exited as if another instance were running. |
| Root cause | Flag parsing happened inside `tauri::Builder::default().run()`. The full event loop started, the single-instance DBus name was registered, the process then exited without printing, and the squatted DBus name made later launches think a peer instance owned the slot. |
| Fix | Parse `--version` / `-V` / `--help` / `-h` from `std::env::args()` before any Tauri builder runs. Print + `std::process::exit(0)`. |
| Files | `src-tauri/src/lib.rs` (-1 / +27) |
| How to verify | `target/release/open-pdf-studio --version` prints the version and exits cleanly. Immediately afterwards a normal launch creates a window without "another instance is already running" complaints. |

### `d4a606c8` fix: register `application/pdf` MIME type for Linux file associations

| Field | Detail |
|---|---|
| Problem | The "Set as default PDF reader" button did nothing on Linux because `xdg-mime` had no record of Open PDF Studio claiming PDFs. |
| Root cause | The `fileAssociations` entry for `.pdf` was missing the `mimeType` field, so `tauri-bundler` could not emit `MimeType=application/pdf` into the generated `.desktop` file. |
| Fix | Add `mimeType: ["application/pdf"]` and a short description. The Tauri bundler translates this into the right `MimeType=` line, after which `xdg-mime query default application/pdf` can resolve to `open-pdf-studio.desktop`. |
| Files | `src-tauri/tauri.conf.json` (+2) |
| How to verify | Build a `.deb`, install, run `xdg-mime query default application/pdf` after pressing the in-app "Set as default" button. |

### `4a894a27` feat(linux): implement default PDF handler via `xdg-mime`

| Field | Detail |
|---|---|
| Problem | `is_default_pdf_app` and `open_default_apps_settings` were Windows-only. The "Set as default" banner was permanently shown on Linux (because `is_default_pdf_app` always returned `false`), and clicking the button returned `Ok(false)` without any side effect. |
| Root cause | The implementation predated Linux support for that feature. |
| Fix | Add Linux branches to both functions. `is_default_pdf_app` shells out to `xdg-mime query default application/pdf` and matches against `open-pdf-studio.desktop`. `open_default_apps_settings` calls `xdg-mime default open-pdf-studio.desktop application/pdf` so the in-app button can complete the round-trip without dragging users into a settings dialog. |
| Files | `src-tauri/src/lib.rs` (-3 / +35) |
| How to verify | On Linux, click "Set as default", then `xdg-mime query default application/pdf` returns `open-pdf-studio.desktop` and the banner disappears on next launch. |

> **macOS note**: A macOS branch for `is_default_pdf_app` / `open_default_apps_settings` is missing. The Linux branch returns `false` on macOS, so the feature degrades gracefully (banner stays, button does nothing). To be addressed in a follow-up PR; out of scope here.

---

## B. NEN 1414 stamp + Vite 7 (1 commit)

### `3ae68466` fix: NEN 1414 symbols below 4 KB rendered as broken stamps

| Field | Detail |
|---|---|
| Problem | A subset of NEN 1414 symbols rendered as `image not found` placeholders in the stamp tool. The set varied with build mode (dev vs prod). |
| Root cause | Vite inlines PNG assets smaller than 4 KB as `data:` URIs. `rasterSvg()` was prepending `window.location.origin` to every URL that did not start with `http`, producing corrupt strings such as `http://localhost:3041data:image/png;base64,...`. |
| Fix | Prepend the origin only when the URL is root-relative (starts with `/`). Update the glob to Vite 7 syntax (`import.meta.glob('...', { query: '?url', import: 'default' })`) since `as: 'url'` is deprecated. Bump `package.json` from `1.45.0` to `1.46.0` to mark the user-visible fix. |
| Files | `js/solid/data/nen1414Library.js`, `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, `tauri.conf.json` (-10 / +11) |
| How to verify | Run a prod build, open the stamp tool, drop any of the previously-broken symbols (e.g. small valves) onto a page; they now render. |

> **Version bump caveat**: If upstream prefers to manage versioning on its own cadence, the `1.45.0 → 1.46.0` part of this commit is straightforward to revert independently. Happy to split if requested.

---

## C. Plugin-API extensions (10 commits)

Plugins author custom annotation types today, but until this branch they could not render those annotations into thumbnails, persist them into the saved PDF, mount their own UI in place of the built-in property panel, or react to selection events without scraping the DOM. Each addition below is a pure addition: existing plugins are unaffected, all new fields and methods are optional.

These extensions are in production use by the private Symitech Tekentool V2 plugin (`symitech.tools`). We can demo it on request.

### Foundations (4 commits)

| Commit | What | Why it matters |
|---|---|---|
| `9621cfc8` | `serializeToPdf` hook on plugin handlers | Plugins persist custom annotation types into saved PDFs. The saver in `js/pdf/saver.js` falls back to the plugin annotation-type registry for unknown types and awaits an optional `serializeToPdf({ pdfDoc, page, annotation, convertX, convertY })`. |
| `884db08d` | Page-pt dimensions + DPR in `state` | `pluginClickTool` augments the state object passed to `typeHandler.create()` with `pageWidth`, `pageHeight`, `docScale`, and `devicePixelRatio`. Eliminates fragile ctx-matrix sniffing. |
| `c313bd78` | `__pdfViewport` singleton sync for blank docs | Blank ("Nieuw") documents skip the vector render path that normally calls `setPage()`, so `window.__pdfViewport.pageW/pageH` stayed at 0 and plugin handlers fell back to A4 defaults regardless of actual page size. Now the singleton is updated for blank docs too. |
| `b15ded06` | `doc.pageDims` cache + zoom controls + page centering | Blank docs now store page dimensions on the document object directly (single source of truth), zoom controls work from the first frame, and the canvas is centered horizontally instead of left-aligned. Three small fixes that cluster around the same root cause. |

### New hooks (6 commits)

#### `b844e54f` `api.registerPropertyPanel(typeName, renderFn)`

Plugins replace the built-in properties panel for their own annotation types.

```js
api.registerPropertyPanel('symitech.titlebar', (annotation, updateAnnotProp, onCommit, onCancel) => {
  const root = document.createElement('div');
  // build custom DOM, wire inputs to updateAnnotProp(...)
  return root;
});
```

`renderFn` returns the root element, OPPS mounts it into the panel slot. `null` falls through to default rendering.

Files: `js/plugins/plugin-api.js`, `js/plugins/property-panel-registry.js` (NEW), `js/solid/components/properties-panel/CustomPluginPanel.jsx` (NEW), `js/solid/components/properties-panel/PropertiesPanel.jsx`, `js/solid/stores/propertiesStore.js`.

#### `1ea2964a` Dot-path support in default `updateAnnotProp` branch

Plugin custom panels need to write nested annotation fields. Before this commit, `updateAnnotProp('data.address.email', x)` created a literal string-keyed property. Now: when the key contains `.`, the default branch splits, walks/creates intermediate objects, and writes to the leaf. Mirroring into the flat Solid store is skipped for nested writes (those are plugin-owned).

```js
updateAnnotProp('data.address.email', 'info@example.com');
// annotation.data.address.email === 'info@example.com'
```

Files: `js/solid/stores/propertiesStore.js` (-2 / +22).

#### `f041bd09` `drawMode: 'polyline'` for plugin handlers

Plugins registering a handler with `drawMode: 'polyline'` are now correctly routed by the tool-dispatcher and the polyline-tool. On finish, the plugin handler's `create()` is called with `state.polylinePoints` set. Previously polyline-mode fell through to the box-tool, producing a drag-rectangle and a generic `type: 'polyline'` annotation that ignored the plugin handler.

```js
const handler = {
  type: 'symitech.scheur',
  drawMode: 'polyline',
  create: (sx, sy, ex, ey, e, state) => ({
    type: 'symitech.scheur',
    points: state.polylinePoints,
  }),
};
```

Files: `js/tools/tool-dispatcher.js`, `js/tools/tools/polyline-tool.js`.

#### `2a0ecc71` `registerSelectionListener` + `setNativePanelVisible` + descriptor `cssClass`

Three small additions that let plugins mount UI outside the native properties panel without DOM-scraping or MutationObserver fallbacks.

```js
api.registerSelectionListener('symitech.titlebar', (annotation) => {
  if (annotation) mountInOwnPalette(annotation);
  else unmountFromOwnPalette();
});
```

```js
const descriptor = {
  cssClass: 'symitech-plugin', // applied directly to the .tp-ext root
  // ...
};
```

`fireSelectionChange()` is called from `propertiesStore` on `storeShowProperties` / `storeHideProperties` / `storeClosePanel` / `storeShowMultiSelection`. `cssClass` removes the need for plugins to scan the DOM looking for their own palette root.

Files: `js/plugins/plugin-api.js`, `js/plugins/selection-listener-registry.js` (NEW), `js/plugins/palette-registry.js`, `js/solid/components/ExtensionToolPalette.jsx`, `js/solid/components/properties-panel/PropertiesPanel.jsx`, `js/solid/components/properties-panel/CustomPluginPanel.jsx`, `js/solid/stores/propertiesStore.js`.

#### `3d1063bd` Overlay plugin/Solid-store annotations on page-thumbnails

The thumbnails panel renders pages via the Rust backend (`render_thumbnail` invoke with `skip_images=true`) or via the PDF.js fallback with `annotationMode: 0`. Both paths skipped plugin and Solid-store annotations, so previews showed empty pages.

After each render path, `renderThumbnailToDataURL` now overlays all annotations for that page on the thumbnail canvas at thumbnail scale. Tolerant per-annotation try/catch so one broken handler does not break the whole thumbnail. Zero-cost early-exit when the page has no annotations.

Files: `js/ui/panels/left-panel.js` (-1 / +63).

#### `686c3bf6` Tool-group state + `features.toolGroups` flag

Foundation for sub-menu palette buttons. A `ToolDefinition` can now declare an optional `subTools: ToolDefinition[]`, turning the entry into a sub-menu group. `tool-group-state.js` (NEW) tracks the active sub-tool per group. The host gate (`features.toolGroups`) defaults to `false` so this is a no-op for plugins that do not opt in. Render layer (G4b) follows in a later PR.

Files: `js/plugins/palette-registry.js`, `js/plugins/plugin-api.js`, `js/plugins/tool-group-state.js` (NEW).

---

## Test coverage

| Layer | Status |
|---|---|
| CI build matrix | ✅ `ubuntu-22.04`, `windows-latest`, `macos-latest` |
| Linux Mint 22.3 manual | ✅ daily-driver, validated with Symitech plugin (titelblok edit-flow, schade symbols, polyline-mode, thumbnail overlay) |
| Windows 11 manual | ⏳ CI build only, no runtime smoke |
| macOS 14 manual | ⏳ CI build only, no runtime smoke |
| Unit tests for new plugin-API hooks | ⏳ none added in this PR; happy to add if reviewers want them as a precondition |

## Risk and limitations

| Risk | Severity | Mitigation |
|---|---|---|
| Hardware-specific window-show fix (`e9fab7b5`) drops a defensive gate | Medium | Open to suggestions; a short timeout-fallback (show after 250ms regardless of paint) is a reasonable middle ground. |
| `xdg-mime` shell-out (`4a894a27`) assumes `xdg-utils` is installed | Low | Standard on every desktop Linux distribution we have tested; fails gracefully with `Ok(false)` if missing. |
| macOS branch for default-PDF handler missing | Low | Linux branch returns `false` on macOS, banner stays visible. Not regressing existing behaviour. |
| Plugin-API extensions break a hypothetical existing plugin | Very low | All hooks are optional and additive. Default behaviour unchanged when a plugin does not register anything. |
| Version bump in `3ae68466` clashes with upstream release flow | Low | Trivial to revert if upstream wants to manage versions independently. |

## Follow-up roadmap

Items intentionally left out of this PR, in rough priority order:

1. **macOS branch** for `is_default_pdf_app` / `open_default_apps_settings` (LaunchServices via `LSCopyDefaultApplicationURLForContentType` + a `defaults write` round-trip).
2. **Defensive window-show** with a short timeout-fallback instead of unconditional `show()`, addressing reviewer concern about `e9fab7b5`.
3. **Tool-group render layer (G4b)**: button group expands into a fly-out, current sub-tool icon morphs into the parent button. State plumbing is already merged here.
4. **Unit tests** for the new plugin-API hooks (`registerPropertyPanel`, `registerSelectionListener`, `serializeToPdf`, dot-path `updateAnnotProp`).

## Suggested review path

The branch is structured so that each commit compiles and ships independently. Suggested order for reviewers who want to land this incrementally:

1. **Section A** (4 commits) is small, scoped, low-risk, and resolves daily Linux pain. Easiest to ship first.
2. **Section C** (10 commits, foundations first then hooks) is the largest delta but every commit is additive. Foundations (`9621cfc8`, `884db08d`, `c313bd78`, `b15ded06`) are mechanically obvious; the new hooks (`b844e54f`, `1ea2964a`, `f041bd09`, `2a0ecc71`, `3d1063bd`, `686c3bf6`) are each self-contained and have a real plugin (Symitech) exercising them.
3. **Section B** (1 commit) is a one-liner glob fix riding along with a version bump.

If splitting this PR into three is preferred, happy to do so; the branch was kept whole because the parts were authored in a tight loop and CI is already validating them together.