### PR TITLE
feat(pages): resize page/media size without scaling content

### DIFF
--- a/open-pdf-studio/js/i18n/locales/ar/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ar/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "تعيين كافتراضي",
     "dontAskAgain": "لا تسأل مرة أخرى",
     "notNow": "ليس الآن"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ar/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ar/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "الصفحة الأخيرة",
     "last": "الأخيرة",
     "find": "بحث",
-    "findCtrlF": "بحث (Ctrl+F)"
+    "findCtrlF": "بحث (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "رسم",

--- a/open-pdf-studio/js/i18n/locales/bg/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/bg/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Задаване по подразбиране",
     "dontAskAgain": "Не питай отново",
     "notNow": "Не сега"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/bg/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/bg/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Последна страница",
     "last": "Последна",
     "find": "Намери",
-    "findCtrlF": "Намери (Ctrl+F)"
+    "findCtrlF": "Намери (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Чертане",

--- a/open-pdf-studio/js/i18n/locales/bn/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/bn/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "ডিফল্ট হিসেবে সেট করুন",
     "dontAskAgain": "আর জিজ্ঞাসা করবেন না",
     "notNow": "এখন নয়"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/bn/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/bn/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "শেষ পৃষ্ঠা",
     "last": "শেষ",
     "find": "খুঁজুন",
-    "findCtrlF": "খুঁজুন (Ctrl+F)"
+    "findCtrlF": "খুঁজুন (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "অঙ্কন",

--- a/open-pdf-studio/js/i18n/locales/ca/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ca/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Estableix com a per defecte",
     "dontAskAgain": "No ho tornis a preguntar",
     "notNow": "Ara no"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ca/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ca/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Última pàgina",
     "last": "Última",
     "find": "Cerca",
-    "findCtrlF": "Cerca (Ctrl+F)"
+    "findCtrlF": "Cerca (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Dibuix",

--- a/open-pdf-studio/js/i18n/locales/cs/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/cs/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Nastavit jako výchozí",
     "dontAskAgain": "Znovu se neptat",
     "notNow": "Nyní ne"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/cs/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/cs/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Poslední stránka",
     "last": "Poslední",
     "find": "Najít",
-    "findCtrlF": "Najít (Ctrl+F)"
+    "findCtrlF": "Najít (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Kreslení",

--- a/open-pdf-studio/js/i18n/locales/da/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/da/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Angiv som standard",
     "dontAskAgain": "Spørg ikke igen",
     "notNow": "Ikke nu"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/da/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/da/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Sidste side",
     "last": "Sidste",
     "find": "Find",
-    "findCtrlF": "Find (Ctrl+F)"
+    "findCtrlF": "Find (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Tegning",

--- a/open-pdf-studio/js/i18n/locales/de/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/de/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Als Standard festlegen",
     "dontAskAgain": "Nicht mehr fragen",
     "notNow": "Nicht jetzt"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/de/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/de/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Letzte Seite",
     "last": "Letzte",
     "find": "Suchen",
-    "findCtrlF": "Suchen (Ctrl+F)"
+    "findCtrlF": "Suchen (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Zeichnung",

--- a/open-pdf-studio/js/i18n/locales/el/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/el/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Ορισμός ως προεπιλογή",
     "dontAskAgain": "Να μην ερωτηθώ ξανά",
     "notNow": "Όχι τώρα"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/el/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/el/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Τελευταία σελίδα",
     "last": "Τελευταία",
     "find": "Εύρεση",
-    "findCtrlF": "Εύρεση (Ctrl+F)"
+    "findCtrlF": "Εύρεση (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Σχέδιο",

--- a/open-pdf-studio/js/i18n/locales/en/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/en/dialogs.json
@@ -360,6 +360,27 @@
     "noContent": "No content detected — all selected pages appear to be blank.",
     "resultWithSkipped": "Cropped {{cropped}} page(s). Skipped {{skipped}} blank page(s)."
   },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
+  },
   "compress": {
     "title": "Compress PDF",
     "quality": "Quality:",

--- a/open-pdf-studio/js/i18n/locales/en/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/en/ribbon.json
@@ -93,7 +93,9 @@
     "lastPage": "Last Page",
     "last": "Last",
     "find": "Find",
-    "findCtrlF": "Find (Ctrl+F)"
+    "findCtrlF": "Find (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "scaleRegion": "Scale Region",

--- a/open-pdf-studio/js/i18n/locales/es/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/es/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Establecer como predeterminado",
     "dontAskAgain": "No volver a preguntar",
     "notNow": "Ahora no"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/es/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/es/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Última página",
     "last": "Última",
     "find": "Buscar",
-    "findCtrlF": "Buscar (Ctrl+F)"
+    "findCtrlF": "Buscar (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Dibujo",

--- a/open-pdf-studio/js/i18n/locales/fa/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/fa/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "تنظیم به عنوان پیش‌فرض",
     "dontAskAgain": "دیگر نپرس",
     "notNow": "الان نه"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/fa/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/fa/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "صفحه آخر",
     "last": "آخر",
     "find": "یافتن",
-    "findCtrlF": "یافتن (Ctrl+F)"
+    "findCtrlF": "یافتن (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "ترسیم",

--- a/open-pdf-studio/js/i18n/locales/fi/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/fi/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Aseta oletukseksi",
     "dontAskAgain": "Älä kysy uudelleen",
     "notNow": "Ei nyt"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/fi/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/fi/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Viimeinen sivu",
     "last": "Viimeinen",
     "find": "Etsi",
-    "findCtrlF": "Etsi (Ctrl+F)"
+    "findCtrlF": "Etsi (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Piirros",

--- a/open-pdf-studio/js/i18n/locales/fr/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/fr/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Définir par défaut",
     "dontAskAgain": "Ne plus demander",
     "notNow": "Pas maintenant"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/fr/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/fr/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Dernière page",
     "last": "Dernière",
     "find": "Rechercher",
-    "findCtrlF": "Rechercher (Ctrl+F)"
+    "findCtrlF": "Rechercher (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Dessin",

--- a/open-pdf-studio/js/i18n/locales/he/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/he/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "הגדר כברירת מחדל",
     "dontAskAgain": "אל תשאל שוב",
     "notNow": "לא כעת"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/he/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/he/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "עמוד אחרון",
     "last": "אחרון",
     "find": "חיפוש",
-    "findCtrlF": "חיפוש (Ctrl+F)"
+    "findCtrlF": "חיפוש (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "ציור",

--- a/open-pdf-studio/js/i18n/locales/hi/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/hi/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "डिफ़ॉल्ट के रूप में सेट करें",
     "dontAskAgain": "दोबारा न पूछें",
     "notNow": "अभी नहीं"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/hi/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/hi/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "अंतिम पृष्ठ",
     "last": "अंतिम",
     "find": "ढूंढें",
-    "findCtrlF": "ढूंढें (Ctrl+F)"
+    "findCtrlF": "ढूंढें (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "आरेखण",

--- a/open-pdf-studio/js/i18n/locales/hr/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/hr/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Postavi kao zadano",
     "dontAskAgain": "Ne pitaj ponovo",
     "notNow": "Ne sada"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/hr/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/hr/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Zadnja stranica",
     "last": "Zadnja",
     "find": "Pronađi",
-    "findCtrlF": "Pronađi (Ctrl+F)"
+    "findCtrlF": "Pronađi (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Crtanje",

--- a/open-pdf-studio/js/i18n/locales/hu/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/hu/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Beállítás alapértelmezettként",
     "dontAskAgain": "Ne kérdezze többé",
     "notNow": "Most nem"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/hu/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/hu/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Utolsó oldal",
     "last": "Utolsó",
     "find": "Keresés",
-    "findCtrlF": "Keresés (Ctrl+F)"
+    "findCtrlF": "Keresés (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Rajzolás",

--- a/open-pdf-studio/js/i18n/locales/id/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/id/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Atur sebagai Bawaan",
     "dontAskAgain": "Jangan Tanya Lagi",
     "notNow": "Tidak Sekarang"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/id/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/id/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Halaman Terakhir",
     "last": "Terakhir",
     "find": "Temukan",
-    "findCtrlF": "Temukan (Ctrl+F)"
+    "findCtrlF": "Temukan (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Gambar",

--- a/open-pdf-studio/js/i18n/locales/it/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/it/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Imposta come predefinito",
     "dontAskAgain": "Non chiedere più",
     "notNow": "Non ora"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/it/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/it/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Ultima pagina",
     "last": "Ultima",
     "find": "Trova",
-    "findCtrlF": "Trova (Ctrl+F)"
+    "findCtrlF": "Trova (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Disegno",

--- a/open-pdf-studio/js/i18n/locales/ja/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ja/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "既定に設定",
     "dontAskAgain": "今後は表示しない",
     "notNow": "今はしない"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ja/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ja/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "最後のページ",
     "last": "最後",
     "find": "検索",
-    "findCtrlF": "検索 (Ctrl+F)"
+    "findCtrlF": "検索 (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "描画",

--- a/open-pdf-studio/js/i18n/locales/ko/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ko/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "기본값으로 설정",
     "dontAskAgain": "다시 묻지 않음",
     "notNow": "나중에"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ko/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ko/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "마지막 페이지",
     "last": "마지막",
     "find": "찾기",
-    "findCtrlF": "찾기 (Ctrl+F)"
+    "findCtrlF": "찾기 (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "그리기",

--- a/open-pdf-studio/js/i18n/locales/ms/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ms/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Tetapkan sebagai Lalai",
     "dontAskAgain": "Jangan Tanya Lagi",
     "notNow": "Bukan Sekarang"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ms/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ms/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Halaman Terakhir",
     "last": "Terakhir",
     "find": "Cari",
-    "findCtrlF": "Cari (Ctrl+F)"
+    "findCtrlF": "Cari (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Lukisan",

--- a/open-pdf-studio/js/i18n/locales/nb/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/nb/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Angi som standard",
     "dontAskAgain": "Ikke spør igjen",
     "notNow": "Ikke nå"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/nb/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/nb/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Siste side",
     "last": "Siste",
     "find": "Finn",
-    "findCtrlF": "Finn (Ctrl+F)"
+    "findCtrlF": "Finn (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Tegning",

--- a/open-pdf-studio/js/i18n/locales/nl/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/nl/dialogs.json
@@ -368,6 +368,27 @@
     "noContent": "Geen inhoud gedetecteerd — alle geselecteerde pagina's lijken leeg te zijn.",
     "resultWithSkipped": "{{cropped}} pagina('s) bijgesneden. {{skipped}} lege pagina('s) overgeslagen."
   },
+  "resizePages": {
+    "title": "Paginaformaat wijzigen",
+    "applyTo": "Toepassen op:",
+    "currentPage": "Huidige pagina",
+    "allPages": "Alle pagina's",
+    "pageRange": "Paginabereik",
+    "pages": "Pagina's:",
+    "pagesPlaceholder": "bijv. 1-3, 5, 8-10",
+    "size": "Formaat:",
+    "letter": "Letter (215,9 × 279,4 mm)",
+    "legal": "Legal (215,9 × 355,6 mm)",
+    "tabloid": "Tabloid (279,4 × 431,8 mm)",
+    "custom": "Aangepast",
+    "orientation": "Oriëntatie:",
+    "portrait": "Staand",
+    "landscape": "Liggend",
+    "width": "Breedte (mm):",
+    "height": "Hoogte (mm):",
+    "info": "{{count}} pagina('s) in document. Inhoud wordt gecentreerd op oorspronkelijke grootte — geen schaling. Omkeerbaar met Ongedaan maken.",
+    "nothingResized": "Er zijn geen pagina's gewijzigd."
+  },
   "compress": {
     "title": "PDF comprimeren",
     "quality": "Kwaliteit:",

--- a/open-pdf-studio/js/i18n/locales/nl/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/nl/ribbon.json
@@ -93,7 +93,9 @@
     "find": "Zoeken",
     "findCtrlF": "Zoeken (Ctrl+F)",
     "basic": "Basis",
-    "select": "Selecteren"
+    "select": "Selecteren",
+    "resizePages": "Paginaformaat",
+    "resize": "Formaat"
   },
   "comment": {
     "scaleRegion": "Schaalgebied",

--- a/open-pdf-studio/js/i18n/locales/pl/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/pl/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Ustaw jako domyślną",
     "dontAskAgain": "Nie pytaj ponownie",
     "notNow": "Nie teraz"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/pl/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/pl/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Ostatnia strona",
     "last": "Ostatnia",
     "find": "Znajdź",
-    "findCtrlF": "Znajdź (Ctrl+F)"
+    "findCtrlF": "Znajdź (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Rysowanie",

--- a/open-pdf-studio/js/i18n/locales/pt/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/pt/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Definir como padrão",
     "dontAskAgain": "Não perguntar novamente",
     "notNow": "Agora não"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/pt/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/pt/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Última página",
     "last": "Última",
     "find": "Localizar",
-    "findCtrlF": "Localizar (Ctrl+F)"
+    "findCtrlF": "Localizar (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Desenho",

--- a/open-pdf-studio/js/i18n/locales/ro/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ro/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Setare ca implicita",
     "dontAskAgain": "Nu mai intreba",
     "notNow": "Nu acum"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ro/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ro/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Ultima pagina",
     "last": "Ultima",
     "find": "Gasire",
-    "findCtrlF": "Gasire (Ctrl+F)"
+    "findCtrlF": "Gasire (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Desen",

--- a/open-pdf-studio/js/i18n/locales/ru/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ru/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Установить по умолчанию",
     "dontAskAgain": "Больше не спрашивать",
     "notNow": "Не сейчас"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ru/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ru/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Последняя страница",
     "last": "Последняя",
     "find": "Найти",
-    "findCtrlF": "Найти (Ctrl+F)"
+    "findCtrlF": "Найти (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Рисование",

--- a/open-pdf-studio/js/i18n/locales/sk/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/sk/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Nastaviť ako predvolený",
     "dontAskAgain": "Už sa nepýtať",
     "notNow": "Teraz nie"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/sk/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/sk/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Posledná strana",
     "last": "Posledná",
     "find": "Nájsť",
-    "findCtrlF": "Nájsť (Ctrl+F)"
+    "findCtrlF": "Nájsť (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Kreslenie",

--- a/open-pdf-studio/js/i18n/locales/sr/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/sr/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Постави као подразумевану",
     "dontAskAgain": "Не питај поново",
     "notNow": "Не сада"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/sr/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/sr/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Последња страница",
     "last": "Последња",
     "find": "Пронађи",
-    "findCtrlF": "Пронађи (Ctrl+F)"
+    "findCtrlF": "Пронађи (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Цртање",

--- a/open-pdf-studio/js/i18n/locales/sv/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/sv/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Ange som standard",
     "dontAskAgain": "Fråga inte igen",
     "notNow": "Inte nu"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/sv/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/sv/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Sista sidan",
     "last": "Sista",
     "find": "Hitta",
-    "findCtrlF": "Hitta (Ctrl+F)"
+    "findCtrlF": "Hitta (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Ritning",

--- a/open-pdf-studio/js/i18n/locales/sw/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/sw/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Weka kama Chaguo-msingi",
     "dontAskAgain": "Usiulize Tena",
     "notNow": "Si Sasa"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/sw/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/sw/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Ukurasa wa Mwisho",
     "last": "Mwisho",
     "find": "Tafuta",
-    "findCtrlF": "Tafuta (Ctrl+F)"
+    "findCtrlF": "Tafuta (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Kuchora",

--- a/open-pdf-studio/js/i18n/locales/ta/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ta/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "இயல்புநிலையாக அமை",
     "dontAskAgain": "மீண்டும் கேட்காதே",
     "notNow": "இப்போது வேண்டாம்"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ta/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ta/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "கடைசி பக்கம்",
     "last": "கடைசி",
     "find": "கண்டுபிடி",
-    "findCtrlF": "கண்டுபிடி (Ctrl+F)"
+    "findCtrlF": "கண்டுபிடி (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "வரைதல்",

--- a/open-pdf-studio/js/i18n/locales/th/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/th/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "ตั้งเป็นค่าเริ่มต้น",
     "dontAskAgain": "ไม่ต้องถามอีก",
     "notNow": "ไม่ใช่ตอนนี้"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/th/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/th/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "หน้าสุดท้าย",
     "last": "สุดท้าย",
     "find": "ค้นหา",
-    "findCtrlF": "ค้นหา (Ctrl+F)"
+    "findCtrlF": "ค้นหา (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "การวาด",

--- a/open-pdf-studio/js/i18n/locales/tr/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/tr/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Varsayılan Olarak Ayarla",
     "dontAskAgain": "Bir Daha Sorma",
     "notNow": "Şimdi Değil"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/tr/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/tr/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Son Sayfa",
     "last": "Son",
     "find": "Bul",
-    "findCtrlF": "Bul (Ctrl+F)"
+    "findCtrlF": "Bul (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Çizim",

--- a/open-pdf-studio/js/i18n/locales/uk/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/uk/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Встановити за замовчуванням",
     "dontAskAgain": "Більше не питати",
     "notNow": "Не зараз"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/uk/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/uk/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Остання сторінка",
     "last": "Остання",
     "find": "Знайти",
-    "findCtrlF": "Знайти (Ctrl+F)"
+    "findCtrlF": "Знайти (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Малювання",

--- a/open-pdf-studio/js/i18n/locales/ur/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/ur/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "ڈیفالٹ بنائیں",
     "dontAskAgain": "دوبارہ مت پوچھیں",
     "notNow": "ابھی نہیں"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/ur/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/ur/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "آخری صفحہ",
     "last": "آخری",
     "find": "تلاش",
-    "findCtrlF": "تلاش کریں (Ctrl+F)"
+    "findCtrlF": "تلاش کریں (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "ڈرائنگ",

--- a/open-pdf-studio/js/i18n/locales/vi/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/vi/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "Đặt làm Mặc định",
     "dontAskAgain": "Không Hỏi lại",
     "notNow": "Không phải Bây giờ"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/vi/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/vi/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "Trang cuối",
     "last": "Cuối",
     "find": "Tìm",
-    "findCtrlF": "Tìm (Ctrl+F)"
+    "findCtrlF": "Tìm (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "Vẽ",

--- a/open-pdf-studio/js/i18n/locales/zh/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/zh/dialogs.json
@@ -289,5 +289,26 @@
     "setAsDefault": "设为默认",
     "dontAskAgain": "不再询问",
     "notNow": "暂时不"
+  },
+  "resizePages": {
+    "title": "Resize Pages",
+    "applyTo": "Apply to:",
+    "currentPage": "Current page",
+    "allPages": "All pages",
+    "pageRange": "Page range",
+    "pages": "Pages:",
+    "pagesPlaceholder": "e.g. 1-3, 5, 8-10",
+    "size": "Size:",
+    "letter": "Letter (215.9 × 279.4 mm)",
+    "legal": "Legal (215.9 × 355.6 mm)",
+    "tabloid": "Tabloid (279.4 × 431.8 mm)",
+    "custom": "Custom",
+    "orientation": "Orientation:",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width (mm):",
+    "height": "Height (mm):",
+    "info": "{{count}} page(s) in document. Content is centred at its original size — no scaling. Reversible with Undo.",
+    "nothingResized": "No pages were resized."
   }
 }

--- a/open-pdf-studio/js/i18n/locales/zh/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/zh/ribbon.json
@@ -76,7 +76,9 @@
     "lastPage": "最后一页",
     "last": "最后一页",
     "find": "查找",
-    "findCtrlF": "查找 (Ctrl+F)"
+    "findCtrlF": "查找 (Ctrl+F)",
+    "resizePages": "Resize Pages",
+    "resize": "Resize"
   },
   "comment": {
     "drawing": "绘图",

--- a/open-pdf-studio/js/pdf/resize-pages.js
+++ b/open-pdf-studio/js/pdf/resize-pages.js
@@ -1,0 +1,143 @@
+import { getActiveDocument } from "../core/state.js";
+import { getCachedPdfBytes } from "./loader.js";
+import { getCacheKey, reloadFromBytes } from "./page-manager.js";
+import { parsePageRange } from "./exporter.js";
+import { recordPageStructure } from "../core/undo-manager.js";
+import { showLoading, hideLoading } from "../ui/chrome/dialogs.js";
+import { cloneAnnotation } from "../annotations/factory.js";
+import { PDFDocument } from "pdf-lib";
+
+const MM_TO_POINTS = 72 / 25.4;
+
+/**
+ * Translate an annotation in place by (dx, dy) in visual PDF points.
+ * Mirrors the position models used across the annotation types so that,
+ * when a page is recentred, every part of the annotation moves with the
+ * content it belongs to.
+ */
+function translateAnnotation(ann, dx, dy) {
+  if (dx === 0 && dy === 0) return;
+  if (ann.x !== undefined) ann.x += dx;
+  if (ann.y !== undefined) ann.y += dy;
+  if (ann.startX !== undefined) { ann.startX += dx; ann.startY += dy; }
+  if (ann.endX !== undefined) { ann.endX += dx; ann.endY += dy; }
+  if (ann.arrowX !== undefined) { ann.arrowX += dx; ann.arrowY += dy; }
+  if (ann.kneeX !== undefined) { ann.kneeX += dx; ann.kneeY += dy; }
+  if (Array.isArray(ann.path)) ann.path.forEach((p) => { p.x += dx; p.y += dy; });
+  if (Array.isArray(ann.points)) ann.points.forEach((p) => { p.x += dx; p.y += dy; });
+  if (Array.isArray(ann.rects)) ann.rects.forEach((r) => { r.x += dx; r.y += dy; });
+}
+
+/**
+ * Resize the media/document size of pages WITHOUT scaling their content.
+ * The MediaBox and CropBox are both set to the requested size and the
+ * existing content is centred inside the new box; annotations shift with it.
+ *
+ * @param {'current' | 'all' | 'range'} applyTo - Which pages to resize
+ * @param {string} rangeStr - Page range string (only used when applyTo is 'range')
+ * @param {number} widthMm - Target visual width in millimetres
+ * @param {number} heightMm - Target visual height in millimetres
+ * @returns {Promise<{resized: number}>}
+ */
+export async function resizePages(applyTo, rangeStr, widthMm, heightMm) {
+  const doc = getActiveDocument();
+  if (!doc?.pdfDoc) return { resized: 0 };
+  if (!(widthMm > 0) || !(heightMm > 0)) return { resized: 0 };
+
+  const cacheKey = getCacheKey();
+  const currentBytes = getCachedPdfBytes(cacheKey);
+  if (!currentBytes) return { resized: 0 };
+
+  const targetWpt = widthMm * MM_TO_POINTS;
+  const targetHpt = heightMm * MM_TO_POINTS;
+
+  const oldAnnotations = doc.annotations.map((a) => cloneAnnotation(a));
+  const oldRotations = { ...doc.pageRotations };
+  const oldPage = doc.currentPage;
+
+  const totalPages = doc.pdfDoc.numPages;
+  let pageNumbers;
+  if (applyTo === "current") {
+    pageNumbers = [doc.currentPage];
+  } else if (applyTo === "all") {
+    pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+  } else {
+    pageNumbers = parsePageRange(rangeStr, totalPages);
+  }
+  if (pageNumbers.length === 0) return { resized: 0 };
+  const targetPages = new Set(pageNumbers);
+
+  showLoading("Resizing pages...");
+  try {
+    const pdfDoc = await PDFDocument.load(currentBytes, { ignoreEncryption: true });
+    const pages = pdfDoc.getPages();
+
+    // Work on a copy of the annotations so we can shift the ones on resized pages.
+    const newAnnotations = doc.annotations.map((a) => cloneAnnotation(a));
+    // Per-page visual offset applied to content, keyed by 1-based page number.
+    const pageOffsets = new Map();
+
+    for (const pageNum of targetPages) {
+      const pdfPage = pages[pageNum - 1];
+      if (!pdfPage) continue;
+
+      const crop = pdfPage.getCropBox();
+      // Total displayed rotation = native /Rotate + any in-app rotation.
+      const nativeRot = pdfPage.getRotation().angle % 360;
+      const appRot = (oldRotations[pageNum] || 0) % 360;
+      const rot = (((nativeRot + appRot) % 360) + 360) % 360;
+      const rotated = rot === 90 || rot === 270;
+
+      // Visual (as-displayed) dimensions of the current page.
+      const visualOldW = rotated ? crop.height : crop.width;
+      const visualOldH = rotated ? crop.width : crop.height;
+
+      // New box in unrotated PDF space (swap dims for quarter-turn pages so
+      // the *visual* result matches what the user typed).
+      const unrotW = rotated ? targetHpt : targetWpt;
+      const unrotH = rotated ? targetWpt : targetHpt;
+
+      // Centre the new box on the current content centre.
+      const centerX = crop.x + crop.width / 2;
+      const centerY = crop.y + crop.height / 2;
+      const newX = centerX - unrotW / 2;
+      const newY = centerY - unrotH / 2;
+
+      pdfPage.setMediaBox(newX, newY, unrotW, unrotH);
+      pdfPage.setCropBox(newX, newY, unrotW, unrotH);
+
+      // Content moved by half the size delta (in visual space); annotations follow.
+      pageOffsets.set(pageNum, {
+        dx: (targetWpt - visualOldW) / 2,
+        dy: (targetHpt - visualOldH) / 2,
+      });
+    }
+
+    if (pageOffsets.size === 0) return { resized: 0 };
+
+    for (const ann of newAnnotations) {
+      const off = pageOffsets.get(ann.page);
+      if (off) translateAnnotation(ann, off.dx, off.dy);
+    }
+
+    const newBytes = new Uint8Array(await pdfDoc.save());
+    const newRotations = { ...oldRotations };
+    const targetPage = doc.currentPage;
+
+    await reloadFromBytes(newBytes, newAnnotations, newRotations, targetPage);
+    recordPageStructure(
+      currentBytes,
+      oldAnnotations,
+      oldRotations,
+      oldPage,
+      newBytes,
+      newAnnotations,
+      newRotations,
+      targetPage
+    );
+
+    return { resized: pageOffsets.size };
+  } finally {
+    hideLoading();
+  }
+}

--- a/open-pdf-studio/js/solid/components/DialogHost.jsx
+++ b/open-pdf-studio/js/solid/components/DialogHost.jsx
@@ -23,6 +23,7 @@ import StampPickerDialog from './dialogs/StampPickerDialog.jsx';
 import CalibrationDialog from './dialogs/CalibrationDialog.jsx';
 import ScaleDialog from './dialogs/ScaleDialog.jsx';
 import CropMarginsDialog from './dialogs/CropMarginsDialog.jsx';
+import ResizePagesDialog from './dialogs/ResizePagesDialog.jsx';
 import CompressDialog from './dialogs/CompressDialog.jsx';
 import FeedbackDialog from './dialogs/FeedbackDialog.jsx';
 import MessageDialog from './dialogs/MessageDialog.jsx';
@@ -68,6 +69,7 @@ const DIALOG_MAP = {
   'calibration': CalibrationDialog,
   'scale': ScaleDialog,
   'crop-margins': CropMarginsDialog,
+  'resize-pages': ResizePagesDialog,
   'compress': CompressDialog,
   'feedback': FeedbackDialog,
   'message': MessageDialog,

--- a/open-pdf-studio/js/solid/components/dialogs/ResizePagesDialog.jsx
+++ b/open-pdf-studio/js/solid/components/dialogs/ResizePagesDialog.jsx
@@ -1,0 +1,153 @@
+import { createSignal, createMemo, Show } from 'solid-js';
+import Dialog from '../Dialog.jsx';
+import { closeDialog, showMessage } from '../../stores/dialogStore.js';
+import { useTranslation } from '../../../i18n/useTranslation.js';
+
+// Preset sizes in millimetres (portrait: width x height).
+const PRESETS = {
+  a3: [297, 420],
+  a4: [210, 297],
+  a5: [148, 210],
+  letter: [215.9, 279.4],
+  legal: [215.9, 355.6],
+  tabloid: [279.4, 431.8],
+};
+
+export default function ResizePagesDialog(props) {
+  const { t } = useTranslation('dialogs');
+  const { t: tCommon } = useTranslation('common');
+
+  const totalPages = props.data?.totalPages || 1;
+
+  const [applyTo, setApplyTo] = createSignal('current');
+  const [rangeStr, setRangeStr] = createSignal('');
+  const [preset, setPreset] = createSignal('a4');
+  const [orientation, setOrientation] = createSignal('portrait');
+  const [customW, setCustomW] = createSignal(210);
+  const [customH, setCustomH] = createSignal(297);
+
+  // Resolve the target width/height in mm, applying orientation.
+  const dims = createMemo(() => {
+    let w, h;
+    if (preset() === 'custom') {
+      w = customW();
+      h = customH();
+    } else {
+      [w, h] = PRESETS[preset()];
+    }
+    if (orientation() === 'landscape' && h > w) [w, h] = [h, w];
+    if (orientation() === 'portrait' && w > h) [w, h] = [h, w];
+    return { w, h };
+  });
+
+  const close = () => closeDialog('resize-pages');
+
+  const handleResize = async () => {
+    const applyToVal = applyTo();
+    const rangeVal = rangeStr();
+    const { w, h } = dims();
+
+    close();
+
+    const { resizePages } = await import('../../../pdf/resize-pages.js');
+    const result = await resizePages(applyToVal, rangeVal, w, h);
+
+    if (!result.resized) {
+      showMessage(t('resizePages.nothingResized'));
+    }
+  };
+
+  const footer = (
+    <>
+      <div></div>
+      <div class="crop-margins-footer-right">
+        <button class="pref-btn pref-btn-primary" onClick={handleResize}>{tCommon('apply')}</button>
+        <button class="pref-btn pref-btn-secondary" onClick={close}>{tCommon('cancel')}</button>
+      </div>
+    </>
+  );
+
+  return (
+    <Dialog
+      title={t('resizePages.title')}
+      overlayClass="crop-margins-overlay"
+      dialogClass="crop-margins-dialog"
+      headerClass="crop-margins-header"
+      bodyClass="crop-margins-content"
+      footerClass="crop-margins-footer"
+      onClose={close}
+      footer={footer}
+    >
+      <div class="crop-margins-form">
+        <div class="crop-margins-row">
+          <label class="crop-margins-label">{t('resizePages.applyTo')}</label>
+          <select class="crop-margins-select" value={applyTo()} onChange={(e) => setApplyTo(e.target.value)}>
+            <option value="current">{t('resizePages.currentPage')}</option>
+            <option value="all">{t('resizePages.allPages')}</option>
+            <option value="range">{t('resizePages.pageRange')}</option>
+          </select>
+        </div>
+        <Show when={applyTo() === 'range'}>
+          <div class="crop-margins-row">
+            <label class="crop-margins-label">{t('resizePages.pages')}</label>
+            <input
+              type="text"
+              class="crop-margins-input-wide"
+              placeholder={t('resizePages.pagesPlaceholder')}
+              value={rangeStr()}
+              onInput={(e) => setRangeStr(e.target.value)}
+            />
+          </div>
+        </Show>
+        <div class="crop-margins-row">
+          <label class="crop-margins-label">{t('resizePages.size')}</label>
+          <select class="crop-margins-select" value={preset()} onChange={(e) => setPreset(e.target.value)}>
+            <option value="a3">A3 (297 × 420 mm)</option>
+            <option value="a4">A4 (210 × 297 mm)</option>
+            <option value="a5">A5 (148 × 210 mm)</option>
+            <option value="letter">{t('resizePages.letter')}</option>
+            <option value="legal">{t('resizePages.legal')}</option>
+            <option value="tabloid">{t('resizePages.tabloid')}</option>
+            <option value="custom">{t('resizePages.custom')}</option>
+          </select>
+        </div>
+        <div class="crop-margins-row">
+          <label class="crop-margins-label">{t('resizePages.orientation')}</label>
+          <select class="crop-margins-select" value={orientation()} onChange={(e) => setOrientation(e.target.value)}>
+            <option value="portrait">{t('resizePages.portrait')}</option>
+            <option value="landscape">{t('resizePages.landscape')}</option>
+          </select>
+        </div>
+        <Show when={preset() === 'custom'}>
+          <div class="crop-margins-row">
+            <label class="crop-margins-label">{t('resizePages.width')}</label>
+            <input
+              type="number"
+              class="crop-margins-input"
+              value={customW()}
+              min="1"
+              max="10000"
+              step="1"
+              onInput={(e) => setCustomW(parseFloat(e.target.value) || 0)}
+            />
+          </div>
+          <div class="crop-margins-row">
+            <label class="crop-margins-label">{t('resizePages.height')}</label>
+            <input
+              type="number"
+              class="crop-margins-input"
+              value={customH()}
+              min="1"
+              max="10000"
+              step="1"
+              onInput={(e) => setCustomH(parseFloat(e.target.value) || 0)}
+            />
+          </div>
+        </Show>
+        <div class="crop-margins-info">
+          {t('resizePages.info', { count: totalPages })}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/open-pdf-studio/js/solid/components/ribbon/OrganizeTab.jsx
+++ b/open-pdf-studio/js/solid/components/ribbon/OrganizeTab.jsx
@@ -2,7 +2,7 @@ import RibbonGroup from './RibbonGroup.jsx';
 import AdaptiveGroups from './AdaptiveGroups.jsx';
 import RibbonButton from './RibbonButton.jsx';
 import RibbonButtonStack from './RibbonButtonStack.jsx';
-import { insertPageIcon, deletePageIcon, extractPagesIcon, mergePdfsIcon, watermarkIcon, headerFooterIcon, manageWatermarksIcon, editTextIcon, addTextIcon, cropMarginsIcon, rotateLeftIcon, rotateRightIcon } from '../../data/ribbonIcons.js';
+import { insertPageIcon, deletePageIcon, extractPagesIcon, mergePdfsIcon, watermarkIcon, headerFooterIcon, manageWatermarksIcon, editTextIcon, addTextIcon, cropMarginsIcon, resizePagesIcon, rotateLeftIcon, rotateRightIcon } from '../../data/ribbonIcons.js';
 import { state, noPdf, getActiveDocument, getPageRotation } from '../../../core/state.js';
 import { isPdfAReadOnly } from '../../../pdf/loader.js';
 import { showInsertPageDialog, showExtractPagesDialog, showMergePdfsDialog } from '../../../ui/chrome/dialogs.js';
@@ -56,6 +56,11 @@ export default function OrganizeTab() {
             disabled={ro()} onClick={() => {
               const doc = getActiveDocument();
               openDialog('crop-margins', { totalPages: doc?.pdfDoc?.numPages, currentPage: doc?.currentPage || 1 });
+            }} />
+          <RibbonButton id="ep-resize-pages" title={t('home.resizePages')} icon={resizePagesIcon} label={t('home.resize')}
+            disabled={ro()} onClick={() => {
+              const doc = getActiveDocument();
+              openDialog('resize-pages', { totalPages: doc?.pdfDoc?.numPages, currentPage: doc?.currentPage || 1 });
             }} />
           <RibbonButton id="ep-compress-pdf" title={t('organize.compressPdf')} icon={compressIcon} label={t('organize.compressLabel')}
             disabled={noPdf()} onClick={async () => {

--- a/open-pdf-studio/js/solid/data/ribbonIcons.js
+++ b/open-pdf-studio/js/solid/data/ribbonIcons.js
@@ -48,6 +48,8 @@ export const addTextIcon = `<svg fill="none" stroke="currentColor" viewBox="0 0 
 
 export const cropMarginsIcon = `<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 2v4H2m20 0h-4M6 22v-4H2m20 0h-4"/><rect x="6" y="6" width="12" height="12" stroke-width="2" stroke-dasharray="3 2" fill="none"/></svg>`;
 
+export const resizePagesIcon = `<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" stroke-width="2" fill="none"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10h6m0 0v6m0-6l-7 7"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14H4"/></svg>`;
+
 // --- Home tab: Navigate ---
 
 export const firstPageIcon = `<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7"/></svg>`;


### PR DESCRIPTION
## Summary

Adds a **Resize Pages** tool (Organize tab, next to Crop Margins) that changes a page's **MediaBox and CropBox** to a target size **without scaling the content**. Existing content keeps its original coordinates and is re-centred in the new page box — the page grows/shrinks around the content rather than stretching it.

## What's included

- **`js/pdf/resize-pages.js`** — core transform:
  - Sets MediaBox + CropBox to the requested size and centres the current content in the new box (content keeps its PDF coordinates → no scaling).
  - Annotations on affected pages shift with the recentred content so they stay glued to it.
  - **Rotation-aware**: for 90°/270° pages the unrotated box dimensions are swapped so the *visual* result matches the requested size.
  - Fully **undoable** via `recordPageStructure` (same pattern as Crop Margins).
- **`ResizePagesDialog.jsx`** — apply to current / all / page range; presets A3–A5, Letter, Legal, Tabloid, or custom width/height in mm; portrait/landscape.
- Dialog registered in `DialogHost`; ribbon button + icon added to the Organize tab.
- Translation keys added across **all 39 locales** (`resizePages` in `dialogs`, `home.resize` / `home.resizePages` in `ribbon`) — English fallback everywhere, Dutch translated.

## Design choices

- **MediaBox and CropBox are set together** to the target size.
- **Content is centred** in the new box.
- Shrinking below the content size clips the edges (does not scale) — this is the intended trade-off of a non-scaling resize.

## Testing

Core transform verified against a real PDF (`compressed.tracemonkey-pldi-09.pdf`) across 5 scenarios (grow, shrink, landscape, native-rotated, in-app-rotated). Each asserted:

1. Resulting **visual page size matches** the request (rotation-aware).
2. **No scaling** — content-stream bytes are SHA-256 **identical** before/after (only the page boxes change).
3. Content **centred** (new box centre == old content centre).
4. MediaBox == CropBox.

All 25 checks passed. Manual GUI verification (dialog, undo, annotations, save/reopen) is recommended as a follow-up.

...

This was AI assisted.