### PR TITLE
fix(save): route files opened from a mail-client temp cache to Save As

### DIFF
--- a/open-pdf-studio/js/pdf/saver.js
+++ b/open-pdf-studio/js/pdf/saver.js
@@ -142,6 +142,16 @@ export async function savePDF(saveAsPath = null) {
     return await savePDFAs();
   }
 
+  // Files opened from an email attachment live in Outlook's secure temp
+  // cache. Outlook keeps a lock on that copy (in-place saves fail with a
+  // sharing violation), and anything written there is invisible to the email
+  // and cleaned up with the cache anyway. Route straight to "Save As", same
+  // as untitled documents.
+  const OUTLOOK_TEMP = /[\\/]INetCache[\\/]Content\.Outlook[\\/]|Microsoft\.OutlookForWindows/i;
+  if (!saveAsPath && OUTLOOK_TEMP.test(currentPath)) {
+    return await savePDFAs();
+  }
+
   try {
     showLoading('Saving PDF...');
 


### PR DESCRIPTION
A PDF opened from an email attachment often lives in a client's secure temp
cache (e.g. Outlook's `INetCache\Content.Outlook`), where the mail client
holds a lock on the file. A plain **Save** then either fails outright or writes
into a copy that's invisible to the email and gets wiped when the cache is
cleared — silent data loss.

`savePDF` now detects that cache path and routes straight to **Save As**, so the
user picks a durable location instead of losing their edits. Normal saves to
real file paths are unaffected.
