### PR TITLE
Closes #226: feat(navigation): add preference to zoom with mouse whee…

### DIFF
--- a/open-pdf-studio/js/core/constants.ts
+++ b/open-pdf-studio/js/core/constants.ts
@@ -235,6 +235,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   // Behavior
   autoSelectAfterCreate: true,
   confirmBeforeDelete: true,
+  wheelZoomWithoutCtrl: false,
 
   // Startup
   restoreLastSession: false,

--- a/open-pdf-studio/js/i18n/locales/ar/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ar/preferences.json
@@ -115,7 +115,9 @@
     "creation": "الإنشاء",
     "autoSelectAfterCreation": "تحديد التعليق تلقائيًا بعد الإنشاء",
     "deletion": "الحذف",
-    "confirmBeforeDeleting": "التأكيد قبل حذف التعليقات"
+    "confirmBeforeDeleting": "التأكيد قبل حذف التعليقات",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "تطبيق PDF الافتراضي",

--- a/open-pdf-studio/js/i18n/locales/bg/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/bg/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Автоматичен избор на анотацията след създаване",
     "deletion": "Изтриване",
     "confirmBeforeDeleting": "Потвърждение преди изтриване на анотации",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/bn/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/bn/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "তৈরির পরে স্বয়ংক্রিয়ভাবে টীকা নির্বাচন করুন",
     "deletion": "মুছে ফেলা",
     "confirmBeforeDeleting": "টীকা মুছে ফেলার আগে নিশ্চিত করুন",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/ca/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ca/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Selecciona automàticament l'anotació després de crear-la",
     "deletion": "Supressió",
     "confirmBeforeDeleting": "Confirma abans de suprimir anotacions",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/cs/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/cs/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Automaticky vybrat anotaci po vytvoření",
     "deletion": "Mazání",
     "confirmBeforeDeleting": "Potvrdit před smazáním anotací",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/da/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/da/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Vælg annotation automatisk efter oprettelse",
     "deletion": "Sletning",
     "confirmBeforeDeleting": "Bekræft før sletning af annotationer",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/de/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/de/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Erstellung",
     "autoSelectAfterCreation": "Anmerkung nach Erstellung automatisch auswählen",
     "deletion": "Löschen",
-    "confirmBeforeDeleting": "Vor dem Löschen von Anmerkungen bestätigen"
+    "confirmBeforeDeleting": "Vor dem Löschen von Anmerkungen bestätigen",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Standard-PDF-Anwendung",

--- a/open-pdf-studio/js/i18n/locales/el/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/el/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Αυτόματη επιλογή σχολιασμού μετά τη δημιουργία",
     "deletion": "Διαγραφή",
     "confirmBeforeDeleting": "Επιβεβαίωση πριν τη διαγραφή σχολιασμών",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/en/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/en/preferences.json
@@ -181,7 +181,9 @@
     "creation": "Creation",
     "autoSelectAfterCreation": "Auto-select annotation after creation",
     "deletion": "Deletion",
-    "confirmBeforeDeleting": "Confirm before deleting annotations"
+    "confirmBeforeDeleting": "Confirm before deleting annotations",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "pageDisplay": {
     "rendering": "Rendering",

--- a/open-pdf-studio/js/i18n/locales/es/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/es/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Creación",
     "autoSelectAfterCreation": "Seleccionar automáticamente la anotación después de crearla",
     "deletion": "Eliminación",
-    "confirmBeforeDeleting": "Confirmar antes de eliminar anotaciones"
+    "confirmBeforeDeleting": "Confirmar antes de eliminar anotaciones",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Aplicación PDF predeterminada",

--- a/open-pdf-studio/js/i18n/locales/fa/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/fa/preferences.json
@@ -115,7 +115,9 @@
     "creation": "ایجاد",
     "autoSelectAfterCreation": "انتخاب خودکار حاشیه‌نویسی پس از ایجاد",
     "deletion": "حذف",
-    "confirmBeforeDeleting": "تایید قبل از حذف حاشیه‌نویسی‌ها"
+    "confirmBeforeDeleting": "تایید قبل از حذف حاشیه‌نویسی‌ها",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "برنامه PDF پیش‌فرض",

--- a/open-pdf-studio/js/i18n/locales/fi/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/fi/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Valitse merkintä automaattisesti luonnin jälkeen",
     "deletion": "Poistaminen",
     "confirmBeforeDeleting": "Vahvista ennen merkintöjen poistamista",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/fr/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/fr/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Création",
     "autoSelectAfterCreation": "Sélectionner automatiquement l'annotation après création",
     "deletion": "Suppression",
-    "confirmBeforeDeleting": "Confirmer avant de supprimer les annotations"
+    "confirmBeforeDeleting": "Confirmer avant de supprimer les annotations",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Application PDF par défaut",

--- a/open-pdf-studio/js/i18n/locales/he/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/he/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "בחירה אוטומטית של הערה לאחר יצירה",
     "deletion": "מחיקה",
     "confirmBeforeDeleting": "אישור לפני מחיקת הערות",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/hi/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/hi/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "निर्माण के बाद एनोटेशन स्वतः चुनें",
     "deletion": "हटाना",
     "confirmBeforeDeleting": "एनोटेशन हटाने से पहले पुष्टि करें",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/hr/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/hr/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Automatski odaberi oznaku nakon stvaranja",
     "deletion": "Brisanje",
     "confirmBeforeDeleting": "Potvrdi prije brisanja oznaka",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/hu/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/hu/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Annotáció automatikus kijelölése létrehozás után",
     "deletion": "Törlés",
     "confirmBeforeDeleting": "Megerősítés annotációk törlése előtt",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/id/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/id/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Pilih otomatis anotasi setelah pembuatan",
     "deletion": "Penghapusan",
     "confirmBeforeDeleting": "Konfirmasi sebelum menghapus anotasi",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/it/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/it/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Creazione",
     "autoSelectAfterCreation": "Seleziona automaticamente l'annotazione dopo la creazione",
     "deletion": "Eliminazione",
-    "confirmBeforeDeleting": "Conferma prima di eliminare le annotazioni"
+    "confirmBeforeDeleting": "Conferma prima di eliminare le annotazioni",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Applicazione PDF predefinita",

--- a/open-pdf-studio/js/i18n/locales/ja/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ja/preferences.json
@@ -115,7 +115,9 @@
     "creation": "作成",
     "autoSelectAfterCreation": "作成後に注釈を自動選択する",
     "deletion": "削除",
-    "confirmBeforeDeleting": "注釈を削除する前に確認する"
+    "confirmBeforeDeleting": "注釈を削除する前に確認する",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "既定の PDF アプリケーション",

--- a/open-pdf-studio/js/i18n/locales/ko/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ko/preferences.json
@@ -115,7 +115,9 @@
     "creation": "생성",
     "autoSelectAfterCreation": "생성 후 주석 자동 선택",
     "deletion": "삭제",
-    "confirmBeforeDeleting": "주석 삭제 전 확인"
+    "confirmBeforeDeleting": "주석 삭제 전 확인",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "기본 PDF 응용 프로그램",

--- a/open-pdf-studio/js/i18n/locales/ms/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ms/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Pilih automatik anotasi selepas penciptaan",
     "deletion": "Pemadaman",
     "confirmBeforeDeleting": "Sahkan sebelum memadam anotasi",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/nb/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/nb/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Velg merknad automatisk etter opprettelse",
     "deletion": "Sletting",
     "confirmBeforeDeleting": "Bekreft før sletting av merknader",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/nl/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/nl/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Aanmaken",
     "autoSelectAfterCreation": "Annotatie automatisch selecteren na aanmaken",
     "deletion": "Verwijderen",
-    "confirmBeforeDeleting": "Bevestigen voordat annotaties worden verwijderd"
+    "confirmBeforeDeleting": "Bevestigen voordat annotaties worden verwijderd",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Standaard PDF-toepassing",

--- a/open-pdf-studio/js/i18n/locales/pl/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/pl/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Tworzenie",
     "autoSelectAfterCreation": "Automatycznie zaznacz adnotację po utworzeniu",
     "deletion": "Usuwanie",
-    "confirmBeforeDeleting": "Potwierdzenie przed usunięciem adnotacji"
+    "confirmBeforeDeleting": "Potwierdzenie przed usunięciem adnotacji",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Domyślna aplikacja PDF",

--- a/open-pdf-studio/js/i18n/locales/pt/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/pt/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Criação",
     "autoSelectAfterCreation": "Selecionar automaticamente a anotação após a criação",
     "deletion": "Exclusão",
-    "confirmBeforeDeleting": "Confirmar antes de excluir anotações"
+    "confirmBeforeDeleting": "Confirmar antes de excluir anotações",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Aplicativo PDF padrão",

--- a/open-pdf-studio/js/i18n/locales/ro/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ro/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Selectare automata a adnotarii dupa creare",
     "deletion": "Stergere",
     "confirmBeforeDeleting": "Confirmare inainte de stergerea adnotarilor",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/ru/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ru/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Автоматически выделять аннотацию после создания",
     "deletion": "Удаление",
     "confirmBeforeDeleting": "Подтверждать перед удалением аннотаций",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/sk/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/sk/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Automaticky vybrať anotáciu po vytvorení",
     "deletion": "Odstraňovanie",
     "confirmBeforeDeleting": "Potvrdiť pred odstránením anotácií",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/sr/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/sr/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Аутоматски изабери анотацију после креирања",
     "deletion": "Брисање",
     "confirmBeforeDeleting": "Потврди пре брисања анотација",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/sv/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/sv/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Välj anteckning automatiskt efter skapande",
     "deletion": "Borttagning",
     "confirmBeforeDeleting": "Bekräfta innan anteckningar raderas",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/sw/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/sw/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Chagua maoni kiotomatiki baada ya kuunda",
     "deletion": "Ufutaji",
     "confirmBeforeDeleting": "Thibitisha kabla ya kufuta maoni",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/ta/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ta/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "உருவாக்கிய பின் குறிப்புரையைத் தானாகத் தேர்வுசெய்",
     "deletion": "நீக்கம்",
     "confirmBeforeDeleting": "குறிப்புரைகளை நீக்கும் முன் உறுதிப்படுத்து",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/th/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/th/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "เลือกคำอธิบายประกอบอัตโนมัติหลังสร้าง",
     "deletion": "การลบ",
     "confirmBeforeDeleting": "ยืนยันก่อนลบคำอธิบายประกอบ",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/tr/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/tr/preferences.json
@@ -115,7 +115,9 @@
     "creation": "Oluşturma",
     "autoSelectAfterCreation": "Oluşturduktan sonra açıklamayı otomatik seç",
     "deletion": "Silme",
-    "confirmBeforeDeleting": "Açıklamaları silmeden önce onayla"
+    "confirmBeforeDeleting": "Açıklamaları silmeden önce onayla",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Varsayılan PDF Uygulaması",

--- a/open-pdf-studio/js/i18n/locales/uk/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/uk/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Автовибір анотації після створення",
     "deletion": "Видалення",
     "confirmBeforeDeleting": "Підтверджувати перед видаленням анотацій",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/ur/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/ur/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "تخلیق کے بعد تشریح خودکار منتخب کریں",
     "deletion": "حذف",
     "confirmBeforeDeleting": "تشریحات حذف کرنے سے پہلے تصدیق کریں",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/vi/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/vi/preferences.json
@@ -132,6 +132,8 @@
     "autoSelectAfterCreation": "Tự động chọn chú thích sau khi tạo",
     "deletion": "Xóa",
     "confirmBeforeDeleting": "Xác nhận trước khi xóa chú thích",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
     "snapToPdfContent": "Snap to PDF Drawing Content"
   },
   "fileAssoc": {

--- a/open-pdf-studio/js/i18n/locales/zh/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/zh/preferences.json
@@ -115,7 +115,9 @@
     "creation": "创建",
     "autoSelectAfterCreation": "创建后自动选择批注",
     "deletion": "删除",
-    "confirmBeforeDeleting": "删除批注前确认"
+    "confirmBeforeDeleting": "删除批注前确认",
+    "navigation": "Navigation",
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
   },
   "fileAssoc": {
     "defaultPdfApplication": "默认 PDF 应用程序",

--- a/open-pdf-studio/js/solid/components/preferences/BehaviorTab.jsx
+++ b/open-pdf-studio/js/solid/components/preferences/BehaviorTab.jsx
@@ -146,6 +146,16 @@ export default function BehaviorTab(props) {
           </label>
         </div>
       </fieldset>
+
+      <fieldset class="pref-fieldset">
+        <legend>{t('behavior.navigation') || 'Navigation'}</legend>
+        <div class="pref-row pref-checkbox-row">
+          <label class="pref-checkbox-label">
+            <input type="checkbox" checked={p.wheelZoomWithoutCtrl[0]()} onChange={e => p.wheelZoomWithoutCtrl[1](e.target.checked)} />
+            <span>{t('behavior.wheelZoomWithoutCtrl') || 'Zoom with mouse wheel (without holding Ctrl)'}</span>
+          </label>
+        </div>
+      </fieldset>
     </>
   );
 }

--- a/open-pdf-studio/js/types/preferences.ts
+++ b/open-pdf-studio/js/types/preferences.ts
@@ -169,6 +169,7 @@ export interface Preferences {
   // Behavior
   autoSelectAfterCreate: boolean;
   confirmBeforeDelete: boolean;
+  wheelZoomWithoutCtrl: boolean;
 
   // Startup
   restoreLastSession: boolean;

--- a/open-pdf-studio/js/ui/setup/navigation-events.js
+++ b/open-pdf-studio/js/ui/setup/navigation-events.js
@@ -50,7 +50,9 @@ export function setupWheelZoom() {
     }
 
     // Ctrl+wheel = zoom (snaps to discrete preset levels at the cursor).
-    if (e.ctrlKey || e.metaKey) {
+    // When wheelZoomWithoutCtrl is enabled, plain wheel also zooms.
+    const _wheelZoomWithoutCtrl = state.preferences.wheelZoomWithoutCtrl;
+    if (e.ctrlKey || e.metaKey || _wheelZoomWithoutCtrl) {
       e.preventDefault();
       // Blank docs (no filePath) bypass the vector viewport entirely; their
       // zoom path is doc.scale + renderPage. Route ctrl+wheel through the


### PR DESCRIPTION
…l without Ctrl

Add a "wheelZoomWithoutCtrl" boolean preference (default: false) that allows users to zoom using the mouse wheel alone, without holding Ctrl. When enabled, the wheel event handler in navigation-events.js triggers zoom in addition to the existing Ctrl+wheel shortcut. Ctrl+wheel continues to work regardless of the setting.

Adds the preference to the Behavior tab under a new Navigation section, and registers the translation key across all 39 language files.

Generated with the assistance of an AI coding tool.