### PR TITLE
fix(open): skip the cold-open pre-render until the PDFium worker pool is ready

### DIFF
--- a/open-pdf-studio/js/pdf/loader.js
+++ b/open-pdf-studio/js/pdf/loader.js
@@ -240,7 +240,17 @@ export async function loadPDF(filePath, docIndex, preloadedData = null) {
         if (_skipPre) console.log('[prog-guard] zware pagina → cold-open pre-render overgeslagen');
       } catch {}
     }
+    // The pre-render is an optimisation, not a requirement: when the PDFium
+    // worker pool hasn't finished spawning (cold start via file association),
+    // it would fall back to an in-process parse in the main process while
+    // PDF.js parses the same bytes — on large documents that doubles peak
+    // memory during boot and can take the whole load down. Skip it then.
+    let _poolReady = false;
     if (filePath && isTauri() && !_skipPre) {
+      try { _poolReady = await invoke('worker_pool_ready'); } catch { _poolReady = false; }
+      if (!_poolReady) console.log('[prog-guard] worker pool not ready → cold-open pre-render skipped');
+    }
+    if (filePath && isTauri() && !_skipPre && _poolReady) {
       const { renderPdfPage: _renderPdfPage } = await import('./engine-router.js');
       _renderPdfPage({
         path: filePath,

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -1572,6 +1572,18 @@ fn render_pdf_page_skia(
     Ok(tauri::ipc::Response::new(out))
 }
 
+/// Whether the PDFium worker pool has finished spawning. Lets the frontend
+/// skip optional work (e.g. the cold-open pre-render) that would otherwise
+/// fall back to an in-process PDFium parse in the main process — on a large
+/// document that fallback runs concurrently with the PDF.js parse of the
+/// same bytes and can take the whole load down at startup.
+#[tauri::command]
+fn worker_pool_ready(
+    pool: tauri::State<'_, std::sync::Arc<tokio::sync::OnceCell<worker_pool::WorkerPool>>>,
+) -> bool {
+    pool.get().is_some()
+}
+
 #[tauri::command]
 async fn render_pdf_page(
     path: String,
@@ -2552,6 +2564,7 @@ pub fn run(opts: StartupOpts) {
             uninstall_plugin,
             read_plugin_file,
             render_pdf_page,
+            worker_pool_ready,
             render_pdf_page_region,
             render_tile_scene_region,
             page_content_size,


### PR DESCRIPTION
The page-1 pre-render fires on every launch. On a cold start via file
association, the PDFium worker pool is still spawning, so the pre-render fell
back to a slower in-process path (or blocked) before the pool was ready — the
optimisation actually hurt the cold-open it was meant to speed up.

Add a small `worker_pool_ready` command and gate the pre-render on it: skip the
pre-render when the pool hasn't finished spawning (it's an optimisation, not a
requirement — the normal render path still runs). Warm opens are unchanged.
