### PR TITLE
fix(thumbnails): apply in-session page rotation in the Rust thumbnail path

### DIFF
--- a/open-pdf-studio/js/ui/panels/left-panel.js
+++ b/open-pdf-studio/js/ui/panels/left-panel.js
@@ -684,10 +684,16 @@ async function renderThumbnailToDataURL(pdfDoc, pageNum, doc) {
   if (doc?.filePath && window.__TAURI__) {
     try {
       const { invoke } = window.__TAURI__.core;
+      // Pass the in-session user rotation so the Rust render matches the main
+      // view. Without it, a rotated page's thumbnail stayed unrotated until the
+      // rotation was baked into the PDF (save + reload) — the other thumbnail
+      // paths (vector replay, prog-bitmap, PDF.js fallback) already rotate.
+      const extraRot = getPageRotation(pageNum);
       const result = await invoke('render_thumbnail', {
         path: doc.filePath,
         pageIndex: pageNum - 1,
         maxWidth: 140,
+        rotation: extraRot || 0,
         skipImages: true,
       });
       const data = JSON.parse(result);
@@ -696,7 +702,11 @@ async function renderThumbnailToDataURL(pdfDoc, pageNum, doc) {
       // Scale = thumbnail-pixels / PDF-pt = data.width / pageWidthPt.
       try {
         const page = await pdfDoc.getPage(pageNum);
-        const viewport = page.getViewport({ scale: 1 });
+        // Rotated render → rotated dims; match the viewport so the overlay
+        // scale stays correct (PDF.js rotation overrides the page default).
+        const vpOpts = { scale: 1 };
+        if (extraRot) vpOpts.rotation = (page.rotate + extraRot) % 360;
+        const viewport = page.getViewport(vpOpts);
         const scale = data.width / viewport.width;
         const composited = await overlayAnnotationsOnDataURL(data.dataURL, pageNum, data.width, data.height, scale, doc);
         return { dataURL: composited, width: data.width, height: data.height };


### PR DESCRIPTION
## Summary

When a page is rotated in-session (via the rotate actions), its thumbnail
stayed in the original orientation until the rotation was baked into the PDF
(i.e. after save + reload).

The cause: the primary Rust thumbnail path (`invoke('render_thumbnail', …)`)
did not pass the user's in-session rotation, so the backend rendered the page
unrotated. The other thumbnail paths (cached vector replay, progressive
bitmap, and the PDF.js fallback) already apply the rotation, so the bug only
showed on the common fast path.

`render_thumbnail` already accepts a `rotation` argument — this passes
`getPageRotation(pageNum)` through, and rotates the viewport used to compute
the annotation-overlay scale so it matches the rotated render.

## Verification

- `npx vite build` (clean)
- Manually verified on Windows: rotating a page now updates its thumbnail
  immediately, no save/reload required; unrotated pages are unaffected.
