### PR TITLE
release: Open PDF Studio 1.79.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       version:
         description: 'Version tag (e.g., v1.0.0)'
         required: true
-        default: 'v1.78.0'
+        default: 'v1.79.0'
 
 jobs:
   create-release:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "open-pdf-studio"
-version = "1.78.0"
+version = "1.79.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/open-pdf-studio/package-lock.json
+++ b/open-pdf-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-pdf-studio",
-      "version": "1.78.0",
+      "version": "1.79.0",
       "license": "MIT",
       "dependencies": {
         "@crabnebula/tauri-plugin-drag": "^2.1.0",

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-pdf-studio",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "A free, open-source PDF annotation editor built with Tauri",
   "scripts": {
     "prepare:native-runtime": "node scripts/native-runtime.mjs",

--- a/open-pdf-studio/scripts/release-config.test.mjs
+++ b/open-pdf-studio/scripts/release-config.test.mjs
@@ -207,7 +207,7 @@ test('release workflows compile macOS once and retry only the bundle phase', asy
   }
 });
 
-test('all release metadata targets version 1.78.0', async () => {
+test('all release metadata targets version 1.79.0', async () => {
   const pkg = await readJson('package.json');
   const packageLock = await readJson('package-lock.json');
   const config = await readJson('src-tauri/tauri.conf.json');
@@ -215,13 +215,13 @@ test('all release metadata targets version 1.78.0', async () => {
   const release = await readFile(path.join(repoDir, '.github', 'workflows', 'release.yml'), 'utf8');
   const cargoLock = await readFile(path.join(repoDir, 'Cargo.lock'), 'utf8');
 
-  assert.equal(pkg.version, '1.78.0');
-  assert.equal(packageLock.version, '1.78.0');
-  assert.equal(packageLock.packages[''].version, '1.78.0');
-  assert.equal(config.version, '1.78.0');
-  assert.match(cargo, /^version = "1\.78\.0"$/m);
-  assert.match(release, /default: 'v1\.78\.0'/);
-  assert.match(cargoLock, /name = "open-pdf-studio"\r?\nversion = "1\.78\.0"/);
+  assert.equal(pkg.version, '1.79.0');
+  assert.equal(packageLock.version, '1.79.0');
+  assert.equal(packageLock.packages[''].version, '1.79.0');
+  assert.equal(config.version, '1.79.0');
+  assert.match(cargo, /^version = "1\.79\.0"$/m);
+  assert.match(release, /default: 'v1\.79\.0'/);
+  assert.match(cargoLock, /name = "open-pdf-studio"\r?\nversion = "1\.79\.0"/);
 });
 
 test('development optimization profiles live at the workspace root', async () => {

--- a/open-pdf-studio/src-tauri/Cargo.lock
+++ b/open-pdf-studio/src-tauri/Cargo.lock
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "open-pdf-studio"
-version = "1.58.4"
+version = "1.79.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/open-pdf-studio/src-tauri/Cargo.toml
+++ b/open-pdf-studio/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-pdf-studio"
-version = "1.78.0"
+version = "1.79.0"
 description = "A free, open-source PDF annotation editor"
 authors = ["OpenAEC Foundation"]
 license = "MIT"

--- a/open-pdf-studio/src-tauri/tauri.conf.json
+++ b/open-pdf-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Open PDF Studio",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "identifier": "org.openaec.openpdfstudio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Wijzigingen

- verhoogt npm-, Tauri- en Cargo-versies naar `1.79.0`
- synchroniseert beide Cargo-lockfiles
- zet de standaard release-workflowinvoer op `v1.79.0`

## Validatie

- `git diff --check`
- versieconsistentie over alle zeven releasebronnen
- `cargo metadata --no-deps --format-version 1`
- `npm run build` (1045 modules, exitcode 0)

Na merge wordt tag `v1.79.0` geplaatst zodat de ondertekende platformbuilds via GitHub Actions worden gemaakt.