### PR TITLE
perf: run printer commands off the main event-loop thread

### DIFF
--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -341,8 +341,11 @@ fn no_window_command(program: &str) -> std::process::Command {
 
 /// Enumerate installed printers via PowerShell CIM.
 /// Returns a JSON array of printer objects.
+/// async: sync commands run on the main event-loop thread, and this one
+/// blocks on a PowerShell subprocess for ~1s — long enough to freeze window
+/// show and input processing at startup. Async moves it to the runtime pool.
 #[tauri::command]
-fn get_printers() -> Result<String, String> {
+async fn get_printers() -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
         let output = no_window_command("powershell")
@@ -440,8 +443,10 @@ fn get_printers() -> Result<String, String> {
 /// ASSOCIATION-INDEPENDENT — the previous ShellExecuteW("printto") approach
 /// broke with SE_ERR_NOASSOC (code 31) whenever this app itself is the
 /// default .pdf handler, because our ProgID registers no printto verb.
+/// async for the same reason as get_printers: GDI spooling is slow blocking
+/// work and must not run on the main event-loop thread.
 #[tauri::command]
-fn print_pdf(path: String, printer: String) -> Result<bool, String> {
+async fn print_pdf(path: String, printer: String) -> Result<bool, String> {
     #[cfg(target_os = "windows")]
     {
         use windows_sys::Win32::Graphics::Gdi::{


### PR DESCRIPTION
Sync tauri commands run on the main event-loop thread — the same thread that shows windows and processes input.

`get_printers` blocks on a PowerShell CIM subprocess for around a second and is invoked during startup (printerStore's eager load), which stalls `window.show()` and input handling: the window sits visible-but-frozen (or, depending on IPC ordering, invisible) until printer enumeration finishes. This appears to be the root cause of the app feeling slow/unresponsive on launch. `print_pdf` has the same shape during print jobs (GDI spooling on the main thread freezes the UI while a job spools).

Declaring both commands `async` moves them onto the runtime thread pool. Measured with boot-time instrumentation on the same machine: `window.show()` resolving went from ~1.3–2.1 s to ~15–25 ms, with the window interactive at roughly 0.3 s and printers enumerating in the background. No frontend changes needed — `invoke()` is already promise-based.
