### PR TITLE
docs: update README to reflect Tauri 2 + SolidJS stack

### DIFF
--- a/open-pdf-studio/README.md
+++ b/open-pdf-studio/README.md
@@ -1,66 +1,79 @@
-# OpenPDFStudio
+# Open PDF Studio
 
-A free, open-source PDF annotation editor built with Electron and PDF.js, featuring a comprehensive ribbon interface.
+A free, open-source PDF annotation editor built with Tauri 2, SolidJS, and PDF.js, featuring a comprehensive ribbon interface.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| [Node.js](https://nodejs.org) | ≥ 20.19.0 | v24 LTS recommended |
+| [Rust](https://rustup.rs) | stable | installs via `rustup` |
+| [MSVC Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) | 2022 | Windows only — select "Desktop development with C++" |
+| [CMake](https://cmake.org/download/) | any recent | required to build `turbojpeg` |
+
+> **Windows users:** After installing Rust, open a new terminal so `~/.cargo/bin` is on your PATH. If using Git Bash, add this to `~/.bashrc`:
+> ```bash
+> export PATH="$HOME/.cargo/bin:$PATH"
+> ```
 
 ## Installation
 
-1. Clone or download this repository
-2. Navigate to the project directory
-3. Install dependencies:
-   ```bash
-   npm install
-   ```
+```bash
+cd open-pdf-studio
+npm install
+```
 
-## Running the Application
+## Development
 
 ```bash
-npm start
+npm run tauri:dev
 ```
+
+The first run compiles all Rust dependencies and takes several minutes. Subsequent runs are fast thanks to incremental compilation. Hot-reload is active — frontend changes reflect immediately without recompiling Rust.
+
+### Windows gotchas
+
+- **Pause Dropbox** (and any other sync client) before running `tauri:dev`. Dropbox locking temp files during Rust compilation causes build failures.
+- **Windows Defender** can also cause file-locking errors on the `target/` directory. Add an exclusion for `src-tauri/target/` and the `cargo.exe` / `rustc.exe` processes to avoid this.
 
 ## Building
 
 ```bash
-# Windows
-npm run build:win
-
-# Linux
-npm run build:linux
-
-# macOS
-npm run build:mac
-
-# All platforms
-npm run build:all
+npm run tauri:build
 ```
+
+This produces a platform installer in `src-tauri/target/release/bundle/`.
 
 ## Project Structure
 
 ```
 open-pdf-studio/
-├── index.html          # Main HTML file with UI
-├── main.js             # Electron main process
-├── preload.js          # Preload script for IPC
-├── js/                 # Application modules
-│   ├── main.js         # Entry point
-│   ├── core/           # State, constants, preferences
-│   ├── annotations/    # Annotation handling
-│   ├── pdf/            # PDF loading, rendering, saving
-│   ├── tools/          # Tool management
-│   ├── ui/             # UI components
-│   ├── events/         # Event handlers
-│   └── utils/          # Utility functions
-├── pdfjs/              # PDF.js library files
-├── package.json        # Project configuration
-└── README.md           # This file
+├── index.html              # App entry point
+├── vite.config.js          # Vite configuration
+├── js/                     # Frontend application
+│   ├── main.js             # Entry point
+│   ├── bridge.ts           # Facade: vanilla JS → SolidJS stores
+│   ├── core/               # State, platform abstraction, constants
+│   ├── annotations/        # Annotation rendering and handling
+│   ├── pdf/                # PDF loading, rendering, saving
+│   ├── solid/              # SolidJS UI components and stores
+│   ├── i18n/               # Internationalization (37 languages)
+│   └── types/              # TypeScript type definitions
+├── src-tauri/              # Rust backend (Tauri)
+│   ├── src/lib.rs          # All Rust commands (file I/O, printing, etc.)
+│   └── Cargo.toml          # Rust dependencies
+├── package.json
+└── README.md
 ```
 
 ## Technologies Used
 
-- **Electron** - Desktop application framework
-- **PDF.js** - PDF rendering engine
-- **pdf-lib** - PDF manipulation and saving
-- **HTML5 Canvas** - For PDF rendering and annotations
-- **JavaScript (ES6 Modules)** - Application logic
+- **[Tauri 2](https://v2.tauri.app)** — Desktop shell and native OS integration
+- **[SolidJS](https://solidjs.com)** — Reactive UI framework
+- **[Vite](https://vitejs.dev)** — Build tool and dev server
+- **[PDF.js](https://mozilla.github.io/pdf.js/)** — PDF rendering engine
+- **[pdf-lib](https://pdf-lib.js.org)** — PDF creation and modification
+- **[i18next](https://www.i18next.com)** — Internationalization (37 languages)
 
 ## License
 

--- a/open-pdf-studio/package-lock.json
+++ b/open-pdf-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.46.0",
+  "version": "1.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-pdf-studio",
-      "version": "1.46.0",
+      "version": "1.48.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/open-pdf-studio/src-tauri/Cargo.lock
+++ b/open-pdf-studio/src-tauri/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "open-pdf-studio"
-version = "1.47.5"
+version = "1.48.1"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",


### PR DESCRIPTION
- Replace outdated Electron references with Tauri 2, SolidJS, and Vite
- Add prerequisites table (Node.js ≥20.19, Rust, MSVC Build Tools, CMake)
- Add Windows-specific gotchas: pause Dropbox before building, add Defender exclusion for src-tauri/target/
- Fix dev and build commands (npm run tauri:dev / tauri:build)
- Update project structure to match current codebase layout