### PR TITLE
fix(search): position match highlights from item geometry (correct at zoom + across text-layer builders)

### DIFF
--- a/open-pdf-studio/js/search/find-bar.js
+++ b/open-pdf-studio/js/search/find-bar.js
@@ -3,7 +3,7 @@
  */
 
 import { state, getActiveDocument } from '../core/state.js';
-import { executeSearch, executeProgressiveSearch, findNext, findPrevious, getCurrentResult, clearSearch, getResultsForPage } from './find-controller.js';
+import { executeSearch, executeProgressiveSearch, findNext, findPrevious, getCurrentResult, clearSearch, getResultsForPage, findDomSpanForItem } from './find-controller.js';
 import { renderPage, renderContinuous } from '../pdf/renderer.js';
 import {
   setFindBarVisible as setVisible, setFindBarResultsText as setResultsText,
@@ -303,7 +303,7 @@ async function navigateToResult(result) {
 
     if (getActiveDocument()?.viewMode === 'continuous') {
       // Scroll to page in continuous mode
-      const pageWrapper = document.querySelector(`[data-page-num="${result.pageNum}"]`);
+      const pageWrapper = document.querySelector(`.page-wrapper[data-page="${result.pageNum}"]`);
       if (pageWrapper) {
         pageWrapper.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
@@ -502,40 +502,59 @@ function findAllMatchPositions(textLayer, searchText, matchCase, wholeWord) {
  * Highlight search results on a page
  */
 function highlightMatch(result, isCurrent) {
-  if (!result || !result.matchText) return;
+  if (!result || !result.items || result.items.length === 0) return;
 
   const pageNum = result.pageNum;
+  const doc = getActiveDocument();
 
   // Get the text layer for this page
   let textLayer;
-  if (getActiveDocument()?.viewMode === 'continuous') {
-    textLayer = document.querySelector(`[data-page-num="${pageNum}"] .textLayer`);
+  if (doc?.viewMode === 'continuous') {
+    const wrapper = document.querySelector(`.page-wrapper[data-page="${pageNum}"]`);
+    textLayer = wrapper?.querySelector('.textLayer');
   } else {
     textLayer = document.querySelector('.textLayer');
   }
 
   if (!textLayer) return;
+  const layerRect = textLayer.getBoundingClientRect();
 
-  // Find all match positions in the text layer
-  const positions = findAllMatchPositions(textLayer, result.matchText, state.search.matchCase, state.search.wholeWord);
+  // Highlight exactly the matched glyphs. The search result already knows
+  // which text items it covers (result.items, with page-text offsets and
+  // itemIndex mapping to span[data-item-index]); positioning from those is
+  // correct regardless of the page's content-stream order. The previous
+  // approach re-scanned the DOM for the match text and paired the Nth
+  // stream-order result with the Nth visual-order occurrence, which lands
+  // on the wrong occurrence whenever those orders differ (multi-column
+  // layouts, tables, headers drawn last, ...).
+  for (const item of result.items) {
+    const span = findDomSpanForItem(item, pageNum, doc);
+    const textNode = span?.firstChild;
+    if (!textNode || textNode.nodeType !== Node.TEXT_NODE) continue;
 
-  // Count which occurrence this result is on this page
-  const pageResults = state.search.results.filter(r => r.pageNum === pageNum);
-  const occurrenceIndex = pageResults.findIndex(r => r.index === result.index);
+    const nodeLen = textNode.textContent.length;
+    const startInItem = Math.max(0, result.startPos - item.startPos);
+    const endInItem = Math.min(item.str.length, result.endPos - item.startPos);
+    if (endInItem <= startInItem) continue;
 
-  if (occurrenceIndex >= 0 && occurrenceIndex < positions.length) {
-    const pos = positions[occurrenceIndex];
+    let rect;
+    try {
+      const range = document.createRange();
+      range.setStart(textNode, Math.min(startInItem, nodeLen));
+      range.setEnd(textNode, Math.min(endInItem, nodeLen));
+      rect = range.getBoundingClientRect();
+    } catch (_) {
+      rect = span.getBoundingClientRect();
+    }
+    if (!rect || rect.width <= 0) continue;
 
     const highlight = document.createElement('div');
     highlight.className = 'search-highlight' + (isCurrent ? ' current' : '');
     highlight.dataset.resultIndex = result.index;
-
-    // Position using calculated visual coordinates
-    highlight.style.left = pos.highlightLeft + 'px';
-    highlight.style.top = pos.highlightTop + 'px';
-    highlight.style.width = pos.matchWidth + 'px';
-    highlight.style.height = pos.matchHeight + 'px';
-
+    highlight.style.left = (rect.left - layerRect.left) + 'px';
+    highlight.style.top = (rect.top - layerRect.top) + 'px';
+    highlight.style.width = rect.width + 'px';
+    highlight.style.height = rect.height + 'px';
     textLayer.appendChild(highlight);
   }
 }

--- a/open-pdf-studio/js/search/find-bar.js
+++ b/open-pdf-studio/js/search/find-bar.js
@@ -3,7 +3,7 @@
  */
 
 import { state, getActiveDocument } from '../core/state.js';
-import { executeSearch, executeProgressiveSearch, findNext, findPrevious, getCurrentResult, clearSearch, getResultsForPage, findDomSpanForItem } from './find-controller.js';
+import { executeSearch, executeProgressiveSearch, findNext, findPrevious, getCurrentResult, clearSearch, getResultsForPage } from './find-controller.js';
 import { renderPage, renderContinuous } from '../pdf/renderer.js';
 import {
   setFindBarVisible as setVisible, setFindBarResultsText as setResultsText,
@@ -395,7 +395,17 @@ export function highlightResults() {
 }
 
 /**
- * Highlight search results on a page
+ * Highlight search results on a page.
+ *
+ * Highlights are positioned from the matched items' own PDF-space geometry
+ * (transform/width/height captured at text extraction), NOT from measuring
+ * DOM spans. The three text-layer builders (custom single-page PDF.js,
+ * stock PDF.js TextLayer in continuous mode, Rust-extracted spans in vector
+ * mode) produce different span structures — only one of them carries
+ * data-item-index — so any DOM-based lookup breaks on the other two.
+ * Item geometry is layer-type independent, and because the rects live in
+ * layer-local coordinates they ride along with the viewport's zoom
+ * transform instead of needing re-measurement.
  */
 function highlightMatch(result, isCurrent) {
   if (!result || !result.items || result.items.length === 0) return;
@@ -409,56 +419,47 @@ function highlightMatch(result, isCurrent) {
     const wrapper = document.querySelector(`.page-wrapper[data-page="${pageNum}"]`);
     textLayer = wrapper?.querySelector('.textLayer');
   } else {
+    if (doc && doc.currentPage !== pageNum) return;
     textLayer = document.querySelector('.textLayer');
   }
-
   if (!textLayer) return;
-  const layerRect = textLayer.getBoundingClientRect();
 
-  // The textLayer is laid out in unscaled PDF points and zoomed via a CSS
-  // transform on the layer itself (pdf-viewport.js). Range/element rects are
-  // visual (post-transform) pixels, so offsets must be divided by the
-  // effective scale before being used as child left/top — the layer's
-  // transform is applied to the highlight divs on top of whatever we set.
-  const scaleX = textLayer.offsetWidth ? layerRect.width / textLayer.offsetWidth : 1;
-  const scaleY = textLayer.offsetHeight ? layerRect.height / textLayer.offsetHeight : 1;
+  // Layer-local px per PDF point. Every layer builder sets
+  // --total-scale-factor on the layer or an ancestor: 1 in vector mode
+  // (layout px = PDF pt, zoom applied via CSS transform), viewport.scale
+  // for the PDF.js-built layers (laid out at scaled size).
+  const scale = parseFloat(
+    getComputedStyle(textLayer).getPropertyValue('--total-scale-factor')
+  ) || 1;
+  const pageHeightPt = textLayer.offsetHeight / scale;
 
-  // Highlight exactly the matched glyphs. The search result already knows
-  // which text items it covers (result.items, with page-text offsets and
-  // itemIndex mapping to span[data-item-index]); positioning from those is
-  // correct regardless of the page's content-stream order. The previous
-  // approach re-scanned the DOM for the match text and paired the Nth
-  // stream-order result with the Nth visual-order occurrence, which lands
-  // on the wrong occurrence whenever those orders differ (multi-column
-  // layouts, tables, headers drawn last, ...).
   for (const item of result.items) {
-    const span = findDomSpanForItem(item, pageNum, doc);
-    const textNode = span?.firstChild;
-    if (!textNode || textNode.nodeType !== Node.TEXT_NODE) continue;
+    const t = item.transform;
+    if (!t) continue; // synthetic (Add Text) items carry no geometry
 
-    const nodeLen = textNode.textContent.length;
     const startInItem = Math.max(0, result.startPos - item.startPos);
     const endInItem = Math.min(item.str.length, result.endPos - item.startPos);
     if (endInItem <= startInItem) continue;
 
-    let rect;
-    try {
-      const range = document.createRange();
-      range.setStart(textNode, Math.min(startInItem, nodeLen));
-      range.setEnd(textNode, Math.min(endInItem, nodeLen));
-      rect = range.getBoundingClientRect();
-    } catch (_) {
-      rect = span.getBoundingClientRect();
-    }
-    if (!rect || rect.width <= 0) continue;
+    // Partial matches inside an item: slice the run width proportionally
+    // by character count. Approximate for proportional fonts, but close
+    // enough for a highlight and independent of DOM/font availability.
+    const len = item.str.length || 1;
+    const itemH = item.height || Math.abs(t[3]) || 10;
+    const itemW = item.width || 0;
+    const x0 = t[4] + itemW * (startInItem / len);
+    const x1 = t[4] + itemW * (endInItem / len);
+    // t[5] is the baseline; ascent ≈ 0.8em above it (same convention the
+    // vector-mode span builder uses), Y flipped into top-left space.
+    const topPt = pageHeightPt - t[5] - itemH * 0.8;
 
     const highlight = document.createElement('div');
     highlight.className = 'search-highlight' + (isCurrent ? ' current' : '');
     highlight.dataset.resultIndex = result.index;
-    highlight.style.left = ((rect.left - layerRect.left) / scaleX) + 'px';
-    highlight.style.top = ((rect.top - layerRect.top) / scaleY) + 'px';
-    highlight.style.width = (rect.width / scaleX) + 'px';
-    highlight.style.height = (rect.height / scaleY) + 'px';
+    highlight.style.left = (x0 * scale) + 'px';
+    highlight.style.top = (topPt * scale) + 'px';
+    highlight.style.width = (Math.max(x1 - x0, 2) * scale) + 'px';
+    highlight.style.height = (itemH * scale) + 'px';
     textLayer.appendChild(highlight);
   }
 }

--- a/open-pdf-studio/js/search/find-bar.js
+++ b/open-pdf-studio/js/search/find-bar.js
@@ -395,110 +395,6 @@ export function highlightResults() {
 }
 
 /**
- * Find all occurrences of search text in the text layer and return their positions
- */
-function findAllMatchPositions(textLayer, searchText, matchCase, wholeWord) {
-  const positions = [];
-  const textSpans = textLayer.querySelectorAll('span');
-  const compareSearchText = matchCase ? searchText : searchText.toLowerCase();
-
-  for (const span of textSpans) {
-    const spanText = span.textContent;
-    if (!spanText) continue;
-
-    const compareSpanText = matchCase ? spanText : spanText.toLowerCase();
-    let startIndex = 0;
-
-    while (true) {
-      const matchIndex = compareSpanText.indexOf(compareSearchText, startIndex);
-      if (matchIndex === -1) break;
-
-      // Whole word check: verify word boundaries in the span text
-      if (wholeWord) {
-        const before = matchIndex > 0 ? compareSpanText[matchIndex - 1] : ' ';
-        const after = matchIndex + compareSearchText.length < compareSpanText.length
-          ? compareSpanText[matchIndex + compareSearchText.length] : ' ';
-        const isWordChar = (c) => /\w/.test(c);
-        if (isWordChar(before) || isWordChar(after)) {
-          startIndex = matchIndex + 1;
-          continue;
-        }
-      }
-
-      const textNode = span.firstChild;
-      if (textNode && textNode.nodeType === Node.TEXT_NODE) {
-        try {
-          // Get span's position within the text layer (from its style)
-          const spanLeft = parseFloat(span.style.left) || 0;
-          const spanTop = parseFloat(span.style.top) || 0;
-
-          // Get the scaleX factor from transform if present
-          let scaleX = 1;
-          const transform = span.style.transform;
-          if (transform) {
-            const scaleMatch = transform.match(/scaleX\(([^)]+)\)/);
-            if (scaleMatch) {
-              scaleX = parseFloat(scaleMatch[1]) || 1;
-            }
-          }
-
-          // Measure the width of text before the match (in original coordinates)
-          let preWidth = 0;
-          if (matchIndex > 0) {
-            const preRange = document.createRange();
-            preRange.setStart(textNode, 0);
-            preRange.setEnd(textNode, matchIndex);
-            preWidth = preRange.getBoundingClientRect().width;
-          }
-
-          // Measure the width of the match itself
-          const matchRange = document.createRange();
-          matchRange.setStart(textNode, matchIndex);
-          matchRange.setEnd(textNode, matchIndex + searchText.length);
-          const matchRect = matchRange.getBoundingClientRect();
-
-          // Get span's visual bounding rect
-          const spanRect = span.getBoundingClientRect();
-          const textLayerRect = span.parentElement.getBoundingClientRect();
-
-          // Calculate position relative to text layer using visual coordinates
-          const highlightLeft = matchRect.left - textLayerRect.left;
-          const highlightTop = matchRect.top - textLayerRect.top;
-
-          // Store position data
-          positions.push({
-            span,
-            highlightLeft,
-            highlightTop,
-            matchWidth: matchRect.width,
-            matchHeight: matchRect.height,
-            matchIndex,
-            spanText,
-            // Also store viewport rect for sorting
-            viewportTop: matchRect.top,
-            viewportLeft: matchRect.left
-          });
-        } catch (e) {
-          console.warn('Range error:', e);
-        }
-      }
-
-      startIndex = matchIndex + 1;
-    }
-  }
-
-  // Sort by position (top to bottom, left to right)
-  positions.sort((a, b) => {
-    if (Math.abs(a.viewportTop - b.viewportTop) > 5) {
-      return a.viewportTop - b.viewportTop;
-    }
-    return a.viewportLeft - b.viewportLeft;
-  });
-
-  return positions;
-}
-
-/**
  * Highlight search results on a page
  */
 function highlightMatch(result, isCurrent) {
@@ -518,6 +414,14 @@ function highlightMatch(result, isCurrent) {
 
   if (!textLayer) return;
   const layerRect = textLayer.getBoundingClientRect();
+
+  // The textLayer is laid out in unscaled PDF points and zoomed via a CSS
+  // transform on the layer itself (pdf-viewport.js). Range/element rects are
+  // visual (post-transform) pixels, so offsets must be divided by the
+  // effective scale before being used as child left/top — the layer's
+  // transform is applied to the highlight divs on top of whatever we set.
+  const scaleX = textLayer.offsetWidth ? layerRect.width / textLayer.offsetWidth : 1;
+  const scaleY = textLayer.offsetHeight ? layerRect.height / textLayer.offsetHeight : 1;
 
   // Highlight exactly the matched glyphs. The search result already knows
   // which text items it covers (result.items, with page-text offsets and
@@ -551,10 +455,10 @@ function highlightMatch(result, isCurrent) {
     const highlight = document.createElement('div');
     highlight.className = 'search-highlight' + (isCurrent ? ' current' : '');
     highlight.dataset.resultIndex = result.index;
-    highlight.style.left = (rect.left - layerRect.left) + 'px';
-    highlight.style.top = (rect.top - layerRect.top) + 'px';
-    highlight.style.width = rect.width + 'px';
-    highlight.style.height = rect.height + 'px';
+    highlight.style.left = ((rect.left - layerRect.left) / scaleX) + 'px';
+    highlight.style.top = ((rect.top - layerRect.top) / scaleY) + 'px';
+    highlight.style.width = (rect.width / scaleX) + 'px';
+    highlight.style.height = (rect.height / scaleY) + 'px';
     textLayer.appendChild(highlight);
   }
 }

--- a/open-pdf-studio/js/search/find-controller.js
+++ b/open-pdf-studio/js/search/find-controller.js
@@ -128,18 +128,41 @@ function searchPage(pageData, pattern, query) {
     );
 
     if (matchItems.length > 0) {
+      // Visual anchor (PDF space, Y-up) of the first geometric item, used
+      // to order results top-to-bottom on the page rather than in
+      // content-stream order.
+      const anchor = matchItems.find(item => item.transform);
       results.push({
         pageNum,
         startPos,
         endPos,
         matchText: text.substring(startPos, endPos),
         items: matchItems,
+        anchorX: anchor ? anchor.transform[4] : null,
+        anchorY: anchor ? anchor.transform[5] : null,
         index: 0 // will be re-indexed later
       });
     }
   }
 
   return results;
+}
+
+/**
+ * Order results the way a reader scans the page: by page, then top to
+ * bottom (PDF Y is up, so larger anchorY first), then left to right.
+ * Content-stream order (startPos) is only the tiebreaker — streams often
+ * draw headers/footers/cards out of visual order.
+ */
+function compareResultsVisually(a, b) {
+  if (a.pageNum !== b.pageNum) return a.pageNum - b.pageNum;
+  if (a.anchorY != null && b.anchorY != null) {
+    if (Math.abs(a.anchorY - b.anchorY) > 2) return b.anchorY - a.anchorY;
+    if (a.anchorX != null && b.anchorX != null && a.anchorX !== b.anchorX) {
+      return a.anchorX - b.anchorX;
+    }
+  }
+  return a.startPos - b.startPos;
 }
 
 /**
@@ -167,12 +190,11 @@ export async function performSearch(query, options = {}) {
     const results = [];
 
     for (const pageData of pagesText) {
-      const pageResults = searchPage(pageData, pattern, query);
-      for (const r of pageResults) {
-        r.index = results.length;
-        results.push(r);
-      }
+      results.push(...searchPage(pageData, pattern, query));
     }
+
+    results.sort(compareResultsVisually);
+    results.forEach((r, i) => r.index = i);
 
     return results;
   } finally {
@@ -251,7 +273,7 @@ export function executeProgressiveSearch(onProgress) {
       textCache.set(docId, pagesText);
     }
 
-    allResults.sort((a, b) => a.pageNum - b.pageNum || a.startPos - b.startPos);
+    allResults.sort(compareResultsVisually);
     allResults.forEach((r, i) => r.index = i);
 
     onProgress(allResults, totalPages, totalPages, true);
@@ -384,29 +406,6 @@ function replaceInTextEdit(doc, result, replaceText) {
   edit.newText = edit.newText.substring(0, idx) + replaceText + edit.newText.substring(idx + matchText.length);
 
   return { type: 'textEdit', id: edit.id, oldText, newText: edit.newText };
-}
-
-/**
- * Find the DOM span for a search result item by matching dataset.itemIndex.
- * This is the ONLY reliable way to map search results to DOM spans.
- */
-export function findDomSpanForItem(item, pageNum, doc) {
-  if (item.itemIndex < 0) return null; // synthetic item (text edit)
-
-  let textLayer;
-  if (doc.viewMode === 'continuous') {
-    const wrapper = document.querySelector(`.page-wrapper[data-page="${pageNum}"]`);
-    textLayer = wrapper?.querySelector('.textLayer');
-  } else {
-    // In single-page mode, verify we're on the correct page
-    if (doc.currentPage !== pageNum) return null;
-    textLayer = document.querySelector('.textLayer');
-  }
-  if (!textLayer) return null;
-
-  // Direct lookup by data-item-index attribute
-  const span = textLayer.querySelector(`span[data-item-index="${item.itemIndex}"]`);
-  return span || null;
 }
 
 /**

--- a/open-pdf-studio/js/search/find-controller.js
+++ b/open-pdf-studio/js/search/find-controller.js
@@ -390,7 +390,7 @@ function replaceInTextEdit(doc, result, replaceText) {
  * Find the DOM span for a search result item by matching dataset.itemIndex.
  * This is the ONLY reliable way to map search results to DOM spans.
  */
-function findDomSpanForItem(item, pageNum, doc) {
+export function findDomSpanForItem(item, pageNum, doc) {
   if (item.itemIndex < 0) return null; // synthetic item (text edit)
 
   let textLayer;

--- a/open-pdf-studio/js/search/find-controller.js
+++ b/open-pdf-studio/js/search/find-controller.js
@@ -145,6 +145,11 @@ function searchPage(pageData, pattern, query) {
     }
   }
 
+  // Sort visually at discovery time, not just in the final pass: the
+  // progressive search picks the initial current match from a page's raw
+  // results, and stream order would make "1 of N" land mid-page.
+  results.sort(compareResultsVisually);
+
   return results;
 }
 


### PR DESCRIPTION
## Summary

Search-match highlights were positioned by re-measuring DOM spans, which broke
in two ways:

1. **At zoom** — the rects were measured in one frame and not rescaled, so at
   any non-100% zoom the highlight boxes drifted off the matched text.
2. **Across text-layer builders** — this app builds the text layer three ways
   (custom single-page PDF.js, stock PDF.js `TextLayer` in continuous mode, and
   Rust-extracted spans in vector mode). Only one of them sets
   `data-item-index`, so a `querySelector`-based span lookup silently failed on
   the other two and highlights either landed wrong or didn't appear.

This positions each highlight from the **matched item's own PDF-space geometry**
(the transform/width/height already returned by `getTextContent`), converted
into the text layer's local coordinates via `--total-scale-factor`. That's
independent of DOM span structure and of font availability, and because the
rects live inside the text layer they ride its zoom transform without needing
re-measurement. Also starts navigation at the **visually-first match on the
current page** rather than document order.

Highlights are appended inside `.textLayer`, so they follow whatever transform
the layer carries — no separate handling here.

## Verification

- `npx vite build` (clean)
- Manually verified on Windows: highlights track the matched text across all
  pages and at multiple zoom levels, in both continuous and single-page modes.
- Repo-wide typecheck reports the same four pre-existing errors, none in the
  changed files.
