### PR TITLE
Fix edited text rotation and colour preservation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report reproducible behaviour that is not working as expected.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: "Please keep one topic per issue and split unrelated problems into separate reports."
+
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: What's wrong
+      description: Describe the expected behaviour and what actually happens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: List the exact actions, in order.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: sample-screenshots
+    attributes:
+      label: Sample / screenshots
+      description: Attach a minimal PDF, screenshots, or a short screen recording when possible.
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system, app version, and the full crash log for crashes.
+      placeholder: |
+        Operating system:
+        App version:
+        Crash log (if applicable):
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature / change request
+description: Describe an implementation-ready improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: "Please keep one topic per issue and split unrelated requests into separate reports."
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: State in one sentence what should be possible after this change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: Describe step by step what the user does, what happens, and the relevant edge cases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: List the observable conditions that show the request is complete.
+      placeholder: |
+        - [ ] When I do X, Y happens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Add screenshots, example files, and where in the UI you expect the outcome.
+    validations:
+      required: false
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: State anything that should explicitly not change.
+    validations:
+      required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,13 @@ jobs:
             target/aarch64-apple-darwin/release/pdfium-worker \
             target/x86_64-apple-darwin/release/pdfium-worker
 
+      - name: Fetch libpdfium.dylib (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          mkdir -p src-tauri/binaries/macos-universal
+          curl -L "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7834/pdfium-mac-univ.tgz" -o /tmp/pdfium-mac.tgz
+          tar xzf /tmp/pdfium-mac.tgz -C /tmp lib/libpdfium.dylib
+          cp /tmp/lib/libpdfium.dylib src-tauri/binaries/macos-universal/libpdfium.dylib
+
       - name: Build Tauri app
         run: npm run tauri build -- --no-bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm install
 
+      - name: Run unit tests
+        run: npm run test:unit
+
       # The PDFium worker pool runs as a Tauri sidecar (bundle.externalBin).
       # Tauri requires binaries/pdfium-worker-<target-triple> to exist at
       # build time on EVERY desktop platform, so build the workspace crate

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -32,15 +32,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry + target
-        uses: actions/cache@v4
+      - name: Restore cargo registry + target
+        id: cargo-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
           key: render-regression-v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          save-always: true
 
       - name: Install npm deps (open-pdf-studio)
         working-directory: open-pdf-studio
@@ -54,6 +54,16 @@ jobs:
           Copy-Item target/debug/pdfium-worker.exe open-pdf-studio/src-tauri/binaries/pdfium-worker-x86_64-pc-windows-msvc.exe -Force
           cargo build -p open-pdf-studio
 
+      - name: Save cargo registry + target
+        if: steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: render-regression-v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Set up python venv
         shell: bash
         run: |
@@ -65,8 +75,8 @@ jobs:
         working-directory: open-pdf-studio
         env:
           OPS_ENABLE_MCP: '1'
-          OPS_TEST_PDFS_DIR: ${{ github.workspace }}/scripts/render_test/tests/fixtures
-        run: npm run test:render:auto
+          OPS_TEST_PDFS_DIR: ${{ github.workspace }}/open-pdf-studio/src-tauri/resources/kaders
+        run: npm run test:render:auto -- --pdf grootformaat_a1_liggend.pdf --out-root "../test pdf-bestanden/render-regression-runs"
 
       - name: Upload regression report
         if: always()

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -38,9 +38,8 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            open-pdf-studio/src-tauri/target
-            open-pdf-render/target
-          key: render-regression-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            target
+          key: render-regression-v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install npm deps (open-pdf-studio)
         working-directory: open-pdf-studio

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -40,6 +40,7 @@ jobs:
             ~/.cargo/git
             target
           key: render-regression-v2-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          save-always: true
 
       - name: Install npm deps (open-pdf-studio)
         working-directory: open-pdf-studio
@@ -64,6 +65,7 @@ jobs:
         working-directory: open-pdf-studio
         env:
           OPS_ENABLE_MCP: '1'
+          OPS_TEST_PDFS_DIR: ${{ github.workspace }}/scripts/render_test/tests/fixtures
         run: npm run test:render:auto
 
       - name: Upload regression report

--- a/.github/workflows/render-regression.yml
+++ b/.github/workflows/render-regression.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   render-regression:
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +44,14 @@ jobs:
       - name: Install npm deps (open-pdf-studio)
         working-directory: open-pdf-studio
         run: npm ci
+
+      - name: Prebuild desktop app
+        shell: pwsh
+        run: |
+          cargo build -p pdfium-worker
+          New-Item -ItemType Directory -Force open-pdf-studio/src-tauri/binaries | Out-Null
+          Copy-Item target/debug/pdfium-worker.exe open-pdf-studio/src-tauri/binaries/pdfium-worker-x86_64-pc-windows-msvc.exe -Force
+          cargo build -p open-pdf-studio
 
       - name: Set up python venv
         shell: bash

--- a/open-pdf-studio/js/annotations/rendering.js
+++ b/open-pdf-studio/js/annotations/rendering.js
@@ -1,4 +1,4 @@
-import { state, getActiveDocument, imageCache } from '../core/state.js';
+import { state, getActiveDocument, getPageRotation, imageCache } from '../core/state.js';
 import { annotationCanvas, annotationCtx, textHighlightCanvas, textHighlightCtx } from '../ui/dom-elements.js';
 import { updateStatusAnnotations } from '../ui/chrome/status-bar.js';
 import { updateAnnotationsList } from '../ui/panels/annotations-list.js';
@@ -25,6 +25,7 @@ import { drawImageAlignGuides } from '../tools/image-align-snap.js';
 import { getTemplate } from '../symbols/registry.js';
 import { hasFill } from './fill-utils.js';
 import { hiddenTypes as evHiddenTypes, halftoneTypes as evHalftoneTypes } from '../solid/stores/elementVisibilityStore.js';
+import { getPageRotationMatrix } from '../text/text-edit-appearance.js';
 
 // Re-export everything that external code needs
 export { drawPolygonShape, drawCloudShape, buildPolygonPath, buildCloudPath } from './rendering/shapes.js';
@@ -2130,15 +2131,16 @@ function drawTextEdits(ctx, pageNum) {
   if (pageEdits.length === 0) return;
 
   const canvasEl = ctx.canvas;
-  const docForScale = state.documents[state.activeDocumentIndex];
-  // In viewport mode the annotation canvas is the CONTAINER (not the page), so
-  // canvas.height/scale is NOT the page height — that broke the Y-flip below and
-  // drew the cover/new text ~hundreds of pt off (text edits "did nothing"). Use
-  // the viewport's real page height; fall back to the canvas math for blank/legacy docs.
-  const _vpTE = window.__pdfViewport;
-  const pageHeight = (_vpTE && _vpTE.active && docForScale?.filePath && _vpTE.pageH)
-    ? _vpTE.pageH
-    : canvasEl.height / (docForScale ? docForScale.scale : 1);
+  const dims = doc.pageDims?.[pageNum];
+  // Text-edit records stay in the page's unrotated PDF frame. Apply the page
+  // matrix only while painting so save coordinates remain stable across turns.
+  const fallbackScale = doc.scale || 1;
+  const pageWidth = dims?.widthPt || canvasEl.width / fallbackScale;
+  const pageHeight = dims?.heightPt || canvasEl.height / fallbackScale;
+  const totalRotation = (Number(dims?.rotation) || 0) + getPageRotation(pageNum);
+
+  ctx.save();
+  ctx.transform(...getPageRotationMatrix(pageWidth, pageHeight, totalRotation));
 
   for (const edit of pageEdits) {
     const fontSize = edit.fontSize;
@@ -2184,6 +2186,7 @@ function drawTextEdits(ctx, pageNum) {
     }
     ctx.restore();
   }
+  ctx.restore();
 }
 
 // Redraw all annotations (single page mode)

--- a/open-pdf-studio/js/pdf/pdf-viewport.js
+++ b/open-pdf-studio/js/pdf/pdf-viewport.js
@@ -5,6 +5,7 @@
 import { renderVectorPage } from './vector-renderer.js';
 import { state, getActiveDocument } from '../core/state.js';
 import { findAnnotationAt as _findAnnotationAt } from '../annotations/geometry.js';
+import { getTextLayerCssMatrix, resolveTextEditPageGeometry } from '../text/text-edit-appearance.js';
 import {
   computeZoomBucket,
   getBestAvailableBitmap,
@@ -786,6 +787,21 @@ function _render() {
   if (textLayer) {
     const tx = viewport.offsetX;
     const ty = viewport.offsetY;
+    const doc = getActiveDocument();
+    const geometry = resolveTextEditPageGeometry(
+      doc?.pageDims?.[viewport.pageNum],
+      viewport.pageW,
+      viewport.pageH,
+      viewport.rotation,
+    );
+    const matrix = getTextLayerCssMatrix(
+      geometry.pageWidth,
+      geometry.pageHeight,
+      geometry.rotation,
+      viewport.zoom,
+      tx,
+      ty,
+    );
     // The text layer lives in PDF user space (origin top-left after Y flip).
     // We size spans with --font-height in PDF points and let CSS compute
     // font-size = --total-scale-factor * --font-height. Setting the factor
@@ -797,9 +813,9 @@ function _render() {
     textLayer.style.position = 'absolute';
     textLayer.style.left = '0';
     textLayer.style.top = '0';
-    textLayer.style.width = `${viewport.pageW}px`;
-    textLayer.style.height = `${viewport.pageH}px`;
-    textLayer.style.transform = `matrix(${viewport.zoom}, 0, 0, ${viewport.zoom}, ${tx}, ${ty})`;
+    textLayer.style.width = `${geometry.pageWidth}px`;
+    textLayer.style.height = `${geometry.pageHeight}px`;
+    textLayer.style.transform = `matrix(${matrix.join(', ')})`;
     textLayer.style.transformOrigin = '0 0';
     // Text layer: keep pointer-events as set by tool manager (don't override)
     // The tool manager sets pointer-events based on active tool (text select = auto, other = none)

--- a/open-pdf-studio/js/pdf/renderer.js
+++ b/open-pdf-studio/js/pdf/renderer.js
@@ -205,7 +205,11 @@ async function _renderPageImpl(pageNum) {
   // vector path is gated off by the filePath check).
   if (!doc.pageDims) doc.pageDims = {};
   const [vx0, vy0, vx1, vy1] = page.view;
-  doc.pageDims[pageNum] = { widthPt: vx1 - vx0, heightPt: vy1 - vy0 };
+  doc.pageDims[pageNum] = {
+    widthPt: vx1 - vx0,
+    heightPt: vy1 - vy0,
+    rotation: page.rotate || 0,
+  };
 
   const pdfCanvas = getPdfCanvas();
   const annotationCanvas = getAnnotationCanvas();
@@ -1182,6 +1186,13 @@ export async function renderContinuous(forceRebuild) {
   // First pass: create all page wrappers with correct dimensions (no rendering)
   for (const pageNum of _pageList) {
     const page = await pdfDoc.getPage(pageNum);
+    if (!doc.pageDims) doc.pageDims = {};
+    const [pageX0, pageY0, pageX1, pageY1] = page.view;
+    doc.pageDims[pageNum] = {
+      widthPt: pageX1 - pageX0,
+      heightPt: pageY1 - pageY0,
+      rotation: page.rotate || 0,
+    };
     const extraRotation = getPageRotation(pageNum);
     const vpOpts = { scale };
     if (extraRotation) {

--- a/open-pdf-studio/js/text/text-edit-appearance.js
+++ b/open-pdf-studio/js/text/text-edit-appearance.js
@@ -1,0 +1,184 @@
+export function normalizePageRotation(rotation) {
+  const normalized = ((Number(rotation) || 0) % 360 + 360) % 360;
+  return normalized === 90 || normalized === 180 || normalized === 270 ? normalized : 0;
+}
+
+export function getPageRotationMatrix(pageWidth, pageHeight, rotation) {
+  switch (normalizePageRotation(rotation)) {
+    case 90:
+      return [0, 1, -1, 0, pageHeight, 0];
+    case 180:
+      return [-1, 0, 0, -1, pageWidth, pageHeight];
+    case 270:
+      return [0, -1, 1, 0, 0, pageWidth];
+    default:
+      return [1, 0, 0, 1, 0, 0];
+  }
+}
+
+export function getTextLayerCssMatrix(
+  pageWidth,
+  pageHeight,
+  rotation,
+  zoom = 1,
+  offsetX = 0,
+  offsetY = 0,
+) {
+  const [a, b, c, d, e, f] = getPageRotationMatrix(pageWidth, pageHeight, rotation);
+  return [
+    a * zoom,
+    b * zoom,
+    c * zoom,
+    d * zoom,
+    offsetX + e * zoom,
+    offsetY + f * zoom,
+  ];
+}
+
+export function applyPageRotation(x, y, pageWidth, pageHeight, rotation) {
+  const [a, b, c, d, e, f] = getPageRotationMatrix(pageWidth, pageHeight, rotation);
+  return { x: a * x + c * y + e, y: b * x + d * y + f };
+}
+
+export function invertPageRotation(x, y, pageWidth, pageHeight, rotation) {
+  switch (normalizePageRotation(rotation)) {
+    case 90:
+      return { x: y, y: pageHeight - x };
+    case 180:
+      return { x: pageWidth - x, y: pageHeight - y };
+    case 270:
+      return { x: pageWidth - y, y: x };
+    default:
+      return { x, y };
+  }
+}
+
+export function getRotatedPageSize(pageWidth, pageHeight, rotation) {
+  const quarterTurn = normalizePageRotation(rotation) % 180 !== 0;
+  return quarterTurn
+    ? { width: pageHeight, height: pageWidth }
+    : { width: pageWidth, height: pageHeight };
+}
+
+export function resolveTextEditPageGeometry(dims, displayWidth, displayHeight, extraRotation = 0) {
+  const intrinsicRotation = Number(dims?.rotation) || 0;
+  const rotation = normalizePageRotation(intrinsicRotation + extraRotation);
+  const hasStoredDimensions = Number(dims?.widthPt) > 0 && Number(dims?.heightPt) > 0;
+  const pageWidth = hasStoredDimensions
+    ? Number(dims.widthPt)
+    : (rotation % 180 ? displayHeight : displayWidth);
+  const pageHeight = hasStoredDimensions
+    ? Number(dims.heightPt)
+    : (rotation % 180 ? displayWidth : displayHeight);
+  const displaySize = getRotatedPageSize(pageWidth, pageHeight, rotation);
+  return {
+    pageWidth,
+    pageHeight,
+    rotation,
+    displayWidth: displaySize.width,
+    displayHeight: displaySize.height,
+  };
+}
+
+export function elementRectToCanvasPixels(elementRect, canvasRect, canvasWidth, canvasHeight) {
+  if (!canvasRect?.width || !canvasRect?.height || !canvasWidth || !canvasHeight) return null;
+  const scaleX = canvasWidth / canvasRect.width;
+  const scaleY = canvasHeight / canvasRect.height;
+  const left = Math.max(0, Math.floor((elementRect.left - canvasRect.left) * scaleX));
+  const top = Math.max(0, Math.floor((elementRect.top - canvasRect.top) * scaleY));
+  const right = Math.min(canvasWidth, Math.ceil((elementRect.right - canvasRect.left) * scaleX));
+  const bottom = Math.min(canvasHeight, Math.ceil((elementRect.bottom - canvasRect.top) * scaleY));
+  if (right <= left || bottom <= top) return null;
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+function componentHex(value) {
+  return Math.max(0, Math.min(255, value)).toString(16).padStart(2, '0');
+}
+
+export function selectTextColor(pixels, fallback = '#000000', width = 0, height = 0) {
+  if (!pixels || pixels.length < 4) return fallback;
+  const clusters = new Map();
+  const hasBounds = width > 1 && height > 1 && width * height * 4 <= pixels.length;
+
+  for (let i = 0; i + 3 < pixels.length; i += 4) {
+    const alpha = pixels[i + 3];
+    if (alpha < 32) continue;
+    if (hasBounds) {
+      const pixelIndex = i / 4;
+      const x = pixelIndex % width;
+      const y = Math.floor(pixelIndex / width);
+      if (x !== 0 && y !== 0 && x !== width - 1 && y !== height - 1) continue;
+    }
+    const r = pixels[i];
+    const g = pixels[i + 1];
+    const b = pixels[i + 2];
+    const key = `${r >> 3},${g >> 3},${b >> 3}`;
+    const cluster = clusters.get(key) || { count: 0, r: 0, g: 0, b: 0 };
+    cluster.count++;
+    cluster.r += r;
+    cluster.g += g;
+    cluster.b += b;
+    clusters.set(key, cluster);
+  }
+
+  if (clusters.size === 0) return fallback;
+  const background = [...clusters.values()].reduce((largest, cluster) =>
+    !largest || cluster.count > largest.count ? cluster : largest
+  , null);
+  const backgroundColor = [
+    background.r / background.count,
+    background.g / background.count,
+    background.b / background.count,
+  ];
+
+  let best = null;
+  let bestDistance = 0;
+  for (let i = 0; i + 3 < pixels.length; i += 4) {
+    if (pixels[i + 3] < 32) continue;
+    const r = pixels[i];
+    const g = pixels[i + 1];
+    const b = pixels[i + 2];
+    const distance = (backgroundColor[0] - r) ** 2
+      + (backgroundColor[1] - g) ** 2
+      + (backgroundColor[2] - b) ** 2;
+    if (distance > bestDistance) {
+      bestDistance = distance;
+      best = [r, g, b];
+    }
+  }
+
+  if (!best || bestDistance <= 3 * 4 ** 2) return fallback;
+  const [r, g, b] = best;
+  if (Math.max(r, g, b) <= 24 && Math.max(r, g, b) - Math.min(r, g, b) <= 4) {
+    return '#000000';
+  }
+  return `#${componentHex(r)}${componentHex(g)}${componentHex(b)}`;
+}
+
+export function restoreTextEditSnapshot(record, snapshot) {
+  if (!record || !snapshot) return;
+  for (const key of Object.keys(record)) {
+    if (!Object.hasOwn(snapshot, key)) delete record[key];
+  }
+  Object.assign(record, snapshot);
+}
+
+export function sampleTextColor(canvas, elementRect, fallback = '#000000') {
+  if (!canvas || !elementRect) return fallback;
+  try {
+    const bounds = elementRectToCanvasPixels(
+      elementRect,
+      canvas.getBoundingClientRect(),
+      canvas.width,
+      canvas.height,
+    );
+    if (!bounds) return fallback;
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) return fallback;
+    const image = context.getImageData(bounds.x, bounds.y, bounds.width, bounds.height);
+    return selectTextColor(image.data, fallback, bounds.width, bounds.height);
+  } catch (_) {
+    return fallback;
+  }
+}

--- a/open-pdf-studio/js/text/text-edit-appearance.test.mjs
+++ b/open-pdf-studio/js/text/text-edit-appearance.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  applyPageRotation,
+  elementRectToCanvasPixels,
+  getPageRotationMatrix,
+  getTextLayerCssMatrix,
+  invertPageRotation,
+  restoreTextEditSnapshot,
+  resolveTextEditPageGeometry,
+  selectTextColor,
+} from './text-edit-appearance.js';
+
+test('page rotation matrix keeps PDF text attached for every quarter turn', () => {
+  const width = 600;
+  const height = 800;
+  const point = { x: 100, y: 200 };
+
+  assert.deepEqual(getPageRotationMatrix(width, height, 0), [1, 0, 0, 1, 0, 0]);
+  assert.deepEqual(getPageRotationMatrix(width, height, 90), [0, 1, -1, 0, 800, 0]);
+  assert.deepEqual(getPageRotationMatrix(width, height, 180), [-1, 0, 0, -1, 600, 800]);
+  assert.deepEqual(getPageRotationMatrix(width, height, 270), [0, -1, 1, 0, 0, 600]);
+
+  assert.deepEqual(applyPageRotation(point.x, point.y, width, height, 90), { x: 600, y: 100 });
+  assert.deepEqual(applyPageRotation(point.x, point.y, width, height, 180), { x: 500, y: 600 });
+  assert.deepEqual(applyPageRotation(point.x, point.y, width, height, 270), { x: 200, y: 500 });
+});
+
+test('rotated display coordinates invert to the original text position', () => {
+  const width = 600;
+  const height = 800;
+  const original = { x: 123, y: 456 };
+
+  for (const rotation of [0, 90, 180, 270]) {
+    const displayed = applyPageRotation(original.x, original.y, width, height, rotation);
+    assert.deepEqual(invertPageRotation(displayed.x, displayed.y, width, height, rotation), original);
+  }
+});
+
+test('text layer matrix composes page rotation, zoom, and viewport offset', () => {
+  assert.deepEqual(
+    getTextLayerCssMatrix(600, 800, 90, 2, 10, 20),
+    [0, 2, -2, 0, 1610, 20],
+  );
+  assert.deepEqual(
+    getTextLayerCssMatrix(600, 800, 270, 1.5, -5, 12),
+    [0, -1.5, 1.5, 0, -5, 912],
+  );
+});
+
+test('text colour selection ignores white background and antialiased grey edges', () => {
+  const blackGlyph = new Uint8ClampedArray([
+    255, 255, 255, 255,
+    188, 188, 188, 255,
+    17, 17, 17, 255,
+    110, 110, 110, 255,
+  ]);
+  assert.equal(selectTextColor(blackGlyph), '#000000');
+
+  const redGlyph = new Uint8ClampedArray([
+    255, 255, 255, 255,
+    255, 170, 170, 255,
+    214, 32, 40, 255,
+  ]);
+  assert.equal(selectTextColor(redGlyph), '#d62028');
+});
+
+test('text colour selection preserves colours on light and dark backgrounds', () => {
+  assert.equal(selectTextColor(new Uint8ClampedArray([
+    0, 0, 0, 255,
+    0, 0, 0, 255,
+    214, 32, 40, 255,
+  ])), '#d62028');
+  assert.equal(selectTextColor(new Uint8ClampedArray([
+    255, 255, 255, 255,
+    255, 255, 255, 255,
+    51, 51, 51, 255,
+  ])), '#333333');
+  assert.equal(selectTextColor(new Uint8ClampedArray([
+    255, 255, 255, 255,
+    255, 255, 255, 255,
+    244, 244, 244, 255,
+  ])), '#f4f4f4');
+
+  assert.equal(selectTextColor(new Uint8ClampedArray([
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 0, 0, 0, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+  ]), '#000000', 3, 3), '#000000');
+});
+
+test('cancelling a live text edit restores the complete record snapshot', () => {
+  const record = { pdfX: 12, pdfY: 30, color: '#ff0000', transient: true };
+  restoreTextEditSnapshot(record, { pdfX: 10, pdfY: 20, color: '#000000' });
+  assert.deepEqual(record, { pdfX: 10, pdfY: 20, color: '#000000' });
+});
+
+test('DOM text bounds are converted to canvas backing pixels', () => {
+  const canvasRect = { left: 20, top: 40, width: 400, height: 300 };
+  const textRect = { left: 120, top: 115, right: 220, bottom: 145 };
+
+  assert.deepEqual(
+    elementRectToCanvasPixels(textRect, canvasRect, 800, 600),
+    { x: 200, y: 150, width: 200, height: 60 },
+  );
+});
+
+test('page geometry combines intrinsic and user rotation', () => {
+  assert.deepEqual(
+    resolveTextEditPageGeometry({ widthPt: 600, heightPt: 800, rotation: 90 }, 800, 600, 90),
+    { pageWidth: 600, pageHeight: 800, rotation: 180, displayWidth: 600, displayHeight: 800 },
+  );
+});

--- a/open-pdf-studio/js/text/text-layer.js
+++ b/open-pdf-studio/js/text/text-layer.js
@@ -1,6 +1,7 @@
-import { state, getActiveDocument } from '../core/state.js';
+import { state, getActiveDocument, getPageRotation } from '../core/state.js';
 import { isTauri, invoke } from '../core/platform.js';
 import * as pdfjsLib from 'pdfjs-dist';
+import { resolveTextEditPageGeometry } from './text-edit-appearance.js';
 
 /**
  * Text Layer Management Module
@@ -314,6 +315,13 @@ export function injectSyntheticTextSpans(textLayerDiv, pageNum, pageWidth, pageH
   const doc = getActiveDocument();
   if (!doc || !doc.textEdits || doc.textEdits.length === 0) return;
 
+  const geometry = resolveTextEditPageGeometry(
+    doc.pageDims?.[pageNum],
+    pageWidth,
+    pageHeight,
+    getPageRotation(pageNum),
+  );
+
   // Remove previously injected synthetic spans
   textLayerDiv.querySelectorAll('span[data-synthetic]').forEach(s => s.remove());
 
@@ -356,14 +364,9 @@ export function injectSyntheticTextSpans(textLayerDiv, pageNum, pageWidth, pageH
       const linePdfX = edit.pdfX;
       const linePdfY = edit.pdfY - i * ls;
 
-      // Convert to text layer positioning (percentages of unscaled page)
-      // left = pdfX (assuming pageX = 0)
-      // top = (pageHeight - pdfY) - fontSize * ascentRatio
-      const left = linePdfX;
-      const top = (pageHeight - linePdfY) - fontSize * ascentRatio;
-
-      const leftPct = (100 * left / pageWidth).toFixed(2);
-      const topPct = (100 * top / pageHeight).toFixed(2);
+      const unrotatedTop = (geometry.pageHeight - linePdfY) - fontSize * ascentRatio;
+      const leftPct = (100 * linePdfX / geometry.pageWidth).toFixed(2);
+      const topPct = (100 * unrotatedTop / geometry.pageHeight).toFixed(2);
 
       // Create span
       const span = document.createElement('span');

--- a/open-pdf-studio/js/tools/text-edit-tool.js
+++ b/open-pdf-studio/js/tools/text-edit-tool.js
@@ -1,4 +1,4 @@
-import { state, getActiveDocument } from '../core/state.js';
+import { state, getActiveDocument, getPageRotation } from '../core/state.js';
 import { execute } from '../core/undo-manager.js';
 import { redrawAnnotations, redrawContinuous } from '../annotations/rendering.js';
 import { showTextEditProperties, hideProperties } from '../ui/panels/properties-panel.js';
@@ -7,6 +7,14 @@ import { canvasContainer, continuousContainer, pdfCanvas } from '../ui/dom-eleme
 import { showPdfTextEditor, hidePdfTextEditor, getPdfEditorText as getEditorText,
   updatePdfEditorStyle, shiftPdfEditorPosition } from '../bridge.js';
 import { injectSyntheticTextSpans } from '../text/text-layer.js';
+import {
+  applyPageRotation,
+  getPageRotationMatrix,
+  invertPageRotation,
+  restoreTextEditSnapshot,
+  resolveTextEditPageGeometry,
+  sampleTextColor,
+} from '../text/text-edit-appearance.js';
 
 let activeEditor = null;
 let hoverListeners = [];
@@ -14,13 +22,6 @@ let textLayerObserver = null;
 let blockGroupsCache = new Map();
 // WeakMap: span -> block group, for fast lookup on hover/click
 let spanToBlock = new WeakMap();
-
-function rgbToHex(rgbStr) {
-  const m = rgbStr.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-  if (!m) return '#000000';
-  const r = parseInt(m[1]), g = parseInt(m[2]), b = parseInt(m[3]);
-  return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1);
-}
 
 // ── Font mapping shared by the text-edit sessions ──
 // Map a display / actual font name + bold/italic flags to a pdf-lib StandardFont
@@ -94,6 +95,20 @@ function applyStyleStateToEditor(st) {
     'font-style': st.italic ? 'italic' : 'normal',
     'font-family': cssFamilyFor(st.family),
   });
+}
+
+function getTextEditGeometry(pageNum, canvasEl) {
+  const doc = getActiveDocument();
+  const scale = doc?.scale || 1;
+  const dpr = window.devicePixelRatio || 1;
+  const displayWidth = canvasEl?.width ? canvasEl.width / (scale * dpr) : 0;
+  const displayHeight = canvasEl?.height ? canvasEl.height / (scale * dpr) : 0;
+  return resolveTextEditPageGeometry(
+    doc?.pageDims?.[pageNum],
+    displayWidth,
+    displayHeight,
+    getPageRotation(pageNum),
+  );
 }
 
 export function activateEditTextTool() {
@@ -262,7 +277,6 @@ function getBlockGroups(layer) {
   // Find the PDF canvas to sample text colors
   const pdfCanvasEl = layer.parentElement?.querySelector('canvas.pdf-canvas')
     || pdfCanvas || document.getElementById('pdf-canvas');
-  const canvasCtx = pdfCanvasEl?.getContext('2d', { willReadFrequently: true });
 
   const groups = blocks.map(block => {
     const allItems = block.flat();
@@ -284,19 +298,7 @@ function getBlockGroups(layer) {
       const isBold = firstSpan.dataset.pdfBold === 'true';
       const isItalic = firstSpan.dataset.pdfItalic === 'true';
 
-      // Sample text color from the rendered canvas
-      let color = '#000000';
-      if (canvasCtx) {
-        const sampleX = Math.round(lineItems[0].domLeft + 2);
-        const sampleY = Math.round((lineItems[0].domTop + lineItems[0].domBottom) / 2);
-        if (sampleX >= 0 && sampleY >= 0 && sampleX < pdfCanvasEl.width && sampleY < pdfCanvasEl.height) {
-          const pixel = canvasCtx.getImageData(sampleX, sampleY, 1, 1).data;
-          // Only use sampled color if it's not white/near-white (background)
-          if (pixel[0] < 240 || pixel[1] < 240 || pixel[2] < 240) {
-            color = '#' + ((1 << 24) | (pixel[0] << 16) | (pixel[1] << 8) | pixel[2]).toString(16).slice(1);
-          }
-        }
-      }
+      const color = sampleTextColor(pdfCanvasEl, firstSpan.getBoundingClientRect());
 
       return {
         text: lineItems.map(it => it.span.textContent).join(''),
@@ -676,6 +678,11 @@ function finishPdfTextEditing() {
 function cancelPdfTextEditing() {
   if (!activeEditor) return;
 
+  if (activeEditor._cancelEditing) {
+    activeEditor._cancelEditing();
+    return;
+  }
+
   const { block } = activeEditor;
   hidePdfTextEditor();
   for (const s of block.spans) s.style.visibility = '';
@@ -741,28 +748,10 @@ export function createReplaceTextEdit(pageNum, originalText, newText, matchSpan)
       : 'Helvetica';
   }
 
-  // Sample text color from the canvas at the span's position
-  let color = '#000000';
   const textLayer = matchSpan.closest('.textLayer');
-  if (textLayer) {
-    const canvasEl = textLayer.parentElement?.querySelector('canvas.pdf-canvas')
-      || document.getElementById('pdf-canvas');
-    if (canvasEl) {
-      try {
-        const ctx = canvasEl.getContext('2d');
-        const spanRect = matchSpan.getBoundingClientRect();
-        const canvasRect = canvasEl.getBoundingClientRect();
-        const sampleX = Math.round(spanRect.left - canvasRect.left + 2);
-        const sampleY = Math.round((spanRect.top + spanRect.bottom) / 2 - canvasRect.top);
-        if (sampleX >= 0 && sampleY >= 0 && sampleX < canvasEl.width && sampleY < canvasEl.height) {
-          const pixel = ctx.getImageData(sampleX, sampleY, 1, 1).data;
-          if (pixel[0] < 240 || pixel[1] < 240 || pixel[2] < 240) {
-            color = '#' + ((1 << 24) | (pixel[0] << 16) | (pixel[1] << 8) | pixel[2]).toString(16).slice(1);
-          }
-        }
-      } catch (_) {}
-    }
-  }
+  const canvasEl = textLayer?.parentElement?.querySelector('canvas.pdf-canvas')
+    || document.getElementById('pdf-canvas');
+  const color = sampleTextColor(canvasEl, matchSpan.getBoundingClientRect());
 
   const editRecord = {
     id: Date.now() + Math.random().toString(36).substr(2, 9),
@@ -795,8 +784,15 @@ export function findTextEditAtPosition(x, y, pageNum, canvasEl) {
   const pageEdits = doc.textEdits.filter(e => e.page === pageNum);
   if (pageEdits.length === 0) return null;
 
-  const _dpr = window.devicePixelRatio || 1;
-  const pageHeight = canvasEl.height / ((doc.scale || 1.5) * _dpr);
+  const geometry = getTextEditGeometry(pageNum, canvasEl);
+  const unrotatedPoint = invertPageRotation(
+    x,
+    y,
+    geometry.pageWidth,
+    geometry.pageHeight,
+    geometry.rotation,
+  );
+  const pageHeight = geometry.pageHeight;
 
   for (const edit of pageEdits) {
     const fontSize = edit.fontSize;
@@ -811,8 +807,8 @@ export function findTextEditAtPosition(x, y, pageNum, canvasEl) {
     const maxCharCount = Math.max(...newLines.map(l => l.length), 1);
     const editWidth = Math.max(edit.pdfWidth || 0, fontSize * 0.6 * maxCharCount) + fontSize * 0.5;
 
-    if (x >= editLeft && x <= editLeft + editWidth &&
-        y >= editTop && y <= editTop + editHeight) {
+    if (unrotatedPoint.x >= editLeft && unrotatedPoint.x <= editLeft + editWidth &&
+        unrotatedPoint.y >= editTop && unrotatedPoint.y <= editTop + editHeight) {
       return edit;
     }
   }
@@ -824,8 +820,8 @@ export function startTextEditEditing(textEdit, pageNum, canvasEl) {
 
   const editDoc = getActiveDocument();
   const editScale = editDoc?.scale || 1.5;
-  const editDpr = window.devicePixelRatio || 1;
-  const pageHeight = canvasEl.height / (editScale * editDpr);
+  const geometry = getTextEditGeometry(pageNum, canvasEl);
+  const pageHeight = geometry.pageHeight;
   const fontSize = textEdit.fontSize;
   const ls = textEdit.lineSpacing || fontSize * 1.2;
   const newLines = textEdit.newText.split('\n');
@@ -847,12 +843,23 @@ export function startTextEditEditing(textEdit, pageNum, canvasEl) {
 
   const padX = 4;
   const padY = 4;
-  const scaledLeft = textEdit.pdfX * editScale;
-  const scaledTop = editTop * editScale;
+  const rotatedTopLeft = applyPageRotation(
+    textEdit.pdfX,
+    editTop,
+    geometry.pageWidth,
+    geometry.pageHeight,
+    geometry.rotation,
+  );
+  const scaledLeft = rotatedTopLeft.x * editScale;
+  const scaledTop = rotatedTopLeft.y * editScale;
   const scaledWidth = editWidth * editScale;
   const scaledHeight = editHeight * editScale;
   const editorFontSize = Math.round(fontSize * editScale * 0.82);
   const visualLineHeight = (scaledHeight / numLines);
+  const activeViewport = window.__pdfViewport;
+  const useViewport = activeViewport?.active && editDoc?.filePath;
+  const pageOffsetX = useViewport ? activeViewport.offsetX : offsetX;
+  const pageOffsetY = useViewport ? activeViewport.offsetY : offsetY;
 
   // Map font family to CSS
   const ff = (textEdit.fontFamily || 'Helvetica').toLowerCase();
@@ -868,14 +875,16 @@ export function startTextEditEditing(textEdit, pageNum, canvasEl) {
   // Build style object using fixed positioning
   const styleObj = {
     position: 'fixed',
-    left: `${containerRect.left + scaledLeft + offsetX - padX}px`,
-    top: `${containerRect.top + scaledTop + offsetY - padY}px`,
+    left: `${containerRect.left + scaledLeft + pageOffsetX - padX}px`,
+    top: `${containerRect.top + scaledTop + pageOffsetY - padY}px`,
     width: `${Math.max(scaledWidth + padX * 2 + 4, 80)}px`,
     height: `${Math.max(scaledHeight + padY * 2 + 6, 24)}px`,
     'font-size': `${editorFontSize}px`,
     'line-height': `${visualLineHeight}px`,
     'font-family': cssFontFamily,
     color: textEdit.color || '#000000',
+    transform: `rotate(${geometry.rotation}deg)`,
+    'transform-origin': '0 0',
     'z-index': '1000'
   };
   if (ff.includes('bold')) styleObj['font-weight'] = 'bold';
@@ -914,7 +923,9 @@ export function startTextEditEditing(textEdit, pageNum, canvasEl) {
   };
 
   const cancelEditing = () => {
+    restoreTextEditSnapshot(textEdit, oldTextEdit);
     hidePdfTextEditor();
+    reRenderAddedText(pageNum);
     activeEditor = null;
     state.pdfTextEditState = null;
     hideProperties();
@@ -1057,8 +1068,19 @@ export function deleteActiveTextEdit() {
 function nudgeActiveTextEdit(dxPdf, dyPdf) {
   if (!activeEditor) return;
   const scale = activeEditor.scale || (getActiveDocument()?.scale || 1.5);
-  // +pdfX → right; +pdfY → up (screen top decreases), so flip Y for the editor.
-  shiftPdfEditorPosition(dxPdf * scale, -dyPdf * scale);
+  // Convert the PDF-space nudge into the rotated display frame.
+  const canvasEl = pdfCanvas || document.getElementById('pdf-canvas');
+  const geometry = getTextEditGeometry(activeEditor.pageNum, canvasEl);
+  const [a, b, c, d] = getPageRotationMatrix(
+    geometry.pageWidth,
+    geometry.pageHeight,
+    geometry.rotation,
+  );
+  const unrotatedDy = -dyPdf;
+  shiftPdfEditorPosition(
+    (a * dxPdf + c * unrotatedDy) * scale,
+    (b * dxPdf + d * unrotatedDy) * scale,
+  );
   if (activeEditor._recordRef) {
     activeEditor._recordRef.pdfX += dxPdf;
     activeEditor._recordRef.pdfY += dyPdf;

--- a/open-pdf-studio/js/tools/text-editing.js
+++ b/open-pdf-studio/js/tools/text-editing.js
@@ -1,4 +1,4 @@
-import { state, getActiveDocument } from '../core/state.js';
+import { state, getActiveDocument, getPageRotation } from '../core/state.js';
 import { redrawAnnotations, redrawContinuous } from '../annotations/rendering.js';
 import { hasFill } from '../annotations/fill-utils.js';
 import { showProperties } from '../ui/panels/properties-panel.js';
@@ -6,6 +6,7 @@ import { recordAdd, recordModify, execute } from '../core/undo-manager.js';
 import { cloneAnnotation } from '../annotations/factory.js';
 import { markDocumentModified } from '../ui/chrome/tabs.js';
 import { injectSyntheticTextSpans } from '../text/text-layer.js';
+import { invertPageRotation, resolveTextEditPageGeometry } from '../text/text-edit-appearance.js';
 import { annotationCanvas } from '../ui/dom-elements.js';
 import { viewport as vpState } from '../pdf/pdf-viewport.js';
 import {
@@ -264,21 +265,25 @@ export async function addTextAnnotation(x, y, pageNum, canvasEl) {
   // Determine page height for coordinate conversion
   const addTextScale = doc?.scale || 1.5;
   const dpr = window.devicePixelRatio || 1;
-  let pageHeight;
-  if (canvasEl) {
-    pageHeight = canvasEl.height / (addTextScale * dpr);
-  } else {
-    const canvas = annotationCanvas || document.getElementById('annotation-canvas');
-    if (canvas) {
-      pageHeight = canvas.height / (addTextScale * dpr);
-    } else {
-      return;
-    }
-  }
+  const activeCanvas = canvasEl || annotationCanvas || document.getElementById('annotation-canvas');
+  if (!activeCanvas) return;
+  const geometry = resolveTextEditPageGeometry(
+    doc?.pageDims?.[page],
+    activeCanvas.width / (addTextScale * dpr),
+    activeCanvas.height / (addTextScale * dpr),
+    getPageRotation(page),
+  );
+  const unrotatedPoint = invertPageRotation(
+    x,
+    y,
+    geometry.pageWidth,
+    geometry.pageHeight,
+    geometry.rotation,
+  );
 
-  // Convert canvas coords to PDF user-space (origin at bottom-left)
-  const pdfX = x;
-  const pdfY = pageHeight - y;
+  // Convert visual page coordinates to PDF user-space (origin at bottom-left).
+  const pdfX = unrotatedPoint.x;
+  const pdfY = geometry.pageHeight - unrotatedPoint.y;
 
   // Map dialog font family + bold/italic to standard PDF font name
   const fn = (result.fontFamily || 'Arial').toLowerCase();
@@ -334,7 +339,6 @@ export async function addTextAnnotation(x, y, pageNum, canvasEl) {
   const textLayer = document.querySelector(`.textLayer[data-page="${page}"]`)
     || document.querySelector('.textLayer');
   if (textLayer) {
-    const activeCanvas = canvasEl || annotationCanvas || document.getElementById('annotation-canvas');
     if (activeCanvas) {
       const pw = activeCanvas.width / addTextScale;
       const ph = activeCanvas.height / addTextScale;

--- a/open-pdf-studio/js/types/document.ts
+++ b/open-pdf-studio/js/types/document.ts
@@ -69,6 +69,7 @@ export interface DocumentState {
   modified: boolean;
   scrollPosition: ScrollPosition;
   pageRotations: Record<number, number>;
+  pageDims?: Record<number, { widthPt: number; heightPt: number; rotation?: number }>;
   pdfaCompliance: string | null;
   pdfADismissed: boolean;
   measureScale: MeasureScale | null;

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -14,6 +14,7 @@
     "tauri:build": "npm run build && tauri build",
     "bump": "node scripts/bump-version.js",
     "typecheck": "tsc --noEmit",
+    "test:unit": "node --test js/pdf/progressive-render.test.mjs js/quantities/engine.test.mjs js/quantities/schedule-image.test.mjs js/quantities/takeoff.test.mjs js/text/text-edit-appearance.test.mjs js/tools/embedded-image-parser.test.mjs",
     "test:render": "..\\scripts\\.venv-test\\Scripts\\python.exe ../scripts/render-regression-test.py",
     "test:render:auto": "node ../scripts/run-render-regression.mjs"
   },

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -2412,10 +2412,9 @@ pub fn run(opts: StartupOpts) {
             // inside `mcp_server::start`).
             if mcp_enabled {
                 let app_handle = app.handle().clone();
-                let test_pdfs_dir = std::env::current_dir()
-                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                    .join("test pdf-bestanden")
-                    .join("Originele bestanden");
+                let test_pdfs_dir = mcp_server::resolve_test_pdfs_dir(
+                    std::env::var_os("OPS_TEST_PDFS_DIR").map(std::path::PathBuf::from),
+                );
                 tauri::async_runtime::spawn(async move {
                     if let Err(e) = mcp_server::start(mcp_port, test_pdfs_dir, Some(app_handle)).await {
                         eprintln!("[mcp] server failed: {e}");

--- a/open-pdf-studio/src-tauri/src/mcp_server.rs
+++ b/open-pdf-studio/src-tauri/src/mcp_server.rs
@@ -58,6 +58,19 @@ pub struct AppState {
     pub app_handle: Option<AppHandle>,
 }
 
+/// Resolve the corpus independently of the process working directory.
+/// CI can point at a small committed fixture set; local runs default to the
+/// repository corpus next to the workspace root.
+pub fn resolve_test_pdfs_dir(override_dir: Option<PathBuf>) -> PathBuf {
+    override_dir.unwrap_or_else(|| {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("test pdf-bestanden")
+            .join("Originele bestanden")
+    })
+}
+
 /// Standard JSON-RPC error codes used by this server. Codes not yet
 /// dispatched in handler bodies are kept available for tool handlers added
 /// in tasks 7-9.
@@ -1269,6 +1282,23 @@ mod tests {
             .expect("descriptor present");
         assert_eq!(tool["inputSchema"]["type"], "object");
         assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+    }
+
+    #[test]
+    fn resolve_test_pdfs_dir_prefers_explicit_override() {
+        let fixture = PathBuf::from("render-fixtures");
+        assert_eq!(resolve_test_pdfs_dir(Some(fixture.clone())), fixture);
+    }
+
+    #[test]
+    fn resolve_test_pdfs_dir_defaults_to_repository_corpus() {
+        let expected = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("test pdf-bestanden")
+            .join("Originele bestanden");
+
+        assert_eq!(resolve_test_pdfs_dir(None), expected);
     }
 
     /// Exercises the real `tool_list_test_pdfs` over a fixture directory.

--- a/open-pdf-studio/styles/text-layer.css
+++ b/open-pdf-studio/styles/text-layer.css
@@ -21,6 +21,20 @@
   --min-font-size-inv: calc(1 / var(--min-font-size));
 }
 
+/* PDF.js lays out text in the page's original coordinate frame. Rotate the
+   complete layer so native and synthetic text share the rendered page frame. */
+.textLayer[data-main-rotation="90"] {
+  transform: rotate(90deg) translateY(-100%);
+}
+
+.textLayer[data-main-rotation="180"] {
+  transform: rotate(180deg) translate(-100%, -100%);
+}
+
+.textLayer[data-main-rotation="270"] {
+  transform: rotate(270deg) translateX(-100%);
+}
+
 .textLayer :is(span, br) {
   color: transparent;
   position: absolute;

--- a/scripts/run-render-regression.mjs
+++ b/scripts/run-render-regression.mjs
@@ -17,7 +17,10 @@ const HARNESS_PY = path.join(__dirname, 'render-regression-test.py');
 const VENV_PY    = path.join(__dirname, '.venv-test', 'Scripts', 'python.exe');
 
 const PORT = 9223;
-const MAX_WAIT_MS = 180_000;
+// A cold Windows runner may need several minutes to compile the desktop app.
+// Keep readiness separate from compilation speed; the workflow-level timeout
+// remains the hard upper bound for hung starts.
+const MAX_WAIT_MS = 600_000;
 
 function waitForPort(port, timeoutMs) {
   const start = Date.now();


### PR DESCRIPTION
## Summary

- keep edited and inserted text aligned through intrinsic and user page rotations
- preserve source glyph colours and restore live edits when the user cancels
- add structured bug and feature issue forms with blank issues disabled
- run the focused JavaScript unit suite in CI

## Verification

- `npm run test:unit` (16 tests passed)
- `npx vite build`
- syntax checks for all changed JavaScript files
- `git diff --check`

The repository-wide typecheck still reports four pre-existing errors outside the changed files.

Closes #292
Closes #295
Closes #296
