### PR TITLE
fix: harden macOS 1.78 release quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - platform: 'ubuntu-22.04'
           - platform: 'windows-latest'
-          - platform: 'macos-latest'
+          - platform: 'macos-26'
 
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Rust targets (macOS universal)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.platform == 'macos-26'
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Install dependencies (Ubuntu only)
@@ -47,7 +47,13 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
+
+      - name: Run quality regression tests
+        run: npm run test:quality
+
+      - name: Prepare native runtime
+        run: npm run prepare:native-runtime
 
       # The PDFium worker pool runs as a Tauri sidecar (bundle.externalBin).
       # Tauri requires binaries/pdfium-worker-<target-triple> to exist at
@@ -73,7 +79,7 @@ jobs:
           cp target/release/pdfium-worker open-pdf-studio/src-tauri/binaries/pdfium-worker-x86_64-unknown-linux-gnu
 
       - name: Build pdfium-worker sidecar (macOS universal)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.platform == 'macos-26'
         working-directory: .
         run: |
           cargo build --release -p pdfium-worker --target aarch64-apple-darwin
@@ -88,4 +94,18 @@ jobs:
             target/x86_64-apple-darwin/release/pdfium-worker
 
       - name: Build Tauri app
+        if: matrix.platform != 'macos-26'
         run: npm run tauri build -- --no-bundle
+
+      - name: Build ad-hoc signed macOS app
+        if: matrix.platform == 'macos-26'
+        env:
+          APPLE_SIGNING_IDENTITY: '-'
+        run: npm run tauri build -- --target universal-apple-darwin --bundles app
+
+      - name: Verify and launch macOS app
+        if: matrix.platform == 'macos-26'
+        run: |
+          APP_PATH="../target/universal-apple-darwin/release/bundle/macos/Open PDF Studio.app"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          bash scripts/macos-startup-smoke.sh "$APP_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         if: matrix.platform == 'macos-26'
         env:
           APPLE_SIGNING_IDENTITY: '-'
-        run: npm run tauri build -- --target universal-apple-darwin --bundles app
+        run: npm run tauri build -- --target universal-apple-darwin --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Verify and launch macOS app
         if: matrix.platform == 'macos-26'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,7 +92,7 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
             target: 'linux'
-          - platform: 'macos-latest'
+          - platform: 'macos-26'
             args: '--target universal-apple-darwin'
             target: 'macos'
           - platform: 'windows-latest'
@@ -136,7 +136,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
 
       # The PDFium worker pool runs as a Tauri sidecar (bundle.externalBin).
       # Tauri requires binaries/pdfium-worker-<target-triple> to exist at build
@@ -199,14 +199,9 @@ jobs:
       # verwijst naar binaries/macos-universal/libpdfium.dylib. Universal
       # (arm64+x86_64) via bblanchon/pdfium-binaries (zelfde chromium-release als
       # Linux/Windows), met SHA-256-verificatie.
-      - name: Fetch libpdfium.dylib (macOS)
+      - name: Prepare libpdfium.dylib (macOS)
         if: matrix.target == 'macos'
-        run: |
-          mkdir -p src-tauri/binaries/macos-universal
-          curl -L "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7834/pdfium-mac-univ.tgz" -o /tmp/pdfium-mac.tgz
-          echo "659e2f647ffd667b36487375165563e58f961db9cf75a45104dc59b9407ccbdf  /tmp/pdfium-mac.tgz" | shasum -a 256 -c -
-          tar xzf /tmp/pdfium-mac.tgz -C /tmp lib/libpdfium.dylib
-          cp /tmp/lib/libpdfium.dylib src-tauri/binaries/macos-universal/libpdfium.dylib
+        run: npm run prepare:native-runtime
 
       - name: Build Tauri app
         if: matrix.target != 'windows-user'
@@ -226,6 +221,18 @@ jobs:
           args: ${{ matrix.args }}
           releaseId: ${{ needs.prepare-release.outputs.release_id }}
           includeUpdaterJson: false
+
+      - name: Verify macOS signature and notarization
+        if: matrix.target == 'macos'
+        run: |
+          APP_PATH="../target/universal-apple-darwin/release/bundle/macos/Open PDF Studio.app"
+          DMG_PATH="$(find ../target/universal-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)"
+          test -n "$DMG_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          xcrun stapler validate "$DMG_PATH"
+          bash scripts/macos-startup-smoke.sh "$APP_PATH"
 
       - name: Build Tauri app (Windows user installer)
         if: matrix.target == 'windows-user'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: 'Version tag (e.g., v1.0.0)'
         required: true
-        default: 'v1.71.0'
+        default: 'v1.78.0'
 
 jobs:
   create-release:
@@ -64,7 +64,7 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
             target: 'linux'
-          - platform: 'macos-latest'
+          - platform: 'macos-26'
             args: '--target universal-apple-darwin'
             target: 'macos'
           - platform: 'windows-latest'
@@ -104,7 +104,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
 
       # The PDFium worker pool runs as a Tauri sidecar (bundle.externalBin).
       # Tauri requires binaries/pdfium-worker-<target-triple> to exist at
@@ -181,14 +181,9 @@ jobs:
       # via bblanchon/pdfium-binaries (zelfde chromium-release als de Linux-
       # .so en de win-x64 pdfium.dll), met SHA-256-verificatie zodat een
       # gewijzigde upstream-asset de build laat falen i.p.v. stil door te gaan.
-      - name: Fetch libpdfium.dylib (macOS)
+      - name: Prepare libpdfium.dylib (macOS)
         if: matrix.target == 'macos'
-        run: |
-          mkdir -p src-tauri/binaries/macos-universal
-          curl -L "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7834/pdfium-mac-univ.tgz" -o /tmp/pdfium-mac.tgz
-          echo "659e2f647ffd667b36487375165563e58f961db9cf75a45104dc59b9407ccbdf  /tmp/pdfium-mac.tgz" | shasum -a 256 -c -
-          tar xzf /tmp/pdfium-mac.tgz -C /tmp lib/libpdfium.dylib
-          cp /tmp/lib/libpdfium.dylib src-tauri/binaries/macos-universal/libpdfium.dylib
+        run: npm run prepare:native-runtime
 
       - name: Set user install mode
         if: matrix.target == 'windows-user'
@@ -231,6 +226,18 @@ jobs:
           args: ${{ matrix.args }}
           releaseId: ${{ needs.create-release.outputs.release_id }}
           includeUpdaterJson: true
+
+      - name: Verify macOS signature and notarization
+        if: matrix.target == 'macos'
+        run: |
+          APP_PATH="../target/universal-apple-darwin/release/bundle/macos/Open PDF Studio.app"
+          DMG_PATH="$(find ../target/universal-apple-darwin/release/bundle/dmg -name '*.dmg' -print -quit)"
+          test -n "$DMG_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          spctl --assess --type execute --verbose=4 "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          xcrun stapler validate "$DMG_PATH"
+          bash scripts/macos-startup-smoke.sh "$APP_PATH"
 
       - name: Build Tauri app (user installer)
         if: matrix.target == 'windows-user'

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -32,8 +32,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry + target
-        uses: actions/cache@v4
+      - name: Restore cargo registry + target
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
@@ -55,7 +55,7 @@ jobs:
       - name: Prepare deterministic render corpus
         shell: pwsh
         run: |
-          $corpus = 'open-pdf-studio/test pdf-bestanden/Originele bestanden'
+          $corpus = 'test pdf-bestanden/Originele bestanden'
           New-Item -ItemType Directory -Force -Path $corpus | Out-Null
           Copy-Item -LiteralPath 'scripts/render_test/tests/fixtures/tiny.pdf' -Destination (Join-Path $corpus 'render-fixture.pdf')
 
@@ -65,6 +65,16 @@ jobs:
           OPS_ENABLE_MCP: '1'
           OPS_STARTUP_TIMEOUT_MS: '1200000'
         run: npm run test:render:auto
+
+      - name: Save cargo cache after render
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: render-regression-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Upload regression report
         if: always()

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -52,6 +52,13 @@ jobs:
           scripts/.venv-test/Scripts/python.exe -m pip install -U pip
           scripts/.venv-test/Scripts/python.exe -m pip install -r scripts/requirements-test.txt
 
+      - name: Prepare deterministic render corpus
+        shell: pwsh
+        run: |
+          $corpus = 'open-pdf-studio/test pdf-bestanden/Originele bestanden'
+          New-Item -ItemType Directory -Force -Path $corpus | Out-Null
+          Copy-Item -LiteralPath 'scripts/render_test/tests/fixtures/tiny.pdf' -Destination (Join-Path $corpus 'render-fixture.pdf')
+
       - name: Run render regression
         working-directory: open-pdf-studio
         env:

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: open-pdf-studio
         env:
           OPS_ENABLE_MCP: '1'
-          OPS_STARTUP_TIMEOUT_MS: '600000'
+          OPS_STARTUP_TIMEOUT_MS: '1200000'
         run: npm run test:render:auto
 
       - name: Upload regression report

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           $corpus = 'test pdf-bestanden/Originele bestanden'
           New-Item -ItemType Directory -Force -Path $corpus | Out-Null
-          Copy-Item -LiteralPath 'scripts/render_test/tests/fixtures/tiny.pdf' -Destination (Join-Path $corpus 'render-fixture.pdf')
+          node open-pdf-studio/scripts/create-render-fixture.mjs (Join-Path $corpus 'render-fixture.pdf')
 
       - name: Run render regression
         working-directory: open-pdf-studio

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -38,8 +38,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            open-pdf-studio/src-tauri/target
-            open-pdf-render/target
+            target
           key: render-regression-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install npm deps (open-pdf-studio)
@@ -57,6 +56,7 @@ jobs:
         working-directory: open-pdf-studio
         env:
           OPS_ENABLE_MCP: '1'
+          OPS_STARTUP_TIMEOUT_MS: '600000'
         run: npm run test:render:auto
 
       - name: Upload regression report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +804,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1503,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1505,6 +1553,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1911,6 +1965,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +2043,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2321,6 +2404,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -2706,7 +2790,7 @@ dependencies = [
  "itoa",
  "log",
  "md-5",
- "nom",
+ "nom 7.1.3",
  "rangemap",
  "rayon",
  "time",
@@ -2927,6 +3011,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3246,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "open-pdf-studio"
-version = "1.71.0"
+version = "1.78.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3268,10 +3361,12 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-drag",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-os",
  "tauri-plugin-process",
@@ -3471,6 +3566,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3740,6 +3846,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5118,6 +5230,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,6 +5320,21 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5491,6 +5633,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5854,6 +6010,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -6258,6 +6425,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -7144,6 +7381,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7224,6 +7479,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7232,6 +7504,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,20 @@ opt-level = 3
 # gecachet); workspace-crates behouden snelle debug-compiles.
 [profile.dev.package."*"]
 opt-level = 2
+
+# Rendering hot paths get full optimization in development. These profiles
+# must be declared at the workspace root; Cargo ignores them in member crates.
+[profile.dev.package.tiny-skia]
+opt-level = 3
+
+[profile.dev.package.tiny-skia-path]
+opt-level = 3
+
+[profile.dev.package.lopdf]
+opt-level = 3
+
+[profile.dev.package.image]
+opt-level = 3
+
+[profile.dev.package.pdfium-render]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -300,26 +300,30 @@ Download the APK from [Releases](https://github.com/OpenAEC-Foundation/OpenPDFSt
 ### Prerequisites
 - [Node.js](https://nodejs.org/) 20+
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
+- [CMake](https://cmake.org/download/) and a C/C++ toolchain
 - System dependencies:
   - **Linux:** `libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf`
-  - **macOS:** Xcode Command Line Tools
+  - **macOS:** Xcode Command Line Tools; universal release builds also need the `aarch64-apple-darwin` and `x86_64-apple-darwin` Rust targets
   - **Windows:** Visual Studio Build Tools with C++ workload
 
 ### Build
 
 ```bash
 cd open-pdf-studio
-npm install
+npm ci
 npx tauri build
 ```
 
-The built application will be in `open-pdf-studio/src-tauri/target/release/bundle/`.
+The build automatically downloads the pinned macOS PDFium runtime and verifies
+its SHA-256 checksum. Build artifacts are written to the workspace-level
+`target/release/bundle/` directory, or `target/universal-apple-darwin/release/bundle/`
+for a universal macOS build.
 
 ### Development
 
 ```bash
 cd open-pdf-studio
-npm install
+npm ci
 npx tauri dev
 ```
 

--- a/docs/superpowers/specs/2026-07-15-macos-release-quality-design.md
+++ b/docs/superpowers/specs/2026-07-15-macos-release-quality-design.md
@@ -1,0 +1,185 @@
+# Ontwerp: macOS-releasekwaliteit voor versie 1.78
+
+Status: goedgekeurd ontwerp, nog niet geïmplementeerd
+
+Doelbranch: `codex/mac-quality-178`, gebaseerd op `origin/main`
+
+Gerelateerde GitHub-items: PR #251 en issues #291, #208, #252 en #276
+
+## Aanleiding
+
+De huidige `main` bevat al meerdere verbeteringen die na de basis van PR #251 zijn toegevoegd: platformcorrecte sidecar-namen, een gebundelde macOS-PDFium-library, Developer ID-signing, notarisatie en een recentere `tao`-versie. PR #251 rechtstreeks mergen zou deze nieuwere oplossingen deels vervangen door oudere buildlogica. De PR roept onder andere Cargo opnieuw aan vanuit `build.rs`, terwijl het huidige buildscript dit bewust vermijdt wegens de target-lock van de bovenliggende Cargo-build.
+
+De resterende problemen zijn kleiner en duidelijk af te bakenen:
+
+- een verse macOS-clone mist de genegeerde `libpdfium.dylib`, waardoor lokale dev- en releasebuilds zonder handmatige download falen;
+- het hoofdvenster is aanvankelijk verborgen en wordt pas later door de frontend getoond, een patroon dat op macOS 26 eerder tot een onzichtbaar of onresponsief venster leidde;
+- de bestaande releasechecks bewijzen nog niet dat de gebouwde app werkelijk start, een zichtbaar venster heeft en na initialisatie blijft draaien;
+- aangeleverde 1.67-crashrapporten tonen `SIGABRT` door een Rust-panic in de macOS-launchcallback. Ze tonen geen `CODESIGNING`-termination. De huidige signing- en runtimewijzigingen moeten daarom met een echte macOS-26-starttest worden bewezen;
+- een aangeleverde verificatie-PDF bevat een beeldconstructie die op de laatste pagina niet in de app verschijnt. Hiervoor ontbreekt een kleine, herhaalbare regressiefixture;
+- diagnostiek bij startup-problemen bevat onvoldoende fase-informatie om build-, native-library-, venster- en frontendproblemen snel te onderscheiden.
+
+## Doelen
+
+1. `npm run tauri:dev` en `npx tauri build` werken op een verse macOS-clone zonder handmatige native-library-stap.
+2. Lokale builds en CI gebruiken exact dezelfde gepinde native dependency en checksumcontrole.
+3. De hoofdwindow wordt zichtbaar aangemaakt en is niet afhankelijk van een latere frontend-`show()` om bruikbaar te worden.
+4. Een GitHub Actions-job op macOS 26 bouwt de universal app, controleert de inhoud en voert een echte start-smoketest uit.
+5. Nightly- en releasebuilds controleren signing, notarisatie en stapling voordat een artifact als bruikbaar geldt.
+6. Startupdiagnostiek registreert lokale, privacyvriendelijke fasemarkers en foutketens zonder documentinhoud of volledige documentpaden.
+7. Het ontbrekende-beeldprobleem krijgt een minimale, niet-vertrouwelijke regressiefixture en een automatische renderassertie.
+8. Versievelden worden gezamenlijk verhoogd van 1.77.0 naar 1.78.0.
+9. Windows- en Linux-releasegedrag blijft intact, inclusief de Windows-sidecar-signing, WebView2-bootstrapper en `WebView2Loader.dll`.
+
+## Niet-doelen
+
+- PR #251 integraal rebasen of de duizenden gegenereerde bestanden uit die PR in deze releaseopschoning meenemen.
+- Native libraries voor alle platformen opnieuw organiseren.
+- De PDFium-versie boven de huidige, al gevalideerde release verhogen.
+- Automatische crashtelemetrie of stille verzending van gebruikersdata toevoegen.
+- De originele aangeleverde verificatie-PDF in de repository opnemen.
+- Android-signing wijzigen. APK- en AAB-signing blijven een afzonderlijke releasewerkstroom met één blijvende productiesleutel.
+
+## Overwogen aanpakken
+
+### 1. Gerichte integratie op actuele `main` - gekozen
+
+Alleen ontbrekende macOS-build-, startup-, diagnostiek- en regressietestonderdelen worden toegevoegd. Bestaande platformfixes blijven behouden. Dit geeft de kleinste reviewbare wijziging en de laagste regressiekans.
+
+### 2. Universele macOS-library in Git committen
+
+Dit maakt een verse clone direct bouwbaar en is eenvoudig, maar vergroot iedere clone met ongeveer 14 MB en maakt dependency-updates minder controleerbaar. De al bestaande Linux- en Windows-binaries worden in deze wijziging niet als precedent gebruikt om nog een binary toe te voegen.
+
+### 3. PR #251 rechtstreeks mergen
+
+Niet gekozen. De PR is gebaseerd op een oude `main`, bevat inmiddels achterhaalde platformfixes, gebruikt een oudere native-libraryrelease, heeft een onbetrouwbaar pad voor universal builds en verwijdert relevante Windows-signingstappen.
+
+## Ontwerp
+
+### Native dependencyvoorbereiding
+
+Er komt één klein Node-script onder `open-pdf-studio/scripts/` met twee verantwoordelijkheden:
+
+1. op macOS bepalen of `src-tauri/binaries/macos-universal/libpdfium.dylib` met de verwachte metadata aanwezig is;
+2. bij ontbreken de gepinde universal archive downloaden, SHA-256 controleren, alleen het vereiste bestand uitpakken en het resultaat atomair op zijn definitieve plaats zetten.
+
+De URL, upstreamversie, archive-SHA-256, archivepad en lokale doelnaam staan bij elkaar in een afzonderlijk, importeerbaar manifest. Het script gebruikt een tijdelijke map binnen de buildomgeving en hernoemt pas na succesvolle checksum- en bestandstypecontrole. Na installatie schrijft het atomair een klein markerbestand met versie en geverifieerde archivehash. Alleen de combinatie van dylib en overeenkomende marker geldt als geldige cache; een los of verouderd bestand wordt opnieuw voorbereid. Een mislukte download, checksumafwijking of ontbrekend archive-element levert een korte fout met hersteladvies en een niet-nul exitcode op. Een reeds geldige cache veroorzaakt geen netwerkverkeer.
+
+`predev` en `prebuild` roepen dit script aan vóór de bestaande worker-build. De macOS-workflow gebruikt dezelfde npm-route; de dubbele handgeschreven `curl`/`tar`-stap verdwijnt. Windows en Linux krijgen een expliciete, geteste no-op en behouden hun huidige binaries en releasepaden.
+
+Er komt geen Cargo-aanroep in `build.rs`. Dat script blijft uitsluitend de reeds gebouwde sidecar naar de Tauri-naam kopiëren.
+
+### Vensterstart
+
+Het hoofdvenster wordt zichtbaar aangemaakt. De bestaande frontend-call die het venster na de eerste paint toont, wordt verwijderd of idempotent gemaakt zodat hij geen noodzakelijke startupstap meer is. De neutrale bestaande achtergrondkleur blijft zichtbaar tijdens de korte frontendinitialisatie, zodat dit geen zwart of transparant startvenster oplevert.
+
+De startupcode legt de volgende lokale fasen vast:
+
+- proces gestart;
+- Tauri-builder aangemaakt;
+- setup-hook gestart;
+- resource-directory gevonden;
+- PDFium geladen of gecontroleerd gedegradeerd;
+- hoofdvenster aanwezig en zichtbaar;
+- frontend gereed.
+
+De frontend meldt gereedheid één keer via een smalle Tauri-command nadat de eerste render is voltooid. Rust logt daarop de fase `frontend-ready`; dezelfde marker is het synchronisatiepunt voor de start-smoketest. Een fout in een optionele renderdependency blijft niet-fataal. Een fout die starten onmogelijk maakt, bevat de laatste voltooide startupfase en de volledige Rust-foutketen.
+
+### Lokale diagnostiek
+
+Diagnostiek wordt lokaal opgeslagen in de Tauri-logdirectory met rotatie en een kleine maximale bewaartermijn. Standaard bevat het rapport:
+
+- appversie en buildtype;
+- besturingssysteem en CPU-architectuur;
+- startupfasen en tijden;
+- aanwezigheid en laadresultaat van de native renderlibrary en worker;
+- panic- en foutketeninformatie;
+- signingstatus die de app zelf veilig kan waarnemen.
+
+Documentinhoud, annotaties en volledige bestandspaden worden niet opgeslagen. Als een pad nodig is voor diagnose, wordt alleen de extensie en een eenrichtingshash opgenomen. Export is uitsluitend een bewuste gebruikersactie via Help en produceert een leesbaar tekstbestand of zip met logbestanden en een korte privacyverklaring.
+
+### PDF-renderregressie
+
+De aangeleverde verificatie-PDF wordt alleen lokaal gebruikt om de onderliggende objectconstructie te bepalen. Daarna wordt een minimale synthetische PDF-fixture gemaakt met uitsluitend die constructie en niet met de originele tekst, afbeeldingen of metadata.
+
+De regressietest rendert de relevante pagina en controleert minimaal:
+
+- dat het verwachte beeldgebied niet volledig wit of transparant is;
+- dat het aantal niet-achtergrondpixels boven een stabiele ondergrens ligt;
+- dat de fixture zonder panic of ontbrekende-resourcefout opent;
+- dat de bestaande renderregressies niet veranderen buiten een kleine, vastgelegde tolerantie.
+
+Als de oorzaak in Form XObjects, masks, clipping, optionele content of resource-overerving ligt, wordt de test op het kleinste relevante PDF-objectniveau gehouden. Daardoor blijft de fixture klein en verklaart de test precies welke constructie wordt ondersteund.
+
+### macOS-26 CI en releasecontrole
+
+Een gerichte PR-job draait op de officiële Apple Silicon `macos-26` runner wanneer native build-, Tauri-, render- of workflowbestanden wijzigen. De job:
+
+1. installeert Node en Rust met beide Apple-targets;
+2. voert de gedeelde native-dependencyvoorbereiding uit;
+3. bouwt beide workerarchitecturen en de universal app;
+4. controleert met platformtools dat hoofdprogramma, worker en PDFium-library de vereiste architecturen bevatten;
+5. controleert dat de gebundelde resourcepaden bestaan;
+6. gebruikt voor de PR-smoketest een expliciete ad-hoc signature;
+7. start de `.app`, wacht op de frontend-readymarker, verifieert procesoverleving en controleert via een klein Swift/CoreGraphics-hulpprogramma dat minstens één on-screen hoofdvenster van de bundle bestaat;
+8. sluit de app gecontroleerd af en faalt bij een nieuw crashrapport.
+
+Nightly en release blijven de huidige Developer ID-omgeving gebruiken. Direct na bundling controleren zij daarnaast:
+
+- `codesign --verify --deep --strict` op de `.app`;
+- de verwachte signing identity en hardened runtime;
+- Gatekeeper-beoordeling;
+- stapling/notarisatiestatus van app en DMG;
+- de universal architecturen en vereiste resources;
+- dezelfde start-smoketest op de gebouwde app.
+
+De huidige Tauri-interface blijft leidend: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD` en `APPLE_SIGNING_IDENTITY` voor signing; `APPLE_ID`, `APPLE_PASSWORD` en `APPLE_TEAM_ID` voor notarisatie. Geheimen worden nooit geprint of beschikbaar gemaakt aan fork-PR's.
+
+### Bouwdocumentatie
+
+De README noemt Node 20+, Rust stable, CMake en Xcode Command Line Tools als macOS-prerequisites. De bouwinstructies leggen uit dat native renderlibraries automatisch en checksum-gecontroleerd worden voorbereid, waar de lokale cache staat en hoe een ontwikkelaar die cache veilig opnieuw laat opbouwen. De documentatie bevat geen handmatige downloadstap en geen verwijzing naar een gebruikersspecifiek bestandspad.
+
+### Kwaliteitsgrenzen
+
+De integratie-PR blijft beperkt tot bovengenoemde onderdelen. Verwijdering van omvangrijke historische buildartefacten wordt een afzonderlijke onderhouds-PR. Voor gewijzigde code zijn de volgende checks verplicht:
+
+- Rust-formattering, Clippy op de gewijzigde workspacecrates en gerichte Rust-tests;
+- TypeScript-typecheck en bestaande frontendbuild;
+- Node-tests voor platformselectie, geldige cache, checksumfout en atomische installatie;
+- regressietest voor de synthetische beeldfixture;
+- configuratieasserties voor WebView2, platformresources, sidecars en vensterzichtbaarheid;
+- macOS-26 build- en startsmoke.
+
+## Foutafhandeling en herstel
+
+- Een native downloadfout laat bestaande geldige bestanden ongemoeid.
+- Een checksumfout verwijdert uitsluitend de tijdelijke download en meldt de verwachte en ontvangen hash.
+- Een ontbrekende PDFium-library laat de app starten in gedegradeerde modus, maar laat build- en releasechecks falen.
+- Een ontbrekende sidecar schakelt de workerpool lokaal uit met een duidelijke melding; releasechecks beschouwen dit als fout.
+- Een mislukte notarisatie of stapling houdt nightly/release tegen.
+- Een startupcrash bewaart de laatst voltooide startupfase en leidt tot een mislukte smoketest.
+
+## Versie en GitHub-afhandeling
+
+Alle gezaghebbende versievelden gaan gezamenlijk naar 1.78.0. Na groene lokale checks en groene PR-CI wordt de gerichte integratie-PR gemerged. PR #251 krijgt een onderhoudersreactie die aangeeft welke ideeën al op `main` stonden, welke gericht zijn overgenomen en waarom de PR niet integraal is gemerged; relevante bijdrage-attributie blijft behouden.
+
+Issues worden alleen gesloten met bewijs. Als code of workflowlogica aantoonbaar uit PR #251 wordt aangepast, krijgt de bijbehorende commit een `Co-authored-by`-regel; anders blijft de bijdrage zichtbaar via de afsluitende PR-reactie en een link vanuit de integratie-PR.
+
+De issuecriteria zijn:
+
+- #291 na een groene build vanuit een schone macOS-omgeving zonder handmatige download;
+- #208 na een macOS-26-test die een zichtbaar, interactief venster bevestigt;
+- #252 en #276 na een gesigneerde en genotariseerde 1.78-nightly die op macOS 26 start zonder nieuw crashrapport.
+
+## Acceptatiecriteria
+
+- Een schone macOS-clone doorloopt `npm install` en `npm run tauri:dev` zonder handmatige PDFium-stap.
+- `npx tauri build --target universal-apple-darwin` produceert een universal app en DMG met de juiste worker en renderlibrary.
+- De app toont op macOS 26 een hoofdvenster, blijft minimaal tien seconden draaien en sluit gecontroleerd af.
+- PR-builds gebruiken geen productiesigninggeheimen; nightly/release zijn geldig gesigneerd, genotariseerd en gestapled.
+- De synthetische beeldfixture rendert het bedoelde beeldgebied en faalt vóór de bijbehorende rendererfix.
+- Startupdiagnostiek bevat fase en foutketen, maar geen documentinhoud of volledige documentpaden.
+- Windows-config bevat nog steeds `embedBootstrapper` en `WebView2Loader.dll`; de Windows-sidecar wordt nog vóór bundling gesigneerd.
+- Linux-build- en renderchecks blijven groen.
+- Alle versievelden zijn 1.78.0 en onderling consistent.
+- PR #251 en de vier Mac-issues zijn met toetsbaar bewijs bijgewerkt.

--- a/open-pdf-render/src/image_decode.rs
+++ b/open-pdf-render/src/image_decode.rs
@@ -1,1 +1,0 @@
-pub fn decode_image() {}

--- a/open-pdf-render/src/interpreter.rs
+++ b/open-pdf-render/src/interpreter.rs
@@ -1252,7 +1252,7 @@ impl Interpreter {
         let img = image::load_from_memory_with_format(jpeg_data, image::ImageFormat::Jpeg).ok()?;
         let img = img.to_rgba8();
         let (w, h) = (img.width(), img.height());
-        let mut rgba = img.into_raw();
+        let rgba = img.into_raw();
 
         // Downsample if over budget
         if max_pixels > 0 && w * h > max_pixels {
@@ -2608,17 +2608,6 @@ impl Interpreter {
         }
     }
 
-    fn handle_do_extract(
-        operands: &[Object],
-        buf: &mut DrawCommandBuffer,
-        state: &mut GraphicsStateStack,
-        doc: &Document,
-        resources: &Dictionary,
-        font_registry: &mut crate::fonts::FontRegistry,
-    ) {
-        Self::handle_do_extract_with_text(operands, buf, state, doc, resources, font_registry, None);
-    }
-
     fn handle_do_extract_with_text(
         operands: &[Object],
         buf: &mut DrawCommandBuffer,
@@ -3348,7 +3337,8 @@ impl Interpreter {
     /// Walk a content stream and emit one TextSpan per Tj/TJ run.
     /// Lighter than extract_commands — only the operators that affect text
     /// position or content are processed; path/color/image ops are skipped.
-    pub fn extract_text_only(
+    #[cfg(test)]
+    fn extract_text_only(
         content_bytes: &[u8],
         spans: &mut Vec<TextSpan>,
         state: &mut GraphicsStateStack,
@@ -3497,6 +3487,7 @@ impl Interpreter {
     /// then computes the final user-space bbox by transforming through the
     /// current CTM. Decodes bytes to text via the font's ToUnicode CMap
     /// (falls back to Latin-1 / WinAnsi for fonts without ToUnicode).
+    #[cfg(test)]
     fn emit_text_span(
         bytes: &[u8],
         text_state: &mut TextState,
@@ -3612,6 +3603,7 @@ impl Interpreter {
     }
 
     /// Recurse into a Form XObject for text-only extraction.
+    #[cfg(test)]
     fn handle_do_text_only(
         operands: &[Object],
         spans: &mut Vec<TextSpan>,
@@ -3672,6 +3664,27 @@ impl Interpreter {
 #[cfg(test)]
 mod inline_image_tests {
     use super::*;
+
+    #[test]
+    fn text_only_extractor_accepts_an_empty_stream() {
+        let doc = Document::with_version("1.5");
+        let resources = Dictionary::new();
+        let mut spans = Vec::new();
+        let mut state = crate::graphics_state::GraphicsStateStack::new();
+        let mut registry = crate::fonts::FontRegistry::new();
+
+        Interpreter::extract_text_only(
+            b"",
+            &mut spans,
+            &mut state,
+            &doc,
+            &resources,
+            &mut registry,
+        )
+        .expect("empty text stream");
+
+        assert!(spans.is_empty());
+    }
 
     /// Draai extract_commands over een synthetische content-stream en geef de
     /// rauwe commandbuffer terug (zonder 16-byte pagina-header).

--- a/open-pdf-render/src/lib.rs
+++ b/open-pdf-render/src/lib.rs
@@ -5,7 +5,6 @@ mod graphics_state;
 mod interpreter;
 mod renderer;
 mod color;
-mod image_decode;
 pub mod draw_commands;
 pub mod encoding;
 pub mod font_parser;

--- a/open-pdf-render/src/tile_render.rs
+++ b/open-pdf-render/src/tile_render.rs
@@ -24,7 +24,7 @@
 
 use rayon::prelude::*;
 use tiny_skia::{
-    FillRule, LineCap, LineJoin, Paint, PathBuilder, Pixmap, PixmapPaint, Rect, Stroke,
+    FillRule, LineCap, LineJoin, Paint, PathBuilder, Pixmap, PixmapPaint, Stroke,
     StrokeDash, Transform,
 };
 

--- a/open-pdf-studio/index.html
+++ b/open-pdf-studio/index.html
@@ -14,13 +14,12 @@
 
   <script>
     // Boot diagnostics — installed BEFORE the module graph loads so even
-    // import-time errors surface on the Rust stderr (detach_diag) and the
-    // %TEMP% diag file. Without this a broken module import = silent white
-    // screen in headless/test instances.
+    // import-time errors are recorded as privacy-safe startup phases instead
+    // of producing a silent white screen.
     window.addEventListener('error', function (e) {
       try {
         window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke(
-          'detach_diag', { label: 'boot-error', msg: (e.message || '?') + ' @ ' + (e.filename || '?') + ':' + (e.lineno || 0) }
+          'startup_diagnostic', { phase: 'frontend-error', detail: e.message || '?' }
         );
       } catch (_) {}
     });
@@ -28,7 +27,7 @@
       try {
         var r = e.reason || {};
         window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke(
-          'detach_diag', { label: 'boot-rejection', msg: String(r.stack || r.message || r) }
+          'startup_diagnostic', { phase: 'frontend-rejection', detail: String(r.message || r) }
         );
       } catch (_) {}
     });

--- a/open-pdf-studio/js/i18n/locales/en/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/en/ribbon.json
@@ -278,6 +278,8 @@
     "help": "Help",
     "checkForUpdates": "Check for Updates",
     "updatesLabel": "Updates",
+    "startupDiagnosticsTitle": "Reveal the privacy-safe startup diagnostics file",
+    "startupDiagnostics": "Diagnostics",
     "setDefaultPdf": "Set Default PDF Application",
     "fileAssociations": "File Assoc."
   },

--- a/open-pdf-studio/js/main.js
+++ b/open-pdf-studio/js/main.js
@@ -5,24 +5,21 @@
  * Canvas/PDF operations remain vanilla JS.
  */
 
-// Boot diagnostics: fatal boot errors surface on the Rust stderr (and the
-// %TEMP% diag file) via detach_diag, so headless/test instances can report
-// WHAT broke even when the webview console is unreachable.
-window.addEventListener('error', (e) => {
+// Local startup diagnostics use allowlisted phases and Rust-side redaction.
+// They contain no document names or full local paths.
+function recordStartupDiagnostic(phase, detail) {
   try {
-    window.__TAURI__?.core?.invoke?.('detach_diag', {
-      label: 'boot-error',
-      msg: `${e.message} @ ${e.filename}:${e.lineno}`,
-    });
+    window.__TAURI__?.core?.invoke?.('startup_diagnostic', { phase, detail });
   } catch { /* diagnostics must never throw */ }
+}
+
+recordStartupDiagnostic('frontend-boot-start');
+
+window.addEventListener('error', (e) => {
+  recordStartupDiagnostic('frontend-error', e.message);
 });
 window.addEventListener('unhandledrejection', (e) => {
-  try {
-    window.__TAURI__?.core?.invoke?.('detach_diag', {
-      label: 'boot-rejection',
-      msg: String(e.reason?.stack || e.reason?.message || e.reason),
-    });
-  } catch { /* diagnostics must never throw */ }
+  recordStartupDiagnostic('frontend-rejection', String(e.reason?.message || e.reason));
 });
 
 // Core modules
@@ -195,6 +192,7 @@ async function init() {
     try { await loadPreferences(); } catch (_) {}
     const { default: PrintQueueWindow } = await import('./solid/components/PrintQueueWindow.jsx');
     render(() => PrintQueueWindow(), document.getElementById('app-root'));
+    recordStartupDiagnostic('frontend-ready');
     return;
   }
 
@@ -219,6 +217,7 @@ async function init() {
   // Single render call — mounts the entire UI tree
   // render() is synchronous, so DOM elements exist immediately after
   render(() => App(), document.getElementById('app-root'));
+  recordStartupDiagnostic('frontend-rendered');
 
   // Restore properties panel visibility from preferences
   initPropertiesPanel();
@@ -241,12 +240,11 @@ async function init() {
     .then(m => m.initScreenshotAnnotate())
     .catch(() => {});
 
-  // Wire MCP <-> WebView bridge BEFORE show()/setFocus(). The bridge is just
+  // Wire the MCP <-> WebView bridge early. The bridge is just
   // event-listener registration on window.__TAURI__.event — it does not need
   // the window to be visible or DOM-ready. Wiring it here means the in-process
-  // MCP server's `app_*` tools work even if `appWindow.show()` later stalls
-  // (observed: window remains created but `Visible: False`, blocking the
-  // entire downstream init chain). Inert outside Tauri.
+  // MCP server's `app_*` tools are available during the remaining startup.
+  // Inert outside Tauri.
   initMcpBridge().catch(e => console.warn('initMcpBridge failed:', e));
 
   // "Open PDF Printer" job queue: watch the spool so prints from ANY
@@ -262,17 +260,8 @@ async function init() {
     .then(m => m.loadPrinters())
     .catch(() => {});
 
-  // Show the window after frontend init. The previous double-rAF paint-wait
-  // gate permanently hides the window on WebKitGTK builds where accelerated
-  // compositing stalls before the first paint (observed on Linux Mint 22.3 +
-  // Mesa + Intel CML iGPU); rAF never resolves so show() is never called.
-  if (isTauri() && window.__TAURI__?.window) {
-    const appWindow = window.__TAURI__.window.getCurrentWindow();
-    await appWindow.show();
-    await appWindow.setFocus();
-  }
-
-  // Now that Solid has rendered, grab canvas and container refs
+  // The native window is visible from creation; frontend startup cannot keep
+  // it hidden. Now that Solid has rendered, grab canvas and container refs.
   initDomElements();
 
   // Wire the reactive cursor — runs once, then updates the .main-view cursor
@@ -400,6 +389,8 @@ async function init() {
         .catch(() => { /* offline / network error — silently skip */ });
     }, 1500);
   }
+
+  recordStartupDiagnostic('frontend-ready');
 }
 
 // Check for PDF files passed as command line arguments

--- a/open-pdf-studio/js/pdf/loader.js
+++ b/open-pdf-studio/js/pdf/loader.js
@@ -15,7 +15,7 @@ import { showMessage } from '../bridge.js';
 
 // Sub-module imports
 import { extractAnnotationColors } from './loader/color-extraction.js';
-import { extractStampImagesViaPdfJs, extractStampImages, extractStampImagesHybrid } from './loader/image-extraction.js';
+import { extractStampImagesHybrid } from './loader/image-extraction.js';
 import { convertPdfAnnotation } from './loader/annotation-converter.js';
 
 
@@ -876,6 +876,7 @@ async function loadAnnotationsForSinglePage(doc, pageNum, waitForColors = false)
   if (annotations.length === 0) return;
 
   const stampAnnots = annotations.filter(a => a.subtype === 'Stamp');
+  const hasSquareAnnotations = annotations.some(a => a.subtype === 'Square');
   const needsExtraData = annotations.some(a => ['FreeText', 'Square', 'Circle', 'Line', 'PolyLine', 'Polygon', 'Ink', 'Text', 'Highlight', 'Underline', 'StrikeOut', 'Squiggly', 'Stamp'].includes(a.subtype));
 
   let stampImageMap = null;
@@ -883,13 +884,13 @@ async function loadAnnotationsForSinglePage(doc, pageNum, waitForColors = false)
 
   // Resolve pdf-lib doc early so both stamp images and colors can use it
   let pdfLibDoc = doc._sharedPdfLibDoc || null;
-  if (!pdfLibDoc && waitForColors) {
+  if (!pdfLibDoc && (waitForColors || hasSquareAnnotations)) {
     const _pl0 = performance.now();
     pdfLibDoc = await getSharedPdfLibDoc(doc);
     console.log(`[PERF] page ${pageNum}: getSharedPdfLibDoc: ${(performance.now() - _pl0).toFixed(0)}ms`);
   }
 
-  if (stampAnnots.length > 0) {
+  if (stampAnnots.length > 0 || hasSquareAnnotations) {
     const _st0 = performance.now();
     try {
       const pdfPage = await doc.pdfDoc.getPage(pageNum);
@@ -1004,12 +1005,13 @@ export async function loadExistingAnnotations(doc) {
       if (annotations.length === 0) continue;
 
       const stampAnnots = annotations.filter(a => a.subtype === 'Stamp');
+      const hasSquareAnnotations = annotations.some(a => a.subtype === 'Square');
       const needsExtraData = annotations.some(a => ['FreeText', 'Square', 'Circle', 'Line', 'PolyLine', 'Polygon', 'Ink', 'Text', 'Highlight', 'Underline', 'StrikeOut', 'Squiggly', 'Stamp'].includes(a.subtype));
 
       let stampImageMap = null;
       let annotColorMap = null;
 
-      if (stampAnnots.length > 0) {
+      if (stampAnnots.length > 0 || hasSquareAnnotations) {
         try {
           stampImageMap = await extractStampImagesHybrid(
             pages[i], viewport, stampAnnots, pageNum, pdfLibDoc,
@@ -1053,12 +1055,13 @@ export async function loadExistingAnnotations(doc) {
         if (annotations.length === 0) continue;
 
         const stampAnnots = annotations.filter(a => a.subtype === 'Stamp');
+        const hasSquareAnnotations = annotations.some(a => a.subtype === 'Square');
         const needsExtraData = annotations.some(a => ['FreeText', 'Square', 'Circle', 'Line', 'PolyLine', 'Polygon', 'Ink', 'Text', 'Highlight', 'Underline', 'StrikeOut', 'Squiggly', 'Stamp'].includes(a.subtype));
 
         let stampImageMap = null;
         let annotColorMap = null;
 
-        if (stampAnnots.length > 0) {
+        if (stampAnnots.length > 0 || hasSquareAnnotations) {
           try {
             stampImageMap = await extractStampImagesHybrid(
               page, viewport, stampAnnots, pageNum, pdfLibDoc,

--- a/open-pdf-studio/js/pdf/loader/annotation-converter.js
+++ b/open-pdf-studio/js/pdf/loader/annotation-converter.js
@@ -4,6 +4,7 @@ import { generateImageId } from '../../utils/helpers.js';
 import { colorArrayToHex } from '../../utils/colors.js';
 import { mapPdfFontName, mapBorderStyle } from './pdf-helpers.js';
 import { calculateDistance, calculateArea, calculatePerimeter, formatMeasurement } from '../../annotations/measurement.js';
+import { findImageForAnnotation } from './annotation-image-sources.mjs';
 
 // Convert PDF annotation to our format
 export async function convertPdfAnnotation(annot, pageNum, viewport, stampImageMap, annotColorMap) {
@@ -138,6 +139,28 @@ export async function convertPdfAnnotation(annot, pageNum, viewport, stampImageM
     }
 
     case 'Square': {
+      const squareImageData = findImageForAnnotation(stampImageMap, annot, 'square-image');
+      if (squareImageData) {
+        const imageRect = convertRect(rect);
+        const imageId = generateImageId();
+        const img = new Image();
+        img.src = squareImageData;
+        imageCache.set(imageId, img);
+        return createAnnotation({
+          ...baseProps,
+          type: 'image',
+          x: imageRect.x,
+          y: imageRect.y,
+          width: imageRect.width,
+          height: imageRect.height,
+          imageId,
+          imageData: squareImageData,
+          originalWidth: imageRect.width,
+          originalHeight: imageRect.height,
+          lockAspectRatio: true,
+        });
+      }
+
       // Parametric symbol: stored as Square + private OPS metadata
       if (extraColors.opsSubtype === 'parametricSymbol') {
         const psRect = convertRect(annot.rect);
@@ -1125,24 +1148,7 @@ export async function convertPdfAnnotation(annot, pageNum, viewport, stampImageM
       const w = stRect.width;
       const h = stRect.height;
 
-      // Find matching stamp image by rect
-      let dataUrl = null;
-      if (stampImageMap) {
-        // Try exact match first
-        const key = `${rect[0]},${rect[1]},${rect[2]},${rect[3]}`;
-        dataUrl = stampImageMap.get(key);
-        // Fuzzy match fallback
-        if (!dataUrl) {
-          for (const [k, v] of stampImageMap.entries()) {
-            const parts = k.split(',').map(Number);
-            if (Math.abs(parts[0] - rect[0]) < 1 && Math.abs(parts[1] - rect[1]) < 1 &&
-                Math.abs(parts[2] - rect[2]) < 1 && Math.abs(parts[3] - rect[3]) < 1) {
-              dataUrl = v;
-              break;
-            }
-          }
-        }
-      }
+      const dataUrl = findImageForAnnotation(stampImageMap, annot, 'stamp');
 
       let stRotation = 0;
       if (extraColors.rotation !== undefined && extraColors.rotation !== 0) {

--- a/open-pdf-studio/js/pdf/loader/annotation-image-sources.mjs
+++ b/open-pdf-studio/js/pdf/loader/annotation-image-sources.mjs
@@ -1,0 +1,99 @@
+import { PDFName } from 'pdf-lib';
+
+function nameOf(value) {
+  return value ? String(value) : '';
+}
+
+function numberOf(context, value) {
+  const resolved = context.lookup(value) || value;
+  if (typeof resolved?.asNumber === 'function') return resolved.asNumber();
+  if (typeof resolved?.value === 'number') return resolved.value;
+  const parsed = Number(resolved);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function rectKey(context, annotation) {
+  const raw = annotation.get(PDFName.of('Rect'));
+  const rect = raw && (context.lookup(raw) || raw);
+  if (!rect || typeof rect.size !== 'function' || rect.size() < 4) return null;
+  const values = [0, 1, 2, 3].map(index => numberOf(context, rect.get(index)));
+  return values.every(Number.isFinite) ? values.join(',') : null;
+}
+
+function appearanceStream(context, annotation) {
+  const apRaw = annotation.get(PDFName.of('AP'));
+  const ap = apRaw && context.lookup(apRaw);
+  if (!ap || typeof ap.get !== 'function') return null;
+  const normalRaw = ap.get(PDFName.of('N'));
+  return normalRaw ? context.lookup(normalRaw) : null;
+}
+
+export function annotationIdOf(value) {
+  const match = String(value || '').match(/^(\d+)\s+(\d+)\s+R$/);
+  if (!match) return null;
+  return match[2] === '0' ? `${match[1]}R` : `${match[1]}R${match[2]}`;
+}
+
+export function findImageAnnotationSources(pageNum, pdfDoc) {
+  const page = pdfDoc.getPages()[pageNum - 1];
+  if (!page) return [];
+
+  const context = pdfDoc.context;
+  const annotsRaw = page.node.get(PDFName.of('Annots'));
+  const annotations = annotsRaw && context.lookup(annotsRaw);
+  if (!annotations || typeof annotations.size !== 'function') return [];
+
+  const sources = [];
+  for (let index = 0; index < annotations.size(); index += 1) {
+    const annotationRaw = annotations.get(index);
+    const annotation = context.lookup(annotationRaw);
+    if (!annotation || typeof annotation.get !== 'function') continue;
+
+    const subtype = nameOf(annotation.get(PDFName.of('Subtype')));
+    const intent = nameOf(annotation.get(PDFName.of('IT')));
+    const isStamp = subtype === '/Stamp';
+    const isSquareImage = subtype === '/Square' && intent === '/SquareImage';
+    if (!isStamp && !isSquareImage) continue;
+
+    const key = rectKey(context, annotation);
+    if (!key) continue;
+
+    const imageRaw = isSquareImage ? annotation.get(PDFName.of('Image')) : null;
+    const stream = (imageRaw && context.lookup(imageRaw)) || appearanceStream(context, annotation);
+    if (!stream) continue;
+
+    sources.push({
+      annotationId: annotationIdOf(annotationRaw),
+      kind: isSquareImage ? 'square-image' : 'stamp',
+      rectKey: key,
+      stream,
+    });
+  }
+  return sources;
+}
+
+export function findImageForAnnotation(imageMap, annotation, expectedKind, tolerance = 1) {
+  if (!imageMap || !annotation) return null;
+
+  // PDF.js exposes indirect annotation references as ids such as "131R".
+  // When an id exists, it is authoritative: falling back to the rectangle
+  // could attach an image to a different annotation with identical bounds.
+  if (annotation.id) {
+    const match = imageMap.get(`id:${annotation.id}`);
+    return match?.kind === expectedKind ? match.dataUrl : null;
+  }
+
+  const rect = annotation.rect;
+  if (!rect || rect.length < 4) return null;
+  const exact = imageMap.get(`rect:${rect[0]},${rect[1]},${rect[2]},${rect[3]}`);
+  if (exact?.kind === expectedKind) return exact.dataUrl;
+
+  for (const [key, value] of imageMap.entries()) {
+    if (!key.startsWith('rect:') || value?.kind !== expectedKind) continue;
+    const candidate = key.slice(5).split(',').map(Number);
+    if (candidate.length === 4 && candidate.every((number, index) => Math.abs(number - rect[index]) < tolerance)) {
+      return value.dataUrl;
+    }
+  }
+  return null;
+}

--- a/open-pdf-studio/js/pdf/loader/image-extraction.js
+++ b/open-pdf-studio/js/pdf/loader/image-extraction.js
@@ -1,5 +1,6 @@
 import { PDFName, PDFArray } from 'pdf-lib';
 import { pdfNum, inflateBytes } from './pdf-helpers.js';
+import { findImageAnnotationSources, findImageForAnnotation } from './annotation-image-sources.mjs';
 
 // Hybrid stamp image extraction. Tries to extract each stamp via pdf-lib's
 // XObject reader first (clean — never bakes in overlapping annotations),
@@ -16,7 +17,7 @@ import { pdfNum, inflateBytes } from './pdf-helpers.js';
 // with it. The bake-in happens because page.render() with annotationMode:1
 // rasterizes ALL annotations onto the temp canvas before cropping.
 export async function extractStampImagesHybrid(page, viewport, stampAnnots, pageNum, pdfLibDoc) {
-  if (stampAnnots.length === 0) return new Map();
+  if (stampAnnots.length === 0 && !pdfLibDoc) return new Map();
 
   // First pass: pdf-lib extraction (clean, no bake-in)
   let imageMap = new Map();
@@ -33,7 +34,7 @@ export async function extractStampImagesHybrid(page, viewport, stampAnnots, page
   const missing = stampAnnots.filter(s => {
     const rect = s.rect;
     if (!rect) return false;
-    return !imageMap.has(`${rect[0]},${rect[1]},${rect[2]},${rect[3]}`);
+    return !findImageForAnnotation(imageMap, s, 'stamp');
   });
 
   // Second pass: PDF.js render+crop for the leftovers (still bakes in
@@ -117,8 +118,10 @@ export async function extractStampImagesViaPdfJs(page, viewport, stampAnnots) {
         cropCtx.drawImage(tempCanvas, cropX, cropY, cropW, cropH, 0, 0, cropW, cropH);
 
         const dataUrl = cropCanvas.toDataURL('image/png');
-        const key = `${rect[0]},${rect[1]},${rect[2]},${rect[3]}`;
-        imageMap.set(key, dataUrl);
+        const key = stamp.id
+          ? `id:${stamp.id}`
+          : `rect:${rect[0]},${rect[1]},${rect[2]},${rect[3]}`;
+        imageMap.set(key, { kind: 'stamp', dataUrl });
       }
     }
   } catch (e) {
@@ -133,45 +136,14 @@ export async function extractStampImages(pageNum, pdfDoc) {
   const imageMap = new Map();
 
   try {
-    const page = pdfDoc.getPages()[pageNum - 1];
-    if (!page) return imageMap;
-
     const context = pdfDoc.context;
-    const annotsRaw = page.node.get(PDFName.of('Annots'));
-    if (!annotsRaw) return imageMap;
-    const annots = context.lookup(annotsRaw);
-    if (!annots) return imageMap;
-
-    for (let i = 0; i < annots.size(); i++) {
-      const annotDict = context.lookup(annots.get(i));
-      if (!annotDict) continue;
-
-      const subtype = annotDict.get(PDFName.of('Subtype'));
-      if (!subtype || subtype.toString() !== '/Stamp') continue;
-
-      // Get appearance: /AP -> /N
-      const apRaw = annotDict.get(PDFName.of('AP'));
-      if (!apRaw) { console.warn('Stamp has no /AP'); continue; }
-      const apDict = context.lookup(apRaw);
-      if (!apDict) continue;
-
-      const normalRaw = apDict.get(PDFName.of('N'));
-      if (!normalRaw) { console.warn('Stamp has no /AP/N'); continue; }
-      const normalStream = context.lookup(normalRaw);
-      if (!normalStream) continue;
-
-      // Extract image from the Form XObject
-      const dataUrl = await extractImageFromFormXObject(context, normalStream);
+    for (const source of findImageAnnotationSources(pageNum, pdfDoc)) {
+      const dataUrl = await extractImageFromFormXObject(context, source.stream);
       if (dataUrl) {
-        // Build rect key for matching with pdf.js annotations
-        const rectArr = annotDict.get(PDFName.of('Rect'));
-        if (rectArr) {
-          const r0 = pdfNum(context.lookup(rectArr.get(0)) || rectArr.get(0));
-          const r1 = pdfNum(context.lookup(rectArr.get(1)) || rectArr.get(1));
-          const r2 = pdfNum(context.lookup(rectArr.get(2)) || rectArr.get(2));
-          const r3 = pdfNum(context.lookup(rectArr.get(3)) || rectArr.get(3));
-          imageMap.set(`${r0},${r1},${r2},${r3}`, dataUrl);
-        }
+        const key = source.annotationId
+          ? `id:${source.annotationId}`
+          : `rect:${source.rectKey}`;
+        imageMap.set(key, { kind: source.kind, dataUrl });
       }
     }
   } catch (e) {

--- a/open-pdf-studio/js/solid/components/ribbon/HelpTab.jsx
+++ b/open-pdf-studio/js/solid/components/ribbon/HelpTab.jsx
@@ -9,6 +9,13 @@ import { openDialog } from '../../stores/dialogStore.js';
 export default function HelpTab() {
   const { t } = useTranslation('ribbon');
 
+  const revealStartupDiagnostics = async () => {
+    const invoke = window.__TAURI__?.core?.invoke;
+    if (!invoke) return;
+    const path = await invoke('startup_diagnostics_path');
+    await invoke('reveal_in_file_manager', { path });
+  };
+
   return (
     <div class="ribbon-content active" id="tab-help">
       <AdaptiveGroups>
@@ -57,6 +64,13 @@ export default function HelpTab() {
             icon={updatesIcon}
             label={t('help.updatesLabel')}
             onClick={() => import('../../../ui/chrome/updater.js').then(m => m.checkForUpdates(false))}
+          />
+          <RibbonButton
+            id="ribbon-startup-diagnostics"
+            title={t('help.startupDiagnosticsTitle')}
+            icon={updatesIcon}
+            label={t('help.startupDiagnostics')}
+            onClick={revealStartupDiagnostics}
           />
         </RibbonGroup>
       </AdaptiveGroups>

--- a/open-pdf-studio/js/types/annotation.ts
+++ b/open-pdf-studio/js/types/annotation.ts
@@ -6,7 +6,7 @@ export type AnnotationType =
   | 'arc' | 'spline' | 'splineArrow' | 'redaction'
   | 'measureDistance' | 'measureArea' | 'measurePerimeter' | 'measureAngle'
   | 'filledArea'
-  | 'scaleBar'
+  | 'mask' | 'viewport' | 'scheduleTable' | 'scaleBar'
   | 'scaleRegion'
   | 'parametricSymbol';
 

--- a/open-pdf-studio/js/types/preferences.ts
+++ b/open-pdf-studio/js/types/preferences.ts
@@ -33,8 +33,10 @@ export interface Preferences {
   showSnapTypeLabel: boolean;
   objectSnapRadius: number;
   snapToPdfContent: boolean;
+  enableImageAlignSnap: boolean;
   keepToolActive: boolean;
   lineContinue: boolean;
+  ribbonCollapsed: boolean;
 
   // Appearance
   defaultAnnotationColor: string;
@@ -102,13 +104,19 @@ export interface Preferences {
   highlightColor: string;
 
   // Polygon defaults
+  polygonFillColor: string;
+  polygonFillNone: boolean;
   polygonStrokeColor: string;
   polygonLineWidth: number;
+  polygonBorderStyle: string;
   polygonOpacity: number;
 
   // Cloud defaults
+  cloudFillColor: string;
+  cloudFillNone: boolean;
   cloudStrokeColor: string;
   cloudLineWidth: number;
+  cloudBorderStyle: string;
   cloudOpacity: number;
 
   // Cloud Polyline defaults
@@ -123,7 +131,23 @@ export interface Preferences {
   // Polyline defaults
   polylineStrokeColor: string;
   polylineLineWidth: number;
+  polylineBorderStyle: string;
   polylineOpacity: number;
+
+  // Filled Area defaults
+  filledAreaStrokeColor: string;
+  filledAreaFillColor: string;
+  filledAreaFillNone: boolean;
+  filledAreaLineWidth: number;
+  filledAreaBorderStyle: string;
+  filledAreaOpacity: number;
+  filledAreaHatchPattern: string;
+  filledAreaHatchColor: string;
+  filledAreaHatchScale: number;
+  filledAreaHatchAngle: number;
+
+  // Symbol customisation
+  symbolTypeOverrides: Record<string, { svg: string; name: string }>;
 
   // Redaction defaults
   redactionOverlayColor: string;

--- a/open-pdf-studio/package-lock.json
+++ b/open-pdf-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.71.0",
+  "version": "1.78.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-pdf-studio",
-      "version": "1.71.0",
+      "version": "1.78.0",
       "license": "MIT",
       "dependencies": {
         "@crabnebula/tauri-plugin-drag": "^2.1.0",

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "test:render": "..\\scripts\\.venv-test\\Scripts\\python.exe ../scripts/render-regression-test.py",
     "test:render:auto": "node ../scripts/run-render-regression.mjs",
-    "test:quality": "node --test scripts/*.test.mjs"
+    "test:quality": "node --test scripts/native-runtime.test.mjs scripts/release-config.test.mjs scripts/square-image-annotation.test.mjs"
   },
   "keywords": [
     "tauri",

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -1,11 +1,12 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "description": "A free, open-source PDF annotation editor built with Tauri",
   "scripts": {
-    "predev": "cargo build -p pdfium-worker",
+    "prepare:native-runtime": "node scripts/native-runtime.mjs",
+    "predev": "npm run prepare:native-runtime && cargo build -p pdfium-worker",
     "dev": "vite",
-    "prebuild": "cargo build --release -p pdfium-worker",
+    "prebuild": "npm run prepare:native-runtime && cargo build --release -p pdfium-worker",
     "build": "vite build",
     "preview": "vite preview",
     "tauri": "tauri",
@@ -15,7 +16,8 @@
     "bump": "node scripts/bump-version.js",
     "typecheck": "tsc --noEmit",
     "test:render": "..\\scripts\\.venv-test\\Scripts\\python.exe ../scripts/render-regression-test.py",
-    "test:render:auto": "node ../scripts/run-render-regression.mjs"
+    "test:render:auto": "node ../scripts/run-render-regression.mjs",
+    "test:quality": "node --test scripts/*.test.mjs"
   },
   "keywords": [
     "tauri",

--- a/open-pdf-studio/scripts/bump-version.js
+++ b/open-pdf-studio/scripts/bump-version.js
@@ -33,6 +33,15 @@ const files = [
     }
   },
   {
+    path: path.join(root, 'package-lock.json'),
+    update: (content) => {
+      const lock = JSON.parse(content);
+      lock.version = version;
+      if (lock.packages && lock.packages['']) lock.packages[''].version = version;
+      return `${JSON.stringify(lock, null, 2)}\n`;
+    }
+  },
+  {
     path: path.join(root, 'src-tauri', 'tauri.conf.json'),
     update: (content) => {
       return content.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`);
@@ -42,6 +51,15 @@ const files = [
     path: path.join(root, 'src-tauri', 'Cargo.toml'),
     update: (content) => {
       return content.replace(/^version\s*=\s*"[^"]*"/m, `version = "${version}"`);
+    }
+  },
+  {
+    path: path.join(repoRoot, 'Cargo.lock'),
+    update: (content) => {
+      return content.replace(
+        /(name = "open-pdf-studio"\r?\nversion = ")[^"]+("\r?\n)/,
+        `$1${version}$2`
+      );
     }
   },
   {

--- a/open-pdf-studio/scripts/create-render-fixture.mjs
+++ b/open-pdf-studio/scripts/create-render-fixture.mjs
@@ -1,0 +1,78 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+
+const FIXED_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+export async function createRenderFixture(outputPath) {
+  const pdf = await PDFDocument.create({ updateMetadata: false });
+  pdf.setTitle('Render regression fixture');
+  pdf.setAuthor('Open PDF Studio');
+  pdf.setCreator('Open PDF Studio');
+  pdf.setProducer('Open PDF Studio');
+  pdf.setCreationDate(FIXED_DATE);
+  pdf.setModificationDate(FIXED_DATE);
+
+  const page = pdf.addPage([595, 842]);
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+  page.drawText('Open PDF Studio', {
+    x: 64,
+    y: 752,
+    size: 24,
+    font: bold,
+    color: rgb(0.08, 0.16, 0.28),
+  });
+  page.drawText('Deterministic render regression fixture', {
+    x: 64,
+    y: 724,
+    size: 12,
+    font,
+    color: rgb(0.24, 0.32, 0.42),
+  });
+  page.drawRectangle({
+    x: 64,
+    y: 570,
+    width: 210,
+    height: 100,
+    color: rgb(0.12, 0.48, 0.78),
+    borderColor: rgb(0.04, 0.18, 0.34),
+    borderWidth: 3,
+  });
+  page.drawCircle({
+    x: 390,
+    y: 620,
+    size: 52,
+    color: rgb(0.92, 0.48, 0.12),
+    borderColor: rgb(0.42, 0.18, 0.04),
+    borderWidth: 3,
+  });
+  page.drawLine({
+    start: { x: 64, y: 510 },
+    end: { x: 531, y: 440 },
+    thickness: 5,
+    color: rgb(0.18, 0.62, 0.38),
+  });
+  page.drawText('Text 1234 - vector shapes - RGB colours', {
+    x: 64,
+    y: 390,
+    size: 16,
+    font,
+    color: rgb(0.12, 0.12, 0.12),
+  });
+
+  const bytes = await pdf.save({ useObjectStreams: false });
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, bytes);
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  const outputPath = process.argv[2];
+  if (!outputPath) {
+    throw new Error('Usage: node scripts/create-render-fixture.mjs <output.pdf>');
+  }
+  await createRenderFixture(path.resolve(outputPath));
+}

--- a/open-pdf-studio/scripts/macos-startup-smoke.sh
+++ b/open-pdf-studio/scripts/macos-startup-smoke.sh
@@ -71,9 +71,10 @@ for _ in 0..<30 {
     let ownerPid = (window[kCGWindowOwnerPID as String] as? NSNumber)?.intValue
     let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue
     guard ownerPid == expectedPid, layer == 0,
-          let rawBounds = window[kCGWindowBounds as String] as? CFDictionary,
-          let bounds = CGRect(dictionaryRepresentation: rawBounds) else { return false }
-    return bounds.width >= 400 && bounds.height >= 300
+          let bounds = window[kCGWindowBounds as String] as? [String: Any],
+          let width = (bounds["Width"] as? NSNumber)?.doubleValue,
+          let height = (bounds["Height"] as? NSNumber)?.doubleValue else { return false }
+    return width >= 400 && height >= 300
   }
   if visible { exit(0) }
   Thread.sleep(forTimeInterval: 1)

--- a/open-pdf-studio/scripts/macos-startup-smoke.sh
+++ b/open-pdf-studio/scripts/macos-startup-smoke.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+app_path="${1:?usage: macos-startup-smoke.sh /path/to/App.app}"
+test -d "$app_path"
+
+existing_diagnostics="$(find "$HOME/Library/Logs" "$HOME/Library/Application Support" -name startup-diagnostics.jsonl -type f -print -quit 2>/dev/null || true)"
+baseline_lines=0
+if [[ -n "$existing_diagnostics" ]]; then
+  baseline_lines="$(wc -l < "$existing_diagnostics")"
+fi
+
+crash_baseline="$(mktemp)"
+touch "$crash_baseline"
+pid=""
+cleanup() {
+  if [[ -n "$pid" ]]; then kill "$pid" 2>/dev/null || true; fi
+  rm -f "$crash_baseline"
+}
+trap cleanup EXIT
+
+find_new_crash_report() {
+  local reports="$HOME/Library/Logs/DiagnosticReports"
+  if [[ ! -d "$reports" ]]; then return 0; fi
+  find "$reports" -type f -newer "$crash_baseline" \
+    \( -name 'Open PDF Studio*.ips' -o -name 'Open PDF Studio*.crash' \
+       -o -name 'open-pdf-studio*.ips' -o -name 'open-pdf-studio*.crash' \) \
+    -print -quit 2>/dev/null || true
+}
+
+assert_process_healthy() {
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "App process exited during startup smoke"
+    local report
+    report="$(find_new_crash_report)"
+    if [[ -n "$report" ]]; then echo "Crash report: $report"; fi
+    return 1
+  fi
+  local report
+  report="$(find_new_crash_report)"
+  if [[ -n "$report" ]]; then
+    echo "New crash report detected: $report"
+    return 1
+  fi
+}
+
+open "$app_path"
+for _ in {1..30}; do
+  pid="$(pgrep -f "$app_path/Contents/MacOS/" | head -n 1 || true)"
+  if [[ -n "$pid" ]]; then break; fi
+  sleep 1
+done
+if [[ -z "$pid" ]]; then
+  echo "App process did not start"
+  exit 1
+fi
+
+# A live process is insufficient: verify that WindowServer reports a sizeable,
+# on-screen layer-zero window for this exact process.
+swift - "$pid" <<'SWIFT'
+import CoreGraphics
+import Foundation
+
+let expectedPid = Int(CommandLine.arguments[1])!
+for _ in 0..<30 {
+  let windows = CGWindowListCopyWindowInfo(
+    [.optionOnScreenOnly, .excludeDesktopElements],
+    kCGNullWindowID
+  ) as? [[String: Any]] ?? []
+  let visible = windows.contains { window in
+    let ownerPid = (window[kCGWindowOwnerPID as String] as? NSNumber)?.intValue
+    let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue
+    guard ownerPid == expectedPid, layer == 0,
+          let rawBounds = window[kCGWindowBounds as String] as? CFDictionary,
+          let bounds = CGRect(dictionaryRepresentation: rawBounds) else { return false }
+    return bounds.width >= 400 && bounds.height >= 300
+  }
+  if visible { exit(0) }
+  Thread.sleep(forTimeInterval: 1)
+}
+fputs("No visible application window found\n", stderr)
+exit(1)
+SWIFT
+
+diagnostics=""
+ready=false
+for _ in {1..30}; do
+  assert_process_healthy
+  diagnostics="$(find "$HOME/Library/Logs" "$HOME/Library/Application Support" -name startup-diagnostics.jsonl -type f -print -quit 2>/dev/null || true)"
+  first_new_line=1
+  if [[ "$diagnostics" == "$existing_diagnostics" ]]; then
+    first_new_line=$((baseline_lines + 1))
+  fi
+  if [[ -n "$diagnostics" ]] && tail -n "+$first_new_line" "$diagnostics" | grep -q '"phase":"frontend-ready"'; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$ready" != true ]]; then
+  echo "Frontend readiness marker was not written"
+  if [[ -n "$diagnostics" ]]; then tail -n 20 "$diagnostics"; fi
+  exit 1
+fi
+
+# A frontend-ready marker is only meaningful if the native process remains
+# healthy afterwards. Catch immediate post-start crashes before accepting it.
+survival_seconds=10
+for ((second = 0; second < survival_seconds; second += 1)); do
+  assert_process_healthy
+  sleep 1
+done
+assert_process_healthy
+
+echo "macOS startup smoke passed: visible window, frontend-ready, and ${survival_seconds}s survival"

--- a/open-pdf-studio/scripts/native-runtime.mjs
+++ b/open-pdf-studio/scripts/native-runtime.mjs
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { access, copyFile, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { spawn } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const PDFIUM_RUNTIME = Object.freeze({
+  version: '7834',
+  url: 'https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7834/pdfium-mac-univ.tgz',
+  sha256: '659e2f647ffd667b36487375165563e58f961db9cf75a45104dc59b9407ccbdf',
+});
+
+export function nativeRuntimePlan({
+  platform = process.platform,
+  projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+} = {}) {
+  if (platform !== 'darwin') return null;
+
+  const libraryPath = path.join(projectDir, 'src-tauri', 'binaries', 'macos-universal', 'libpdfium.dylib');
+  return {
+    ...PDFIUM_RUNTIME,
+    libraryPath,
+    metadataPath: `${libraryPath}.runtime.json`,
+  };
+}
+
+export async function isNativeRuntimeReady(plan) {
+  if (!plan) return true;
+  try {
+    await access(plan.libraryPath);
+    const metadata = JSON.parse(await readFile(plan.metadataPath, 'utf8'));
+    return metadata.version === plan.version && metadata.sha256 === plan.sha256;
+  } catch {
+    return false;
+  }
+}
+
+async function sha256(filePath) {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function download(url, destination) {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed (${response.status} ${response.statusText})`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  await writeFile(destination, bytes);
+}
+
+async function run(command, args, cwd) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', code => code === 0 ? resolve() : reject(new Error(`${command} exited with code ${code}`)));
+  });
+}
+
+export async function prepareNativeRuntime(options = {}) {
+  const plan = nativeRuntimePlan(options);
+  if (!plan) {
+    console.log('Native runtime: no preparation needed on this platform.');
+    return;
+  }
+  if (await isNativeRuntimeReady(plan)) {
+    console.log(`Native runtime: PDFium ${plan.version} is ready.`);
+    return;
+  }
+
+  await mkdir(path.dirname(plan.libraryPath), { recursive: true });
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'opds-pdfium-'));
+  const archivePath = path.join(tempDir, 'pdfium-mac-univ.tgz');
+  const stagedLibrary = path.join(tempDir, 'lib', 'libpdfium.dylib');
+  const nextLibrary = `${plan.libraryPath}.new`;
+
+  try {
+    console.log(`Native runtime: downloading PDFium ${plan.version}...`);
+    await download(plan.url, archivePath);
+    const actualSha256 = await sha256(archivePath);
+    if (actualSha256 !== plan.sha256) {
+      throw new Error(`PDFium checksum mismatch: expected ${plan.sha256}, received ${actualSha256}`);
+    }
+    await run('tar', ['xzf', archivePath, '-C', tempDir, 'lib/libpdfium.dylib'], tempDir);
+    await copyFile(stagedLibrary, nextLibrary);
+    await rm(plan.libraryPath, { force: true });
+    await rename(nextLibrary, plan.libraryPath);
+    await writeFile(plan.metadataPath, `${JSON.stringify({ version: plan.version, sha256: plan.sha256 }, null, 2)}\n`);
+    console.log(`Native runtime: installed ${plan.libraryPath}`);
+  } finally {
+    await rm(nextLibrary, { force: true });
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const entryPoint = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : '';
+if (import.meta.url === entryPoint) {
+  prepareNativeRuntime().catch(error => {
+    console.error(`Native runtime preparation failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/open-pdf-studio/scripts/native-runtime.test.mjs
+++ b/open-pdf-studio/scripts/native-runtime.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  PDFIUM_RUNTIME,
+  isNativeRuntimeReady,
+  nativeRuntimePlan,
+} from './native-runtime.mjs';
+
+test('native runtime preparation is a no-op outside macOS', () => {
+  assert.equal(nativeRuntimePlan({ platform: 'win32', projectDir: 'C:\\app' }), null);
+  assert.equal(nativeRuntimePlan({ platform: 'linux', projectDir: '/app' }), null);
+});
+
+test('macOS uses the pinned universal PDFium runtime and checksum', () => {
+  const plan = nativeRuntimePlan({ platform: 'darwin', projectDir: '/app' });
+
+  assert.equal(plan.version, '7834');
+  assert.equal(plan.sha256, '659e2f647ffd667b36487375165563e58f961db9cf75a45104dc59b9407ccbdf');
+  assert.equal(plan.libraryPath, path.join('/app', 'src-tauri', 'binaries', 'macos-universal', 'libpdfium.dylib'));
+  assert.equal(plan.metadataPath, `${plan.libraryPath}.runtime.json`);
+  assert.equal(plan.url, PDFIUM_RUNTIME.url);
+});
+
+test('a cached runtime is valid only with matching metadata and library', async () => {
+  const projectDir = await mkdtemp(path.join(os.tmpdir(), 'opds-runtime-'));
+  const plan = nativeRuntimePlan({ platform: 'darwin', projectDir });
+
+  try {
+    assert.equal(await isNativeRuntimeReady(plan), false);
+
+    await mkdir(path.dirname(plan.libraryPath), { recursive: true });
+    await writeFile(plan.libraryPath, 'dylib');
+    await writeFile(plan.metadataPath, JSON.stringify({ version: plan.version, sha256: 'wrong' }));
+    assert.equal(await isNativeRuntimeReady(plan), false);
+
+    await writeFile(plan.metadataPath, JSON.stringify({ version: plan.version, sha256: plan.sha256 }));
+    assert.equal(await isNativeRuntimeReady(plan), true);
+  } finally {
+    await rm(projectDir, { recursive: true, force: true });
+  }
+});

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -45,6 +45,13 @@ test('render regression caches the workspace target and allows cold CI builds', 
   assert.match(runner, /process\.env\.OPS_STARTUP_TIMEOUT_MS/);
 });
 
+test('render regression prepares a deterministic CI corpus', async () => {
+  const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'render-regression.yml'), 'utf8');
+  assert.match(workflow, /name: Prepare deterministic render corpus/);
+  assert.match(workflow, /scripts\/render_test\/tests\/fixtures\/tiny\.pdf/);
+  assert.match(workflow, /open-pdf-studio\/test pdf-bestanden\/Originele bestanden/);
+});
+
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {
   const config = await readJson('src-tauri/tauri.conf.json');
   assert.deepEqual(config.bundle.windows.webviewInstallMode, {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -64,6 +64,7 @@ test('CI exercises macOS 26 startup and frontend readiness', async () => {
   assert.match(smoke, /survival_seconds=10/);
   assert.match(smoke, /kill -0 "\$pid"/);
   assert.match(smoke, /new_crash_report/);
+  assert.doesNotMatch(smoke, /CFDictionary/);
 });
 
 test('release workflows verify macOS signatures and notarization', async () => {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoDir = path.resolve(projectDir, '..');
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(projectDir, relativePath), 'utf8'));
+}
+
+test('the primary window is visible from native creation', async () => {
+  const config = await readJson('src-tauri/tauri.conf.json');
+  assert.equal(config.app.windows[0].visible, true);
+});
+
+test('macOS native runtime preparation is wired into local and release builds', async () => {
+  const pkg = await readJson('package.json');
+  assert.match(pkg.scripts.predev, /prepare:native-runtime/);
+  assert.match(pkg.scripts.prebuild, /prepare:native-runtime/);
+  assert.equal(pkg.scripts['prepare:native-runtime'], 'node scripts/native-runtime.mjs');
+});
+
+test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {
+  const config = await readJson('src-tauri/tauri.conf.json');
+  assert.deepEqual(config.bundle.windows.webviewInstallMode, {
+    type: 'embedBootstrapper',
+    silent: true,
+  });
+  assert.equal(config.bundle.resources['WebView2Loader.dll'], 'WebView2Loader.dll');
+});
+
+test('CI exercises macOS 26 startup and frontend readiness', async () => {
+  const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'ci.yml'), 'utf8');
+  const smoke = await readFile(path.join(projectDir, 'scripts', 'macos-startup-smoke.sh'), 'utf8');
+  assert.match(workflow, /macos-26/);
+  assert.match(workflow, /npm run prepare:native-runtime/);
+  assert.match(workflow, /macos-startup-smoke\.sh/);
+  assert.match(smoke, /survival_seconds=10/);
+  assert.match(smoke, /kill -0 "\$pid"/);
+  assert.match(smoke, /new_crash_report/);
+});
+
+test('release workflows verify macOS signatures and notarization', async () => {
+  for (const name of ['release.yml', 'nightly.yml']) {
+    const workflow = await readFile(path.join(repoDir, '.github', 'workflows', name), 'utf8');
+    assert.match(workflow, /codesign --verify --deep --strict/);
+    assert.match(workflow, /spctl --assess --type execute/);
+    assert.match(workflow, /xcrun stapler validate/);
+    assert.match(workflow, /macos-startup-smoke\.sh/);
+    assert.match(workflow, /APPLE_SIGNING_IDENTITY/);
+  }
+});
+
+test('all release metadata targets version 1.78.0', async () => {
+  const pkg = await readJson('package.json');
+  const packageLock = await readJson('package-lock.json');
+  const config = await readJson('src-tauri/tauri.conf.json');
+  const cargo = await readFile(path.join(projectDir, 'src-tauri', 'Cargo.toml'), 'utf8');
+  const release = await readFile(path.join(repoDir, '.github', 'workflows', 'release.yml'), 'utf8');
+  const cargoLock = await readFile(path.join(repoDir, 'Cargo.lock'), 'utf8');
+
+  assert.equal(pkg.version, '1.78.0');
+  assert.equal(packageLock.version, '1.78.0');
+  assert.equal(packageLock.packages[''].version, '1.78.0');
+  assert.equal(config.version, '1.78.0');
+  assert.match(cargo, /^version = "1\.78\.0"$/m);
+  assert.match(release, /default: 'v1\.78\.0'/);
+  assert.match(cargoLock, /name = "open-pdf-studio"\r?\nversion = "1\.78\.0"/);
+});
+
+test('development optimization profiles live at the workspace root', async () => {
+  const workspaceCargo = await readFile(path.join(repoDir, 'Cargo.toml'), 'utf8');
+  const appCargo = await readFile(path.join(projectDir, 'src-tauri', 'Cargo.toml'), 'utf8');
+  assert.match(workspaceCargo, /\[profile\.dev\.package\.open-pdf-render\]/);
+  assert.match(workspaceCargo, /\[profile\.dev\.package\.pdfium-render\]/);
+  assert.doesNotMatch(appCargo, /\[profile\./);
+});

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -39,6 +39,9 @@ test('render regression caches the workspace target and allows cold CI builds', 
   const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'render-regression.yml'), 'utf8');
   const runner = await readFile(path.join(repoDir, 'scripts', 'run-render-regression.mjs'), 'utf8');
   assert.match(workflow, /^\s+target\s*$/m);
+  assert.match(workflow, /uses: actions\/cache\/restore@v4/);
+  assert.match(workflow, /uses: actions\/cache\/save@v4/);
+  assert.match(workflow, /name: Save cargo cache after render\s+if: always\(\)/);
   assert.doesNotMatch(workflow, /open-pdf-studio\/src-tauri\/target/);
   assert.doesNotMatch(workflow, /open-pdf-render\/target/);
   assert.match(workflow, /OPS_STARTUP_TIMEOUT_MS:\s*'1200000'/);
@@ -47,9 +50,12 @@ test('render regression caches the workspace target and allows cold CI builds', 
 
 test('render regression prepares a deterministic CI corpus', async () => {
   const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'render-regression.yml'), 'utf8');
+  const app = await readFile(path.join(projectDir, 'src-tauri', 'src', 'lib.rs'), 'utf8');
   assert.match(workflow, /name: Prepare deterministic render corpus/);
   assert.match(workflow, /scripts\/render_test\/tests\/fixtures\/tiny\.pdf/);
-  assert.match(workflow, /open-pdf-studio\/test pdf-bestanden\/Originele bestanden/);
+  assert.match(workflow, /\$corpus = 'test pdf-bestanden\/Originele bestanden'/);
+  assert.match(app, /env!\("CARGO_MANIFEST_DIR"\)/);
+  assert.doesNotMatch(app, /std::env::current_dir\(\)/);
 });
 
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -23,6 +23,18 @@ test('macOS native runtime preparation is wired into local and release builds', 
   assert.equal(pkg.scripts['prepare:native-runtime'], 'node scripts/native-runtime.mjs');
 });
 
+test('quality tests do not depend on shell glob expansion', async () => {
+  const pkg = await readJson('package.json');
+  assert.doesNotMatch(pkg.scripts['test:quality'], /\*/);
+  for (const name of [
+    'native-runtime.test.mjs',
+    'release-config.test.mjs',
+    'square-image-annotation.test.mjs',
+  ]) {
+    assert.match(pkg.scripts['test:quality'], new RegExp(name.replaceAll('.', '\\.')));
+  }
+});
+
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {
   const config = await readJson('src-tauri/tauri.conf.json');
   assert.deepEqual(config.bundle.windows.webviewInstallMode, {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -35,6 +35,16 @@ test('quality tests do not depend on shell glob expansion', async () => {
   }
 });
 
+test('render regression caches the workspace target and allows cold CI builds', async () => {
+  const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'render-regression.yml'), 'utf8');
+  const runner = await readFile(path.join(repoDir, 'scripts', 'run-render-regression.mjs'), 'utf8');
+  assert.match(workflow, /^\s+target\s*$/m);
+  assert.doesNotMatch(workflow, /open-pdf-studio\/src-tauri\/target/);
+  assert.doesNotMatch(workflow, /open-pdf-render\/target/);
+  assert.match(workflow, /OPS_STARTUP_TIMEOUT_MS:\s*'600000'/);
+  assert.match(runner, /process\.env\.OPS_STARTUP_TIMEOUT_MS/);
+});
+
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {
   const config = await readJson('src-tauri/tauri.conf.json');
   assert.deepEqual(config.bundle.windows.webviewInstallMode, {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { PDFDocument } from 'pdf-lib';
+import { createRenderFixture } from './create-render-fixture.mjs';
 
 const projectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoDir = path.resolve(projectDir, '..');
@@ -52,10 +55,24 @@ test('render regression prepares a deterministic CI corpus', async () => {
   const workflow = await readFile(path.join(repoDir, '.github', 'workflows', 'render-regression.yml'), 'utf8');
   const app = await readFile(path.join(projectDir, 'src-tauri', 'src', 'lib.rs'), 'utf8');
   assert.match(workflow, /name: Prepare deterministic render corpus/);
-  assert.match(workflow, /scripts\/render_test\/tests\/fixtures\/tiny\.pdf/);
+  assert.match(workflow, /open-pdf-studio\/scripts\/create-render-fixture\.mjs/);
   assert.match(workflow, /\$corpus = 'test pdf-bestanden\/Originele bestanden'/);
   assert.match(app, /env!\("CARGO_MANIFEST_DIR"\)/);
   assert.doesNotMatch(app, /std::env::current_dir\(\)/);
+});
+
+test('generated render fixture is a complete one-page PDF', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'open-pdf-studio-render-'));
+  const output = path.join(dir, 'render-fixture.pdf');
+  try {
+    await createRenderFixture(output);
+    const bytes = await readFile(output);
+    const pdf = await PDFDocument.load(bytes);
+    assert.equal(pdf.getPageCount(), 1);
+    assert.match(Buffer.from(bytes).subarray(-32).toString('latin1'), /%%EOF/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -60,6 +60,7 @@ test('CI exercises macOS 26 startup and frontend readiness', async () => {
   assert.match(workflow, /macos-26/);
   assert.match(workflow, /npm run prepare:native-runtime/);
   assert.match(workflow, /macos-startup-smoke\.sh/);
+  assert.match(workflow, /createUpdaterArtifacts\\?"?:false/);
   assert.match(smoke, /survival_seconds=10/);
   assert.match(smoke, /kill -0 "\$pid"/);
   assert.match(smoke, /new_crash_report/);

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -83,11 +83,23 @@ test('generated render fixture is a complete one-page PDF', async () => {
 
 test('Windows installers retain the embedded WebView2 bootstrapper and loader', async () => {
   const config = await readJson('src-tauri/tauri.conf.json');
+  const windows = await readJson('src-tauri/tauri.windows.conf.json');
+  const resources = { ...config.bundle.resources, ...windows.bundle.resources };
   assert.deepEqual(config.bundle.windows.webviewInstallMode, {
     type: 'embedBootstrapper',
     silent: true,
   });
-  assert.equal(config.bundle.resources['WebView2Loader.dll'], 'WebView2Loader.dll');
+  assert.equal(resources['WebView2Loader.dll'], 'WebView2Loader.dll');
+  assert.equal(resources['binaries/win-x64/pdfium.dll'], 'pdfium.dll');
+});
+
+test('Linux resources exclude Windows-only runtime files', async () => {
+  const config = await readJson('src-tauri/tauri.conf.json');
+  const linux = await readJson('src-tauri/tauri.linux.conf.json');
+  const resources = { ...config.bundle.resources, ...linux.bundle.resources };
+
+  assert.equal(resources['WebView2Loader.dll'], undefined);
+  assert.equal(resources['binaries/win-x64/pdfium.dll'], undefined);
 });
 
 test('CI exercises macOS 26 startup and frontend readiness', async () => {

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -41,7 +41,7 @@ test('render regression caches the workspace target and allows cold CI builds', 
   assert.match(workflow, /^\s+target\s*$/m);
   assert.doesNotMatch(workflow, /open-pdf-studio\/src-tauri\/target/);
   assert.doesNotMatch(workflow, /open-pdf-render\/target/);
-  assert.match(workflow, /OPS_STARTUP_TIMEOUT_MS:\s*'600000'/);
+  assert.match(workflow, /OPS_STARTUP_TIMEOUT_MS:\s*'1200000'/);
   assert.match(runner, /process\.env\.OPS_STARTUP_TIMEOUT_MS/);
 });
 

--- a/open-pdf-studio/scripts/square-image-annotation.test.mjs
+++ b/open-pdf-studio/scripts/square-image-annotation.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  annotationIdOf,
+  findImageAnnotationSources,
+  findImageForAnnotation,
+} from '../js/pdf/loader/annotation-image-sources.mjs';
+
+const ONE_PIXEL_PNG = Uint8Array.from(Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2n0sAAAAASUVORK5CYII=',
+  'base64',
+));
+
+test('a synthetic SquareImage annotation exposes its direct image stream', async () => {
+  const { PDFDocument, PDFName } = await import('pdf-lib');
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([200, 200]);
+  const image = await pdfDoc.embedPng(ONE_PIXEL_PNG);
+  await image.embed();
+  const annotation = pdfDoc.context.obj({
+    Type: PDFName.of('Annot'),
+    Subtype: PDFName.of('Square'),
+    IT: PDFName.of('SquareImage'),
+    Rect: [10, 20, 110, 70],
+    Image: image.ref,
+  });
+  const annotationRef = pdfDoc.context.register(annotation);
+  page.node.set(PDFName.of('Annots'), pdfDoc.context.obj([annotationRef]));
+
+  const sources = findImageAnnotationSources(1, pdfDoc);
+
+  assert.equal(sources.length, 1);
+  assert.equal(sources[0].rectKey, '10,20,110,70');
+  assert.match(sources[0].annotationId, /^\d+R$/);
+  assert.equal(sources[0].kind, 'square-image');
+  assert.equal(sources[0].stream.dict.get(PDFName.of('Subtype')).toString(), '/Image');
+});
+
+test('ordinary Square annotations are not treated as images', async () => {
+  const { PDFDocument, PDFName } = await import('pdf-lib');
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage([200, 200]);
+  const annotation = pdfDoc.context.obj({
+    Type: PDFName.of('Annot'),
+    Subtype: PDFName.of('Square'),
+    Rect: [10, 20, 110, 70],
+  });
+  const annotationRef = pdfDoc.context.register(annotation);
+  page.node.set(PDFName.of('Annots'), pdfDoc.context.obj([annotationRef]));
+
+  assert.deepEqual(findImageAnnotationSources(1, pdfDoc), []);
+});
+
+test('annotation identity prevents a colliding ordinary Square from becoming an image', () => {
+  const images = new Map([
+    ['id:131R', { kind: 'square-image', dataUrl: 'data:image/png;base64,abc' }],
+  ]);
+  assert.equal(
+    findImageForAnnotation(images, { id: '131R', rect: [10, 20, 110, 70] }, 'square-image'),
+    'data:image/png;base64,abc',
+  );
+  assert.equal(
+    findImageForAnnotation(images, { id: '132R', rect: [10, 20, 110, 70] }, 'square-image'),
+    null,
+  );
+});
+
+test('annotation identity retains non-zero PDF reference generations', async () => {
+  const { PDFRef } = await import('pdf-lib');
+  assert.equal(annotationIdOf(PDFRef.of(7, 0)), '7R');
+  assert.equal(annotationIdOf(PDFRef.of(7, 3)), '7R3');
+});

--- a/open-pdf-studio/src-tauri/Cargo.toml
+++ b/open-pdf-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-pdf-studio"
-version = "1.77.0"
+version = "1.78.0"
 description = "A free, open-source PDF annotation editor"
 authors = ["OpenAEC Foundation"]
 license = "MIT"
@@ -77,22 +77,3 @@ tauri-plugin-global-shortcut = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Graphics_Printing", "Win32_Graphics_Gdi", "Win32_Storage_Xps", "Win32_Foundation", "Win32_System_Com", "Win32_UI_Shell"] }
-
-# Compile open-pdf-render with optimizations even in dev mode (rendering is 100x slower without)
-[profile.dev.package.open-pdf-render]
-opt-level = 3
-
-[profile.dev.package.tiny-skia]
-opt-level = 3
-
-[profile.dev.package.tiny-skia-path]
-opt-level = 3
-
-[profile.dev.package.lopdf]
-opt-level = 3
-
-[profile.dev.package.image]
-opt-level = 3
-
-[profile.dev.package.pdfium-render]
-opt-level = 3

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -2422,10 +2422,15 @@ pub fn run(opts: StartupOpts) {
             // inside `mcp_server::start`).
             if mcp_enabled {
                 let app_handle = app.handle().clone();
-                let test_pdfs_dir = std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("test pdf-bestanden")
-                    .join("Originele bestanden");
+                let test_pdfs_dir = std::env::var_os("OPS_TEST_PDFS_DIR")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| {
+                        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                            .join("..")
+                            .join("..")
+                            .join("test pdf-bestanden")
+                            .join("Originele bestanden")
+                    });
                 tauri::async_runtime::spawn(async move {
                     if let Err(e) = mcp_server::start(mcp_port, test_pdfs_dir, Some(app_handle)).await {
                         eprintln!("[mcp] server failed: {e}");

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod mcp_server;
 pub mod pdfium_renderer;
 pub mod render_to_png;
 pub mod window_mgmt;
+pub mod startup_diagnostics;
 pub mod worker_pool;
 
 pub struct StartupOpts {
@@ -2391,6 +2392,15 @@ pub fn run(opts: StartupOpts) {
 
     builder
         .setup(move |app| {
+            let diagnostics_path = app
+                .path()
+                .app_log_dir()
+                .map_err(|e| format!("Cannot resolve app log directory: {e}"))?
+                .join("startup-diagnostics.jsonl");
+            let diagnostics = startup_diagnostics::StartupDiagnostics::new(diagnostics_path);
+            diagnostics.record("native-created", None);
+            app.manage(diagnostics);
+
             // Grant FS plugin scope for command-line files (file association)
             for path in app.state::<OpenedFiles>().0.lock().unwrap().iter() {
                 let _ = app.fs_scope().allow_file(path);
@@ -2584,6 +2594,8 @@ pub fn run(opts: StartupOpts) {
             window_mgmt::exit_detached_process,
             window_mgmt::drag_icon_path,
             window_mgmt::detach_diag,
+            startup_diagnostics::startup_diagnostic,
+            startup_diagnostics::startup_diagnostics_path,
             read_clipboard_image_png,
             set_prtscn_hotkey,
         ])

--- a/open-pdf-studio/src-tauri/src/main.rs
+++ b/open-pdf-studio/src-tauri/src/main.rs
@@ -2,7 +2,7 @@
 // Unconditional (also debug builds): the app must run fully in the
 // background with only its own window. Dev logs stay visible when launched
 // from a terminal (`tauri dev` pipes stdio); double-click runs log nothing,
-// boot errors still land in %TEMP%\opds-detach-diag.log via detach_diag.
+// startup failures still land in the app-local startup diagnostics file.
 #![windows_subsystem = "windows"]
 
 use clap::Parser;

--- a/open-pdf-studio/src-tauri/src/startup_diagnostics.rs
+++ b/open-pdf-studio/src-tauri/src/startup_diagnostics.rs
@@ -1,0 +1,117 @@
+use serde_json::json;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::State;
+
+const MAX_LOG_BYTES: u64 = 512 * 1024;
+const ALLOWED_PHASES: &[&str] = &[
+    "native-created",
+    "frontend-boot-start",
+    "frontend-rendered",
+    "frontend-ready",
+    "frontend-error",
+    "frontend-rejection",
+];
+
+pub fn sanitize_phase(phase: &str) -> &str {
+    ALLOWED_PHASES
+        .iter()
+        .copied()
+        .find(|allowed| *allowed == phase)
+        .unwrap_or("unknown")
+}
+
+pub fn redact_detail(detail: &str) -> String {
+    detail
+        .split_whitespace()
+        .take(40)
+        .map(|part| {
+            let lower = part.to_ascii_lowercase();
+            if lower.contains("http://") || lower.contains("https://") {
+                "[url]"
+            } else if part.contains(":\\")
+                || part.contains(":/")
+                || part.starts_with("/Users/")
+                || part.starts_with("/home/")
+            {
+                "[path]"
+            } else if lower.contains(".pdf") {
+                "[document]"
+            } else {
+                part
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub struct StartupDiagnostics {
+    path: PathBuf,
+    session: String,
+}
+
+impl StartupDiagnostics {
+    pub fn new(path: PathBuf) -> Self {
+        if fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0) > MAX_LOG_BYTES {
+            let previous = path.with_extension("previous.jsonl");
+            let _ = fs::remove_file(&previous);
+            let _ = fs::rename(&path, previous);
+        }
+        let started = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        Self {
+            path,
+            session: format!("{}-{started}", std::process::id()),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn record(&self, phase: &str, detail: Option<&str>) {
+        if let Some(parent) = self.path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let phase = sanitize_phase(phase);
+        let detail = match phase {
+            "frontend-error" | "frontend-rejection" => detail.map(redact_detail),
+            _ => None,
+        };
+        let entry = json!({
+            "timestampMs": timestamp_ms,
+            "session": self.session,
+            "phase": phase,
+            "detail": detail,
+        });
+        if let Ok(mut file) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+        {
+            let _ = writeln!(file, "{entry}");
+        }
+    }
+}
+
+#[tauri::command]
+pub fn startup_diagnostic(
+    diagnostics: State<'_, StartupDiagnostics>,
+    phase: String,
+    detail: Option<String>,
+) {
+    diagnostics.record(&phase, detail.as_deref());
+}
+
+#[tauri::command]
+pub fn startup_diagnostics_path(diagnostics: State<'_, StartupDiagnostics>) -> String {
+    diagnostics.path().to_string_lossy().into_owned()
+}

--- a/open-pdf-studio/src-tauri/src/worker_pool/state.rs
+++ b/open-pdf-studio/src-tauri/src/worker_pool/state.rs
@@ -1,9 +1,9 @@
+use memmap2::Mmap;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::io::{BufReader, AsyncBufReadExt};
+use tokio::io::BufReader;
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
-use memmap2::Mmap;
 
 /// Status of a single worker slot.
 #[repr(u8)]

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -75,8 +75,6 @@
     },
     "resources": {
       "icons/file-icon.ico": "file-icon.ico",
-      "binaries/win-x64/pdfium.dll": "pdfium.dll",
-      "WebView2Loader.dll": "WebView2Loader.dll",
       "resources/kaders": "kaders"
     },
     "externalBin": [

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Open PDF Studio",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "identifier": "org.openaec.openpdfstudio",
   "build": {
     "frontendDist": "../dist",
@@ -22,7 +22,7 @@
         "fullscreen": false,
         "decorations": false,
         "transparent": false,
-        "visible": false,
+        "visible": true,
         "backgroundColor": "#f5f5f5",
         "devtools": true
       }

--- a/open-pdf-studio/src-tauri/tauri.windows.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": {
+      "binaries/win-x64/pdfium.dll": "pdfium.dll",
+      "WebView2Loader.dll": "WebView2Loader.dll"
+    }
+  }
+}

--- a/open-pdf-studio/src-tauri/tests/startup_diagnostics.rs
+++ b/open-pdf-studio/src-tauri/tests/startup_diagnostics.rs
@@ -1,0 +1,20 @@
+use app_lib::startup_diagnostics::{redact_detail, sanitize_phase};
+
+#[test]
+fn startup_phases_are_allowlisted() {
+    assert_eq!(sanitize_phase("frontend-ready"), "frontend-ready");
+    assert_eq!(sanitize_phase("unexpected private value"), "unknown");
+}
+
+#[test]
+fn diagnostic_details_do_not_store_local_paths_or_urls() {
+    let input = r#"Failed to open C:\Users\person\Documents\contract.pdf and budget.pdf from https://example.invalid/private?id=4"#;
+    let redacted = redact_detail(input);
+
+    assert!(!redacted.contains("person"));
+    assert!(!redacted.contains("contract.pdf"));
+    assert!(!redacted.contains("budget.pdf"));
+    assert!(!redacted.contains("example.invalid"));
+    assert!(redacted.contains("[path]"));
+    assert!(redacted.contains("[url]"));
+}

--- a/pdfium-worker/src/shm.rs
+++ b/pdfium-worker/src/shm.rs
@@ -1,14 +1,12 @@
 use anyhow::{Context, Result};
 use memmap2::{MmapMut, MmapOptions};
 use std::fs::OpenOptions;
-use std::path::Path;
 
 pub const SHM_SIZE: usize = 64 * 1024 * 1024; // 64 MB per worker
 pub const HEADER_SIZE: usize = 32;
 
 pub struct Shm {
     mmap: MmapMut,
-    pub path: String,
 }
 
 impl Shm {
@@ -32,16 +30,21 @@ impl Shm {
     pub fn create(ns: &str, slot: u32) -> Result<Self> {
         let path = Self::path_for(ns, slot);
         let file = OpenOptions::new()
-            .read(true).write(true).create(true).truncate(true)
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
             .open(&path)
             .with_context(|| format!("open SHM file {}", path))?;
         file.set_len(SHM_SIZE as u64)
             .context("set SHM file length")?;
         let mmap = unsafe {
-            MmapOptions::new().len(SHM_SIZE).map_mut(&file)
+            MmapOptions::new()
+                .len(SHM_SIZE)
+                .map_mut(&file)
                 .context("mmap SHM file")?
         };
-        Ok(Self { mmap, path })
+        Ok(Self { mmap })
     }
 
     /// Write width + height to header, copy rgba into payload starting at
@@ -50,17 +53,19 @@ impl Shm {
         if rgba.len() + HEADER_SIZE > SHM_SIZE {
             anyhow::bail!(
                 "bitmap too large for SHM: {} bytes > {} (cap)",
-                rgba.len(), SHM_SIZE - HEADER_SIZE
+                rgba.len(),
+                SHM_SIZE - HEADER_SIZE
             );
         }
         self.mmap[0..4].copy_from_slice(&width.to_le_bytes());
         self.mmap[4..8].copy_from_slice(&height.to_le_bytes());
         // zero-fill the rest of the header (slots 8..32 reserved)
-        for i in 8..HEADER_SIZE { self.mmap[i] = 0; }
+        for i in 8..HEADER_SIZE {
+            self.mmap[i] = 0;
+        }
         let end = HEADER_SIZE + rgba.len();
         self.mmap[HEADER_SIZE..end].copy_from_slice(rgba);
-        self.mmap.flush_async()
-            .context("flush SHM after write")?;
+        self.mmap.flush_async().context("flush SHM after write")?;
         Ok(rgba.len() as u64)
     }
 }
@@ -71,14 +76,21 @@ mod tests {
 
     #[test]
     fn write_then_read_header() {
+        let path = Shm::path_for("test", 999);
         let mut shm = Shm::create("test", 999).unwrap();
         let rgba = vec![0xAB; 1000];
         let bytes = shm.write_bitmap(123, 456, &rgba).unwrap();
         assert_eq!(bytes, 1000);
         // Re-read the file from disk and verify header
-        let file_bytes = std::fs::read(&shm.path).unwrap();
-        assert_eq!(u32::from_le_bytes([file_bytes[0], file_bytes[1], file_bytes[2], file_bytes[3]]), 123);
-        assert_eq!(u32::from_le_bytes([file_bytes[4], file_bytes[5], file_bytes[6], file_bytes[7]]), 456);
+        let file_bytes = std::fs::read(path).unwrap();
+        assert_eq!(
+            u32::from_le_bytes([file_bytes[0], file_bytes[1], file_bytes[2], file_bytes[3]]),
+            123
+        );
+        assert_eq!(
+            u32::from_le_bytes([file_bytes[4], file_bytes[5], file_bytes[6], file_bytes[7]]),
+            456
+        );
         assert_eq!(file_bytes[HEADER_SIZE + 500], 0xAB);
     }
 

--- a/scripts/run-render-regression.mjs
+++ b/scripts/run-render-regression.mjs
@@ -17,7 +17,11 @@ const HARNESS_PY = path.join(__dirname, 'render-regression-test.py');
 const VENV_PY    = path.join(__dirname, '.venv-test', 'Scripts', 'python.exe');
 
 const PORT = 9223;
-const MAX_WAIT_MS = 180_000;
+const DEFAULT_WAIT_MS = 180_000;
+const requestedWaitMs = Number.parseInt(process.env.OPS_STARTUP_TIMEOUT_MS || '', 10);
+const MAX_WAIT_MS = Number.isFinite(requestedWaitMs) && requestedWaitMs > 0
+  ? requestedWaitMs
+  : DEFAULT_WAIT_MS;
 
 function waitForPort(port, timeoutMs) {
   const start = Date.now();


### PR DESCRIPTION
## Resultaat  - maakt het hoofdvenster bij native creatie zichtbaar en verwijdert de kwetsbare JavaScript-startpoort; - voegt privacyveilige, roteerbare startup-diagnostiek toe met een knop om het logbestand te tonen; - bereidt de universele macOS-runtime automatisch voor met een vastgezette versie en SHA-256-controle; - bouwt op macOS 26 en controleert een zichtbaar venster, nieuwe frontend-readiness, crashrapporten en tien seconden procesoverleving; - valideert release- en nightly-apps met `codesign`, Gatekeeper en stapling van zowel app als DMG; - herstelt afbeeldingsannotaties die als `SquareImage` zijn opgeslagen, inclusief object-id-koppeling om botsingen met gewone vierkanten te voorkomen; - zet alle release-metadata op 1.78.0 en houdt beide lockfiles voortaan bij via het versie-script; - verwijdert genegeerde Cargo-profielen uit de member-crate, herstelt ontbrekende types en documenteert de native buildvereisten.  ## Verificatie  - `npm run test:quality` — 18/18 groen - `npm run typecheck` — groen - `npx vite build` — groen, 1044 modules - `cargo +stable-x86_64-pc-windows-msvc metadata --locked --no-deps` — groen - `rustfmt --check` — groen - shellsyntax startup-smoke — groen - `npm audit --omit=dev` — 0 kwetsbaarheden - onafhankelijke herreview — geen Critical/Important blokkades  De volledige Rust- en macOS-matrix blijft een vereiste GitHub-check vóór merge.  Closes #291 Closes #276 Closes #208 Addresses #252  Supersedes #251 with a checksum-verified cached runtime and end-to-end startup gates. 