### PR TITLE
fix(windows): file association fixes — quoted command, valid ProgId, Open With registration

### DIFF
--- a/open-pdf-studio/src-tauri/nsis/installer.nsi
+++ b/open-pdf-studio/src-tauri/nsis/installer.nsi
@@ -656,7 +656,10 @@ Section Install
   ; Create file associations
   {{#each file_associations as |association| ~}}
     {{#each association.ext as |ext| ~}}
-       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
+       ; Quote the exe path: an unquoted path with spaces breaks stricter
+       ; ShellExecute callers (classic Outlook resolves the association but
+       ; the launch dies silently). Matches the protocol registration below.
+       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
     {{/each}}
   {{/each}}
 

--- a/open-pdf-studio/src-tauri/nsis/installer.nsi
+++ b/open-pdf-studio/src-tauri/nsis/installer.nsi
@@ -660,8 +660,29 @@ Section Install
        ; ShellExecute callers (classic Outlook resolves the association but
        ; the launch dies silently). Matches the protocol registration below.
        !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+       ; APP_ASSOCIATE only writes the ProgId and the extension's default
+       ; value. On a clean machine that is not enough for the app to appear
+       ; in Explorer's "Open with > Choose another app" picker or the
+       ; Settings > Default apps page; those read OpenWithProgids, the
+       ; Applications key, and RegisteredApplications/Capabilities.
+       WriteRegStr SHCTX "Software\Classes\.{{ext}}\OpenWithProgids" "{{or association.name ext}}" ""
     {{/each}}
   {{/each}}
+
+  ; Applications registration (feeds the "Open with" picker)
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\shell\open\command" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe" "FriendlyAppName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\DefaultIcon" "" "$INSTDIR\${MAINBINARYNAME}.exe,0"
+
+  ; RegisteredApplications + Capabilities (feeds Settings > Default apps)
+  WriteRegStr SHCTX "Software\${PRODUCTNAME}\Capabilities" "ApplicationName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "Software\${PRODUCTNAME}\Capabilities" "ApplicationDescription" "${PRODUCTNAME}"
+  {{#each file_associations as |association| ~}}
+    {{#each association.ext as |ext| ~}}
+      WriteRegStr SHCTX "Software\${PRODUCTNAME}\Capabilities\FileAssociations" ".{{ext}}" "{{or association.name ext}}"
+    {{/each}}
+  {{/each}}
+  WriteRegStr SHCTX "Software\RegisteredApplications" "${PRODUCTNAME}" "Software\${PRODUCTNAME}\Capabilities"
 
   ; Register deep links
   {{#each deep_link_protocols as |protocol| ~}}
@@ -791,8 +812,12 @@ Section Uninstall
   {{#each file_associations as |association| ~}}
     {{#each association.ext as |ext| ~}}
       !insertmacro APP_UNASSOCIATE "{{ext}}" "{{or association.name ext}}"
+      DeleteRegValue SHCTX "Software\Classes\.{{ext}}\OpenWithProgids" "{{or association.name ext}}"
     {{/each}}
   {{/each}}
+  DeleteRegKey SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe"
+  DeleteRegValue SHCTX "Software\RegisteredApplications" "${PRODUCTNAME}"
+  DeleteRegKey SHCTX "Software\${PRODUCTNAME}\Capabilities"
 
   ; Delete deep links
   {{#each deep_link_protocols as |protocol| ~}}

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -84,7 +84,7 @@
           "pdf"
         ],
         "mimeType": "application/pdf",
-        "name": "PDF Document",
+        "name": "OpenPDFStudio.pdf",
         "description": "Portable Document Format",
         "role": "Editor"
       }


### PR DESCRIPTION
Three related fixes to the Windows `.pdf` file association, found while running the app as the system default PDF handler:

1. **Unquoted exe path in the association command.** The registered open command was `<path with spaces>\open-pdf-studio.exe "%1"`. Explorer tolerates this (CreateProcess retries progressively longer prefixes), but stricter ShellExecute callers do not — classic Outlook resolves the association and then the launch dies silently, no UI at all. Quoting matches the deep-link protocol registration and hooks.nsh, which already do this correctly.

2. **ProgId contained a space.** `fileAssociations.name` was `PDF Document`, which the NSIS template uses as the ProgId — but spaces are invalid in ProgIds, and classic Outlook refuses to resolve the association entirely (double-clicking an attachment does nothing; the attachment is never even extracted). Renamed to `OpenPDFStudio.pdf`, the same ProgId hooks.nsh already registers on admin installs, so the two paths now agree. Note: existing installs whose default points at the old ProgId will be re-asked once after updating.

3. **App missing from "Open with" on clean machines.** `APP_ASSOCIATE` writes the ProgId and the extension default value, but Explorer's "Open with → Choose another app" picker and Settings → Default apps read `OpenWithProgids`, the `Applications` key, and `RegisteredApplications`/Capabilities — none of which were written. On a machine where the user hasn't already picked the app once, it simply doesn't appear as a choice. All three are now registered at install and removed at uninstall.

Verified on Windows 11 (build 26100) with classic and new Outlook: with these fixes the app appears in the picker on a clean machine, and attachments open directly in the app once it's the default handler.
