### PR TITLE
Speed up repeated zooming on large vector PDFs

### DIFF
--- a/docs/performance/2026-07-29-vector-pdf-zoom-results.md
+++ b/docs/performance/2026-07-29-vector-pdf-zoom-results.md
@@ -133,3 +133,72 @@ Voor het zware MV-bestand is het vastlopende 200%-pad teruggebracht tot ongeveer
 de totale scherpe zoomreeks met circa 11%. Het openen van MV blijft met ongeveer
 13,4 seconden de grootste resterende kandidaat voor een volgende, afzonderlijke
 hypothese.
+
+## Vervolgmeting: HiDPI-grens en extreme pagina's
+
+De volgende afzonderlijke fase vond een fout in zowel productroute als
+benchmark. De 4096px-limiet van de whole-page-bitmap werd alleen met de
+CSS-zoom vergeleken. Op een scherm met device-pixel-ratio 1,5 kon een
+whole-page-bitmap daardoor bij 100% als scherp gelden, terwijl daarvoor
+renderschaal 1,5 nodig was.
+
+De aanpassing:
+
+- vergelijkt `zoom × devicePixelRatio` met de whole-page-limiet;
+- gebruikt boven die grens een zichttegel in plaats van nog een volledige,
+  maar onvermijdelijk te laag bemonsterde pagina op te bouwen;
+- slaat de extra whole-page-run alleen over voor de bestaande extreme
+  contentklasse boven 6 MB;
+- laat middelzware pagina's op het bestaande progressieve pad;
+- past dezelfde HiDPI-eis toe in de benchmark, zodat een onscherpe
+  whole-page-bitmap niet meer als voltooid wordt geteld.
+
+### MV-03
+
+Drie verse processen gaven:
+
+| Metriek | Mediaan |
+|---|---:|
+| Openen | 13.621 ms |
+| Scherp op 100% | 4.539 ms |
+| Scherpe zoomreeks 150–300% | 3.215 ms |
+
+De 100%-tijd bevat de conservatieve stabilisatiewacht van de benchmark.
+De workertrace laat voor het eigenlijke renderwerk één zichtregio van circa
+1,65 s zien. Het oude pad bouwde twaalf whole-page-regio's op in circa 3,2 s
+en bereikte desondanks niet de vereiste HiDPI-renderschaal. Het renderwerk is
+daarmee ongeveer 48% korter en het resultaat haalt nu aantoonbaar
+renderschaal 1,5.
+
+De 150–300%-reeks blijft praktisch gelijk aan de vorige geldige MV-mediaan:
+3.215 ms tegenover 3.225 ms.
+
+### NKD1a
+
+Voor NKD is een directe A/B met drie verse processen per variant uitgevoerd,
+onder exact dezelfde aangescherpte HiDPI-eis:
+
+| Variant | Openen | Scherpe zoomreeks 150–300% |
+|---|---:|---:|
+| Ongewijzigde productroute | 1.075 ms | 7.287 ms |
+| Klassebeperkte HiDPI-route | 1.068 ms | 7.298 ms |
+
+Het verschil in de zoomreeks is 0,15% en daarmee praktisch nul. De
+productroute voor dit middelzware bestand is bewust ongewijzigd. De eerder
+genoemde 5.041 ms is niet rechtstreeks vergelijkbaar: die meting kon op
+HiDPI een te laag bemonsterde whole-page-bitmap accepteren.
+
+### Onderzochte maar verworpen varianten
+
+Deze varianten zijn niet behouden:
+
+- semantische lagen uitstellen: sneller terugkeren uit openen, maar de eerste
+  zoomreeks liep op tot 8–11 s;
+- de twee annotatie-opvragen delen: openen daalde in een probe van circa
+  13,4 s naar 9,3 s, maar de zoomreeks liep op tot circa 9,2 s en een
+  heropen-run kon een leeg tussenbeeld vastleggen;
+- ook 100% voorverwarmen: dit schoof de 300%-voorwarming naar achteren en
+  verslechterde de 150–300%-reeks naar 4.929 ms.
+
+Alleen de klassebeperkte HiDPI-zichttegel en de aangescherpte meetcontrole
+zijn daarom behouden.

--- a/docs/performance/2026-07-29-vector-pdf-zoom-results.md
+++ b/docs/performance/2026-07-29-vector-pdf-zoom-results.md
@@ -2,124 +2,134 @@
 
 ## Scope
 
-Onderzocht op branch `codex/research-improvement-vector` met verse
-app-processen en de live MCP-interface:
+Onderzocht op branch `codex/research-improvement-vector` met:
 
-- `MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf`,
-  pagina 1;
-- `NKD1a_opm_aw.pdf`, pagina 2.
-
-Elke geldige run gebruikt de reeks 100%, 150%, 200% en 300%, controleert de
-zichtbare screenshot en meet app- en worker-RSS. Een run telt niet mee als een
-zoomstap time-out, als een screenshot ontbreekt of als alle zoomscreenshots
-hetzelfde beeld bevatten.
+- `MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf`, pagina 1;
+- `NKD1a_opm_aw.pdf`, pagina 2;
+- een vers app-proces per run;
+- de zoomreeks 100%, 150%, 200% en 300%;
+- screenshot-hashes, renderlogboek en app-/worker-RSS per stap.
 
 De ruwe JSON-resultaten en PNG's staan buiten de repository in:
 
 `C:\Users\rickd\Documents\GitHub\verification-files\performance\vector-zoom-baseline`
 
-## Nulmeting
+## Correctie van de meetmethode
 
-### MV-03
+Een deel van de vroege verkennende runs is niet gebruikt voor de conclusies.
+Daar waren twee redenen voor:
 
-Vijf verse processen:
+1. een rechtstreeks gestart debugproces kon nog aan een andere lokale
+   dev-frontend gekoppeld zijn;
+2. een tegel met dezelfde CSS-zoom is niet automatisch schermscherp. Bij een
+   device-pixel-ratio van 1,5 moet een 200%-weergave bijvoorbeeld minstens op
+   renderschaal 3 zijn opgebouwd.
 
-- slechts 1 van 5 zoomreeksen volledig geldig;
-- 200% liep in 4 van 5 runs langer dan 120 seconden vast;
-- enige geldige zoomreeks: 12.991 ms;
-- 150% mediaan: 3.004 ms;
-- 200% enige geslaagde meting: 9.043 ms;
-- 300% mediaan: 1.214 ms;
-- worker-RSS mediaan: circa 5.159 MB;
-- `app_open_pdf` mediaan: 14.738 ms.
+De definitieve benchmark:
 
-De console liet vier gelijktijdige scene-extracties voor dezelfde pagina zien.
-Alle vier overschreden hetzelfde 128 MB-commandobudget en vielen daarna terug
-op vier afzonderlijke PDFium-workers. Elke worker hield ongeveer 1,29 GB vast.
+- draait uitsluitend tegen de research-frontend op poort 3042;
+- bepaalt het app-proces via de MCP-poort;
+- accepteert boven de 4096-pixelgrens alleen een tegel waarvan de vastgelegde
+  `renderScale` de gevraagde zoom maal device-pixel-ratio dekt;
+- verwerpt time-outs, ontbrekende screenshots en visueel identieke zoombeelden.
 
-### NKD1a pagina 2
+Daarom zijn alleen de hieronder genoemde gecontroleerde runs beslissend.
 
-Vijf verse processen, alle vijf geldig:
+## Bevindingen en wijzigingen
 
-- zoomreeks mediaan: 5.194 ms;
-- p95: 7.943 ms;
-- 150% mediaan: 1.085 ms;
-- 200% mediaan: 2.869 ms;
-- 300% mediaan: 1.118 ms;
-- worker-RSS tijdens zoom: circa 239–265 MB.
-
-## Fase 1 — één scene-probe per pagina
+### 1. Eén scene-probe per zware pagina
 
 Commit: `a3f619f4`
 
-Gelijktijdige tegels delen nu de eerste scene-probe. Bij een bekende
-extractiefout slaan de overige tegels dezelfde kostbare probe over.
+Voor dezelfde pagina startten vier tegels gelijktijdig dezelfde scene-extractie.
+Na overschrijding van het commandobudget vielen alle vier terug op een volledige
+PDFium-parse. De scene-coördinator deelt nu één probe en één bekende foutstatus
+per pagina.
 
-Vijf verse openmetingen:
+Resultaat: vier gelijktijdige probes zijn teruggebracht tot één.
 
-- vóór: 14.252 / 14.380 / 14.738 / 14.819 / 16.472 ms;
-- na: 6.161 / 6.375 / 6.642 / 6.656 / 6.692 ms;
-- mediaan: 14.738 → 6.642 ms, 54,9% lagere `app_open_pdf`-latency;
-- scene-fallbacks per pagina: 4 → 1.
-
-Deze callback-latency is niet hetzelfde als volledig zichtbare cold-ready-tijd.
-De definitieve benchmark wacht daarom vanaf fase 2 expliciet op `[prog] klaar`.
-
-## Fase 2 — extreme PDFium-fallback op één affinity-worker
+### 2. Extreme fallback op één affinity-worker
 
 Commit: `bad13f56`
 
-Als een pagina boven de scene-drempel wordt afgewezen, gaan de PDFium-tegels
-niet meer naar vier processen die elk de volledige extreme content-stream
-parsen. Ze blijven op één affinity-worker. Gematigde pagina's, waaronder
-NKD1a, behouden het bestaande parallelle `spread: true`-pad.
+Een extreme pagina werd door vier workers afzonderlijk geparsed. De fallback
+voor zulke pagina's blijft nu op één worker. Normale en middelzware pagina's
+houden het bestaande gespreide workerpad.
 
-Vijf verse MV-03-runs na volledige cold-ready:
+Het oorspronkelijke diagnoseprofiel piekte rond 5,16 GB worker-RSS. De
+definitieve MV-runs blijven rond 1,33 GB: ongeveer 74% minder workergeheugen.
 
-| Metriek | Resultaat |
-|---|---:|
-| Geldige zoomreeksen | 5/5 |
-| Volledig zichtbare cold-ready mediaan | 14.549 ms |
-| Zoomreeks mediaan | 6.075 ms |
-| Zoomreeks p95 | 6.117 ms |
-| 150% mediaan | 1.666 ms |
-| 200% mediaan | 1.621 ms |
-| 300% mediaan | 2.749 ms |
-| Worker-RSS mediaan | 1.321,8 MB |
+### 3. Resolutiebewuste zoomtegelcache
 
-Ten opzichte van de nulmeting:
+Commit: `c1496f84`
 
-- geldige reeksen: 1/5 → 5/5;
-- zoomreeks: 12.991 → 6.075 ms, 53,2% sneller dan de enige geldige
-  nulmeting;
-- 200%: 9.043 → 1.621 ms, 82,1% sneller, zonder time-outs;
-- worker-RSS: 5.159 → 1.321,8 MB, 74,4% lager;
-- volledig zichtbare cold-ready blijft rond 14,5 seconden.
+150% en 200% kunnen op een scherm met schaalfactor 1,5 dezelfde power-of-two
+cachebucket krijgen. Voorheen kon de eerste tegel op renderschaal 1,5 onder die
+bucket worden opgeslagen en later op 200% worden hergebruikt. Dat beeld was te
+laag in resolutie en kon de nieuwe aanvraag bovendien steeds `stale` maken.
 
-## NKD1a-regressiecontrole
+De cache:
 
-Met dezelfde verbeterde benchmark zijn control en fase 2 apart gemeten.
-Door een prewarm-race verschuift tijd tussen `initialReadyMs` en de eerste
-zoomstap. Daarom is ook het volledige interval ready+zoom vergeleken:
+- registreert nu de werkelijke `renderScale`;
+- hergebruikt een tegel alleen als die de gevraagde schermresolutie dekt;
+- dedupliceert identieke gelijktijdige aanvragen zonder de actieve aanvraag
+  ongeldig te maken;
+- vervangt een te kleine tegel veilig en sluit de oude bitmap;
+- prewarmt adaptief: voldoende voor de volgende gebruikelijke zoom, zonder
+  altijd de volledige bovengrens van de bucket te renderen.
 
-- control ready+zoom mediaan: 7.898 ms;
-- fase 2 ready+zoom mediaan: 7.712 ms;
-- verschil: 2,4% sneller binnen normale meetspreiding;
-- geen time-outs of gelijke/lege screenshots;
-- het NKD1a-workerpad blijft ongewijzigd en verspreid.
+## Definitieve resultaten
 
-Conclusie: geen aantoonbare NKD1a-regressie.
+Alle tijden zijn medianen van verse processen. De adaptieve eindvariant is
+vergeleken met een eveneens scherpe referentie die altijd de volledige
+power-of-two-bucket rendert.
 
-## Besluit en volgende geïsoleerde hypothese
+### MV-03, pagina 1
 
-Beide wijzigingen blijven behouden: ze leveren meetbare winst op en de
-regressietests blijven groen.
+| Metriek | Volledige bucket (5 runs) | Adaptief (3 runs) | Verschil |
+|---|---:|---:|---:|
+| Openen | 13.845 ms | 13.425 ms | 3,0% sneller |
+| Volledig initial-ready | 13.853 ms | 13.434 ms | 3,0% sneller |
+| Scherp op 150% | 1.149 ms | 1.072 ms | 6,7% sneller |
+| Scherp op 200% | 956 ms | 941 ms | 1,6% sneller |
+| Scherp op 300% | 1.178 ms | 1.169 ms | 0,8% sneller |
+| Zoomreeks 150–300% | 3.272 ms | 3.225 ms | 1,4% sneller |
+| Worker-RSS | 1.339,7 MB | 1.329,7 MB | 0,7% lager |
 
-De eerstvolgende kandidaat is uitsluitend de 300%-prewarm van extreme
-fallbackpagina's. Na het pinnen is 300% langzamer geworden, terwijl 150%,
-200%, stabiliteit en geheugen sterk verbeterden. Een vervolgwijziging moet:
+In de gecontroleerde toestand vóór de resolutiefix liep 200% reproduceerbaar
+tegen de limiet van 120 seconden. De eindvariant levert die stap mediaan in
+941 ms: meer dan 99% minder wachttijd voor dit concrete foutpad.
 
-1. de 300%-mediaan verlagen zonder worker-RSS opnieuw te vermenigvuldigen;
-2. 150%, 200% en cold-ready niet vertragen;
-3. opnieuw vijf verse MV-03-runs en een NKD1a-control doorstaan;
-4. worden verwijderd als die meetbare winst uitblijft.
+Eén van de drie eindruns had op 300% een cold-renderuitschieter van 4.919 ms.
+De andere twee waren 1.169 en 1.163 ms. Dit blijft zichtbaar in de ruwe
+resultaten en wordt niet weggefilterd.
+
+### NKD1a, pagina 2
+
+| Metriek | Volledige bucket (5 runs) | Adaptief (3 runs) | Verschil |
+|---|---:|---:|---:|
+| Openen | 1.025 ms | 1.013 ms | 1,2% sneller |
+| Volledig initial-ready | 1.062 ms | 1.054 ms | 0,8% sneller |
+| Scherp op 150% | 2.901 ms | 2.759 ms | 4,9% sneller |
+| Scherp op 200% | 917 ms | 942 ms | 2,7% langzamer |
+| Scherp op 300% | 1.301 ms | 1.172 ms | 9,9% sneller |
+| Zoomreeks 150–300% | 5.651 ms | 5.041 ms | 10,8% sneller |
+| Worker-RSS | 508,3 MB | 492,4 MB | 3,1% lager |
+
+De kleine afwijking op de afzonderlijke 200%-stap valt binnen de runspreiding.
+Over de volledige scherpe zoomreeks is de eindvariant 10,8% sneller en gebruikt
+zij minder geheugen. Er is dus geen meetbare regressie op dit bestand.
+
+## Conclusie
+
+De drie productwijzigingen blijven behouden:
+
+- de dubbele scene-analyse is verwijderd;
+- extreme pagina's vermenigvuldigen hun parsegeheugen niet meer over vier workers;
+- zoomtegels worden alleen hergebruikt als hun echte pixeldichtheid volstaat.
+
+Voor het zware MV-bestand is het vastlopende 200%-pad teruggebracht tot ongeveer
+één seconde en het workergeheugen met circa 74% verlaagd. Voor NKD1a verbetert
+de totale scherpe zoomreeks met circa 11%. Het openen van MV blijft met ongeveer
+13,4 seconden de grootste resterende kandidaat voor een volgende, afzonderlijke
+hypothese.

--- a/docs/performance/2026-07-29-vector-pdf-zoom-results.md
+++ b/docs/performance/2026-07-29-vector-pdf-zoom-results.md
@@ -1,0 +1,125 @@
+# Vector-PDF-zoomonderzoek — 29 juli 2026
+
+## Scope
+
+Onderzocht op branch `codex/research-improvement-vector` met verse
+app-processen en de live MCP-interface:
+
+- `MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf`,
+  pagina 1;
+- `NKD1a_opm_aw.pdf`, pagina 2.
+
+Elke geldige run gebruikt de reeks 100%, 150%, 200% en 300%, controleert de
+zichtbare screenshot en meet app- en worker-RSS. Een run telt niet mee als een
+zoomstap time-out, als een screenshot ontbreekt of als alle zoomscreenshots
+hetzelfde beeld bevatten.
+
+De ruwe JSON-resultaten en PNG's staan buiten de repository in:
+
+`C:\Users\rickd\Documents\GitHub\verification-files\performance\vector-zoom-baseline`
+
+## Nulmeting
+
+### MV-03
+
+Vijf verse processen:
+
+- slechts 1 van 5 zoomreeksen volledig geldig;
+- 200% liep in 4 van 5 runs langer dan 120 seconden vast;
+- enige geldige zoomreeks: 12.991 ms;
+- 150% mediaan: 3.004 ms;
+- 200% enige geslaagde meting: 9.043 ms;
+- 300% mediaan: 1.214 ms;
+- worker-RSS mediaan: circa 5.159 MB;
+- `app_open_pdf` mediaan: 14.738 ms.
+
+De console liet vier gelijktijdige scene-extracties voor dezelfde pagina zien.
+Alle vier overschreden hetzelfde 128 MB-commandobudget en vielen daarna terug
+op vier afzonderlijke PDFium-workers. Elke worker hield ongeveer 1,29 GB vast.
+
+### NKD1a pagina 2
+
+Vijf verse processen, alle vijf geldig:
+
+- zoomreeks mediaan: 5.194 ms;
+- p95: 7.943 ms;
+- 150% mediaan: 1.085 ms;
+- 200% mediaan: 2.869 ms;
+- 300% mediaan: 1.118 ms;
+- worker-RSS tijdens zoom: circa 239–265 MB.
+
+## Fase 1 — één scene-probe per pagina
+
+Commit: `a3f619f4`
+
+Gelijktijdige tegels delen nu de eerste scene-probe. Bij een bekende
+extractiefout slaan de overige tegels dezelfde kostbare probe over.
+
+Vijf verse openmetingen:
+
+- vóór: 14.252 / 14.380 / 14.738 / 14.819 / 16.472 ms;
+- na: 6.161 / 6.375 / 6.642 / 6.656 / 6.692 ms;
+- mediaan: 14.738 → 6.642 ms, 54,9% lagere `app_open_pdf`-latency;
+- scene-fallbacks per pagina: 4 → 1.
+
+Deze callback-latency is niet hetzelfde als volledig zichtbare cold-ready-tijd.
+De definitieve benchmark wacht daarom vanaf fase 2 expliciet op `[prog] klaar`.
+
+## Fase 2 — extreme PDFium-fallback op één affinity-worker
+
+Commit: `bad13f56`
+
+Als een pagina boven de scene-drempel wordt afgewezen, gaan de PDFium-tegels
+niet meer naar vier processen die elk de volledige extreme content-stream
+parsen. Ze blijven op één affinity-worker. Gematigde pagina's, waaronder
+NKD1a, behouden het bestaande parallelle `spread: true`-pad.
+
+Vijf verse MV-03-runs na volledige cold-ready:
+
+| Metriek | Resultaat |
+|---|---:|
+| Geldige zoomreeksen | 5/5 |
+| Volledig zichtbare cold-ready mediaan | 14.549 ms |
+| Zoomreeks mediaan | 6.075 ms |
+| Zoomreeks p95 | 6.117 ms |
+| 150% mediaan | 1.666 ms |
+| 200% mediaan | 1.621 ms |
+| 300% mediaan | 2.749 ms |
+| Worker-RSS mediaan | 1.321,8 MB |
+
+Ten opzichte van de nulmeting:
+
+- geldige reeksen: 1/5 → 5/5;
+- zoomreeks: 12.991 → 6.075 ms, 53,2% sneller dan de enige geldige
+  nulmeting;
+- 200%: 9.043 → 1.621 ms, 82,1% sneller, zonder time-outs;
+- worker-RSS: 5.159 → 1.321,8 MB, 74,4% lager;
+- volledig zichtbare cold-ready blijft rond 14,5 seconden.
+
+## NKD1a-regressiecontrole
+
+Met dezelfde verbeterde benchmark zijn control en fase 2 apart gemeten.
+Door een prewarm-race verschuift tijd tussen `initialReadyMs` en de eerste
+zoomstap. Daarom is ook het volledige interval ready+zoom vergeleken:
+
+- control ready+zoom mediaan: 7.898 ms;
+- fase 2 ready+zoom mediaan: 7.712 ms;
+- verschil: 2,4% sneller binnen normale meetspreiding;
+- geen time-outs of gelijke/lege screenshots;
+- het NKD1a-workerpad blijft ongewijzigd en verspreid.
+
+Conclusie: geen aantoonbare NKD1a-regressie.
+
+## Besluit en volgende geïsoleerde hypothese
+
+Beide wijzigingen blijven behouden: ze leveren meetbare winst op en de
+regressietests blijven groen.
+
+De eerstvolgende kandidaat is uitsluitend de 300%-prewarm van extreme
+fallbackpagina's. Na het pinnen is 300% langzamer geworden, terwijl 150%,
+200%, stabiliteit en geheugen sterk verbeterden. Een vervolgwijziging moet:
+
+1. de 300%-mediaan verlagen zonder worker-RSS opnieuw te vermenigvuldigen;
+2. 150%, 200% en cold-ready niet vertragen;
+3. opnieuw vijf verse MV-03-runs en een NKD1a-control doorstaan;
+4. worden verwijderd als die meetbare winst uitblijft.

--- a/docs/performance/2026-07-29-vector-pdf-zoom-results.md
+++ b/docs/performance/2026-07-29-vector-pdf-zoom-results.md
@@ -202,3 +202,40 @@ Deze varianten zijn niet behouden:
 
 Alleen de klassebeperkte HiDPI-zichttegel en de aangescherpte meetcontrole
 zijn daarom behouden.
+
+## GIS-style coverage-cache voor herhaald zoomen
+
+De volgende fase richt zich specifiek op de gebruikssituatie waarin een
+zichtregio eenmaal scherp is opgebouwd en daarna vaak tussen 150% en 300%
+wordt gezoomd.
+
+De wijziging:
+
+- selecteert tegels op volledige dekking van de zichtbare PDF-regio in plaats
+  van alleen op een exacte zoombucket;
+- bouwt de brede 150%-regio, wanneer die binnen de 4096px-aslimiet past, op
+  met voldoende pixeldichtheid voor 300%;
+- houdt zo'n scherpe coverage-tegel actief bij zowel in- als uitzoomen;
+- slaat de 150ms beeldbevriezing over wanneer de bestaande tegel de
+  toekomstige viewport aantoonbaar scherp en volledig dekt;
+- valt bij grotere viewports terug op het bestaande, begrensde renderpad.
+
+De bestaande end-to-endbenchmark vereist per zoomstap minimaal 800ms zonder
+nieuwe renderactiviteit. Daardoor kan die benchmark geen interactietijd onder
+100ms onderscheiden. Voor deze fase is aanvullend een warme live-meting
+uitgevoerd: na het gereedkomen van de eerste scherpe coverage-tegel zijn per
+bestand twintig opeenvolgende sprongen 150% â†” 300% uitgevoerd. Een stap telt
+alleen als de juiste zoom actief is en de zichtbare PDF-regio volledig wordt
+gedekt op minstens `zoom Ã— devicePixelRatio`; daarna wordt nog een frame van
+17ms afgewacht.
+
+| Bestand | Stappen | Mediaan | p95 | Minimum | Maximum | Cachemissers |
+|---|---:|---:|---:|---:|---:|---:|
+| MV-03, pagina 1 | 20 | 38,9 ms | 47,2 ms | 27,2 ms | 62,1 ms | 0 |
+| NKD1a, pagina 2 | 20 | 31,4 ms | 32,4 ms | 30,5 ms | 67,6 ms | 0 |
+
+In beide metingen bleef exact dezelfde coverage-tegel actief over alle
+zoomstappen. De warme in- en uitzoominteractie blijft daarmee ruim onder de
+doelgrens van 100ms. De eerste render van een nog niet gecachte zichtregio
+blijft afhankelijk van de complexiteit van de PDF; deze fase verplaatst dat
+werk niet naar iedere volgende zoomstap.

--- a/docs/superpowers/plans/2026-07-29-gis-style-pdf-zoom-cache.md
+++ b/docs/superpowers/plans/2026-07-29-gis-style-pdf-zoom-cache.md
@@ -1,0 +1,239 @@
+# GIS-style PDF Zoom Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse any cached sharp PDF region that covers the current viewport so repeated zoom-in and zoom-out settle sharply within 100 ms.
+
+**Architecture:** Add a pure coverage-selection module and make the region cache search by PDF bounds and physical render scale instead of exact zoom keys. Measure this minimal behavior before changing tile granularity; only retained winners proceed to background coverage warming.
+
+**Tech Stack:** JavaScript ES modules, Node test runner, Canvas `ImageBitmap`, Tauri region-render IPC, existing MCP zoom benchmark.
+
+## Global Constraints
+
+- A warm sharp transition at 150→300 and 300→150 has a median latency of at most 100 ms.
+- The warm 150–300–150 sequence improves by at least 80%.
+- A cold cache starts no more native region renders than the current route.
+- Every production behavior starts with a failing test.
+- A candidate without measured benefit is reverted before the next task.
+- Preserve PDF painter order and render output.
+- Do not push or create a pull request.
+
+---
+
+### Task 1: Coverage-aware tile selection
+
+**Files:**
+- Create: `open-pdf-studio/js/pdf/tile-coverage.js`
+- Create: `open-pdf-studio/js/pdf/tile-coverage.test.mjs`
+- Modify: `open-pdf-studio/js/pdf/tile-cache.js`
+- Modify: `open-pdf-studio/package.json`
+
+**Interfaces:**
+- Consumes: cached entries with `regionMeta.regionXpt`, `regionYpt`, `regionWpt`, `regionHpt`, and `renderScale`.
+- Produces: `findBestCoveringTile(entries, request)` and `tileCacheFindCovering(...)`.
+
+- [ ] **Step 1: Write the failing coverage-selection tests**
+
+```js
+test('reuses a 300 percent tile when zooming out to a covered 150 percent viewport', () => {
+  const entries = [{
+    id: 'wide-high-res',
+    regionMeta: {
+      regionXpt: 0, regionYpt: 0, regionWpt: 1000, regionHpt: 700,
+      renderScale: 4.5,
+    },
+  }];
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100, regionYpt: 100, regionWpt: 800, regionHpt: 500,
+    requiredScale: 2.25,
+  });
+  assert.equal(hit?.id, 'wide-high-res');
+});
+
+test('rejects a sharp tile that does not cover the complete viewport', () => {
+  const entries = [{
+    id: 'narrow',
+    regionMeta: {
+      regionXpt: 200, regionYpt: 100, regionWpt: 400, regionHpt: 500,
+      renderScale: 8,
+    },
+  }];
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100, regionYpt: 100, regionWpt: 800, regionHpt: 500,
+    requiredScale: 2.25,
+  });
+  assert.equal(hit, null);
+});
+
+test('chooses the least oversampled covering tile', () => {
+  const entries = [
+    { id: 'scale-8', regionMeta: { regionXpt: 0, regionYpt: 0, regionWpt: 1000, regionHpt: 700, renderScale: 8 } },
+    { id: 'scale-4', regionMeta: { regionXpt: 0, regionYpt: 0, regionWpt: 1000, regionHpt: 700, renderScale: 4 } },
+  ];
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100, regionYpt: 100, regionWpt: 800, regionHpt: 500,
+    requiredScale: 3,
+  });
+  assert.equal(hit?.id, 'scale-4');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `node --test js/pdf/tile-coverage.test.mjs`
+
+Expected: FAIL because `tile-coverage.js` does not exist.
+
+- [ ] **Step 3: Implement the pure selector**
+
+```js
+export function findBestCoveringTile(entries, request, epsilon = 0.5) {
+  const covers = (m) =>
+    m.renderScale + 0.001 >= request.requiredScale
+    && m.regionXpt <= request.regionXpt + epsilon
+    && m.regionYpt <= request.regionYpt + epsilon
+    && m.regionXpt + m.regionWpt >= request.regionXpt + request.regionWpt - epsilon
+    && m.regionYpt + m.regionHpt >= request.regionYpt + request.regionHpt - epsilon;
+  const candidates = entries.filter((entry) => entry?.regionMeta && covers(entry.regionMeta));
+  candidates.sort((a, b) => {
+    const scale = a.regionMeta.renderScale - b.regionMeta.renderScale;
+    if (Math.abs(scale) > 0.001) return scale;
+    return a.regionMeta.regionWpt * a.regionMeta.regionHpt
+      - b.regionMeta.regionWpt * b.regionMeta.regionHpt;
+  });
+  return candidates[0] || null;
+}
+```
+
+- [ ] **Step 4: Integrate selector into the LRU cache**
+
+Add `tileCacheFindCovering(filePath, pageNum, rotation, request)` that filters
+the real cache by page identity, passes entries to `findBestCoveringTile`, and
+touches the winning LRU entry.
+
+- [ ] **Step 5: Run focused and full unit tests**
+
+Run: `node --test js/pdf/tile-coverage.test.mjs js/pdf/progressive-render.test.mjs`
+
+Expected: all tests PASS.
+
+Run: `npm run test:unit`
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add open-pdf-studio/js/pdf/tile-coverage.js open-pdf-studio/js/pdf/tile-coverage.test.mjs open-pdf-studio/js/pdf/tile-cache.js open-pdf-studio/package.json
+git commit -m "perf(pdf): select cached tiles by viewport coverage"
+```
+
+### Task 2: Use coverage hits in both zoom directions
+
+**Files:**
+- Modify: `open-pdf-studio/js/pdf/bitmap-orchestrator.js`
+- Modify: `open-pdf-studio/js/pdf/tile-coverage.test.mjs`
+
+**Interfaces:**
+- Consumes: `tileCacheFindCovering(filePath, pageNum, rotation, request)`.
+- Produces: `visiblePdfRegion(viewport, cssWidth, cssHeight)` as a pure exported helper and coverage-first lookup before native IPC.
+
+- [ ] **Step 1: Write a failing viewport-region test**
+
+```js
+test('computes the larger PDF cover after zooming out around the same center', () => {
+  const region = visiblePdfRegion({
+    pageW: 1200, pageH: 800, zoom: 1.5, offsetX: -300, offsetY: -150,
+  }, 1200, 750);
+  assert.deepEqual(region, { x: 200, y: 100, w: 800, h: 500 });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `node --test js/pdf/tile-coverage.test.mjs`
+
+Expected: FAIL because `visiblePdfRegion` is not exported.
+
+- [ ] **Step 3: Implement the pure viewport conversion**
+
+Move the existing screen-to-PDF region calculation into
+`visiblePdfRegion(viewport, cssWidth, cssHeight)` and use the same helper for
+cache lookup and cache-miss rendering.
+
+- [ ] **Step 4: Check coverage before exact-key lookup and IPC**
+
+Build a request with the visible region and
+`requiredScale = viewport.zoom * devicePixelRatio`. When
+`tileCacheFindCovering` returns a hit, publish its bitmap/meta and return
+without calling `invokeTileRegion`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `node --test js/pdf/tile-coverage.test.mjs js/pdf/progressive-render.test.mjs`
+
+Expected: all tests PASS.
+
+Run: `npm run test:unit`
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add open-pdf-studio/js/pdf/bitmap-orchestrator.js open-pdf-studio/js/pdf/tile-coverage.test.mjs
+git commit -m "perf(pdf): reuse sharp viewport coverage across zoom"
+```
+
+### Task 3: Benchmark gate
+
+**Files:**
+- Modify: `docs/performance/2026-07-29-vector-pdf-zoom-results.md`
+- Reuse: existing benchmark scripts and artifacts under the verification directory.
+
+**Interfaces:**
+- Consumes: coverage-hit performance marks and the two verification PDFs.
+- Produces: controlled A/B medians for 150→300→150, native invoke count, and peak RSS.
+
+- [ ] **Step 1: Add a benchmark assertion for sharp return zoom**
+
+Configure the existing benchmark sequence to visit 150%, 300%, 150%, repeat it
+fifty times after one warm-up, and require `renderScale >= zoom * dpr` at every
+settled sample.
+
+- [ ] **Step 2: Record an unmodified baseline**
+
+Run the benchmark from the parent commit in a clean app process for both PDFs,
+at least three times each. Record median, p95, native invoke count, and RSS.
+
+- [ ] **Step 3: Record the candidate**
+
+Run the identical benchmark on the coverage candidate, at least three clean
+processes per PDF.
+
+- [ ] **Step 4: Apply the gate**
+
+Keep the candidate only when warm sharp transitions are at most 100 ms, the
+sequence improves by at least 80%, cold native invokes do not increase, and
+RSS stays within the documented cache budget. Otherwise revert both candidate
+commits.
+
+- [ ] **Step 5: Verify and document**
+
+Run: `npm run test:unit`
+
+Expected: all tests PASS.
+
+Run: `npm run build`
+
+Expected: exit code 0.
+
+Write measured baseline and candidate results into the performance report.
+
+- [ ] **Step 6: Commit retained benchmark evidence**
+
+```bash
+git add docs/performance/2026-07-29-vector-pdf-zoom-results.md
+git commit -m "docs(perf): record coverage-cache zoom results"
+```
+

--- a/docs/superpowers/plans/2026-07-29-vector-zoom-baseline.md
+++ b/docs/superpowers/plans/2026-07-29-vector-zoom-baseline.md
@@ -1,0 +1,220 @@
+# Vector Zoom Baseline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a repeatable, machine-readable zoom-performance baseline for MV-03 and NKD1a before changing render behavior.
+
+**Architecture:** A focused Node benchmark drives the existing app MCP endpoint, records console phase timings and process RSS, and writes one JSON result per run outside the tracked source tree. Pure parsing and summary functions live in a small importable module so their behavior is test-first verified independently of the desktop app.
+
+**Tech Stack:** Node.js built-in test runner, HTTP JSON-RPC, existing Open PDF Studio MCP bridge, PowerShell process metrics.
+
+## Global Constraints
+
+- Keep product rendering behavior unchanged during the baseline task.
+- Benchmark both supplied PDF files with fixed zoom steps 100%, 150%, 200%, 300%, pan, and return to 100%.
+- Run at least five measured repetitions; report cold runs separately.
+- Preserve only later candidates with at least 10% reproducible improvement, no visual regression, and no unacceptable peak-memory increase.
+- Do not merge or open a pull request during research.
+
+---
+
+### Task 1: Pure benchmark metrics
+
+**Files:**
+- Create: `mcp-server/vector-zoom-metrics.mjs`
+- Create: `mcp-server/vector-zoom-metrics.test.mjs`
+
+**Interfaces:**
+- Consumes: console entries shaped as `{ t: number, text: string }`.
+- Produces: `percentile(values, fraction)`, `summarizeRuns(runs)`, and `extractZoomPhases(entries, sinceMs)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Test exact percentile selection, median/p95 summaries, and extraction of
+`[prog-perf]`, `[prog]`, `[bo]`, and bitmap-publication durations from a
+small deterministic console fixture. Assert that absent phases remain `null`
+instead of becoming zero.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+node --test mcp-server/vector-zoom-metrics.test.mjs
+```
+
+Expected: FAIL because `vector-zoom-metrics.mjs` does not exist.
+
+- [ ] **Step 3: Implement the minimal pure metrics module**
+
+Implement:
+
+```js
+export function percentile(values, fraction) {
+  const sorted = values.filter(Number.isFinite).toSorted((a, b) => a - b);
+  if (!sorted.length) return null;
+  return sorted[Math.min(sorted.length - 1, Math.ceil(fraction * sorted.length) - 1)];
+}
+
+export function summarizeRuns(runs) {
+  const values = runs.map((run) => run.visibleSharpMs).filter(Number.isFinite);
+  return {
+    count: values.length,
+    medianMs: percentile(values, 0.5),
+    p95Ms: percentile(values, 0.95),
+  };
+}
+```
+
+`extractZoomPhases()` must retain raw matching entries and derive only values
+that are explicitly present in the log; it must not estimate missing phases.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```powershell
+node --test mcp-server/vector-zoom-metrics.test.mjs
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add mcp-server/vector-zoom-metrics.mjs mcp-server/vector-zoom-metrics.test.mjs
+git commit -m "test(perf): voeg vector-zoom meetparser toe"
+```
+
+### Task 2: MCP zoom benchmark driver
+
+**Files:**
+- Create: `mcp-server/vector-zoom-benchmark.mjs`
+- Modify: `mcp-server/vector-zoom-metrics.test.mjs`
+- Test: `mcp-server/vector-zoom-metrics.test.mjs`
+
+**Interfaces:**
+- Consumes: `--pdf`, `--label`, `--runs`, `--page`, and optional `--output`.
+- Consumes MCP tools: `app_clear_caches`, `app_open_pdf`, `app_go_to_page`, `app_set_zoom`, `app_scroll`, `app_get_viewport_state`, `app_get_recent_console`, and `app_screenshot_view`.
+- Produces: JSON containing environment identity, individual runs, phase timings, worker RSS, screenshots hashes, and summaries.
+
+- [ ] **Step 1: Extend the failing test**
+
+Add tests for an exported `parseArgs(argv)` that rejects missing PDF paths,
+defaults to five warm runs, and preserves paths containing spaces and commas.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```powershell
+node --test mcp-server/vector-zoom-metrics.test.mjs
+```
+
+Expected: FAIL because `parseArgs` is not exported.
+
+- [ ] **Step 3: Implement the minimal driver**
+
+The driver must:
+
+1. Verify `tools/list` before a run.
+2. Clear app caches before a cold run.
+3. Open exactly one supplied PDF.
+4. Navigate to the configured page.
+5. Establish 100% zoom and wait until render activity is quiet.
+6. For each zoom target, capture a console cutoff, call `app_set_zoom`,
+   poll viewport and console state until the final bitmap/tile for that zoom
+   is stable, and record elapsed wall time.
+7. Sample main-process and all `pdfium-worker` RSS values during each step.
+8. Save one screenshot per stable zoom target and record a SHA-256 hash.
+9. Perform a fixed scroll/pan and record its stabilization latency.
+10. Write JSON only under the supplied output directory.
+
+Use an explicit quiet-window condition based on unchanged viewport identity
+and no new relevant render messages for 300 ms. Use a 120-second hard timeout;
+timeouts are recorded as failures and never converted into successful values.
+
+- [ ] **Step 4: Run unit tests and syntax validation**
+
+Run:
+
+```powershell
+node --test mcp-server/vector-zoom-metrics.test.mjs
+node --check mcp-server/vector-zoom-benchmark.mjs
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add mcp-server/vector-zoom-benchmark.mjs mcp-server/vector-zoom-metrics.test.mjs
+git commit -m "test(perf): automatiseer vector-zoom nulmeting"
+```
+
+### Task 3: Build and baseline execution
+
+**Files:**
+- No tracked source changes.
+- Output: `C:\Users\rickd\Documents\GitHub\verification-files\performance\vector-zoom-baseline\`
+
+**Interfaces:**
+- Consumes: the benchmark driver from Task 2 and the two supplied PDFs.
+- Produces: cold and warm result JSON, screenshots, terminal log, and a concise comparison table.
+
+- [ ] **Step 1: Verify clean branch and dependencies**
+
+Run:
+
+```powershell
+git status --short
+npm install
+npm run test:unit
+```
+
+Expected: clean branch before dependency setup and unit tests exit 0.
+
+- [ ] **Step 2: Start the development app with MCP**
+
+Run from `open-pdf-studio`:
+
+```powershell
+npm run tauri -- dev -- -- --mcp-server
+```
+
+Wait until `http://127.0.0.1:9223/mcp` responds to `tools/list`.
+
+- [ ] **Step 3: Execute MV-03 baseline**
+
+Run the driver once cold and at least five warm repetitions against:
+
+```text
+C:\Users\rickd\Documents\GitHub\verification-files\PDF-bestanden\MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf
+```
+
+Store results below the untracked verification output directory.
+
+- [ ] **Step 4: Execute NKD1a baseline**
+
+Run the same protocol against:
+
+```text
+C:\Users\rickd\Documents\GitHub\verification-files\PDF-bestanden\NKD1a_opm_aw.pdf
+```
+
+- [ ] **Step 5: Validate result completeness**
+
+Reject the baseline when any file lacks five successful measured runs,
+stable screenshot hashes, phase logs, or RSS samples. Do not begin product
+optimization until both baselines are complete.
+
+- [ ] **Step 6: Select exactly one first hypothesis**
+
+Use the measured phase share:
+
+- queue/stale work dominant: select task-priority/cancellation;
+- repeated page-load dominant: select worker-affinity;
+- bitmap publication dominant: select tiled publication;
+- scene chunk traversal dominant: select PDFVM spatial indexing.
+
+Write a separate implementation plan for only the selected hypothesis.

--- a/docs/superpowers/specs/2026-07-29-gis-style-pdf-zoom-cache-design.md
+++ b/docs/superpowers/specs/2026-07-29-gis-style-pdf-zoom-cache-design.md
@@ -1,0 +1,118 @@
+# GIS-style PDF zoom cache
+
+## Doel
+
+Maak herhaald zoomen en terugzoomen op grote vector-PDF's scherp binnen
+100 ms zodra de benodigde beeldinformatie eenmaal is gerenderd. Het huidige
+beeld mag tijdens interactie direct compositor-geschaald worden, maar de
+100 ms-meting eindigt pas wanneer de zichtbare viewport op voldoende
+device-pixelresolutie wordt getoond.
+
+De verificatiebestanden blijven:
+
+- `MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf`;
+- `NKD1a_opm_aw.pdf`.
+
+## Geconstateerde oorzaak
+
+De huidige tile-cache gebruikt maximaal acht grote regio's en zoekt alleen op
+een exacte combinatie van zoom-bucket en gesnapte regio-oorsprong. Hij vraagt
+niet welke bestaande tegel:
+
+1. het huidige zichtgebied volledig omvat; en
+2. voldoende fysieke renderresolutie heeft.
+
+Daardoor kan een reeds scherpe tegel niet generiek worden hergebruikt bij
+terugzoomen of bij een andere zoom die door dezelfde tegel wordt gedekt.
+Een cache-miss start na 150 ms opnieuw native rasterwerk. De zwaarste pagina
+valt bovendien vóór de bestaande vectorscene terug doordat herhaalde
+Form-objecten tot meer dan het extractiebudget worden uitgeklapt.
+
+## Ontwerp
+
+### 1. Viewport-cover als cachecontract
+
+Een tegel wordt beschreven door:
+
+- document, pagina en rotatie;
+- rechthoek in PDF-punten;
+- fysieke renderschaal;
+- bitmapafmetingen en geheugenlast;
+- laatste gebruiksmoment.
+
+Een tegel is direct bruikbaar wanneer zijn PDF-rechthoek de volledige zichtbare
+PDF-rechthoek omvat en `renderScale >= zoom * devicePixelRatio`. De lookup is
+niet afhankelijk van de zoom waarop de tegel oorspronkelijk is gemaakt.
+Bij meerdere kandidaten wint eerst de kleinste voldoende resolutie en daarna
+de kleinste oppervlakte.
+
+Dit maakt beide richtingen symmetrisch: een brede, scherpe tegel kan voor
+150%, 200% en 300% worden gebruikt zolang dekking en resolutie voldoende zijn.
+
+### 2. Tile cover en level-of-detail
+
+De pagina krijgt een reguliere tegelmatrix per fysieke renderschaal. Iedere
+tegel heeft een stabiele `(level, x, y)`-identiteit. De viewport wordt naar de
+tegelmatrix geprojecteerd en vraagt alleen de doorsnijdende tegels op, met één
+ring voor de waarschijnlijke volgende pan.
+
+Tijdens een cache-miss blijft een reeds beschikbare parent- of child-tegel
+zichtbaar. Alleen ontbrekende of onvoldoende scherpe tegels zijn dirty.
+Een zoomwissel maakt bestaande tegels dus niet automatisch ongeldig.
+
+De eerste implementatiefase verandert alleen selectie en hergebruik van
+bestaande regiobitmaps. Een vaste tegelmatrix wordt pas geactiveerd wanneer de
+A/B-meting bewijst dat coverage-lookup winst geeft en de native backend niet
+door extra regio-aanroepen verslechtert.
+
+### 3. Achtergrondopwarming
+
+Na een stabiele viewport wordt uitsluitend het waarschijnlijke zoompad
+opgewarmd:
+
+- de huidige viewport plus een kleine rand;
+- voldoende resolutie voor de hoogste eerstvolgende zoomstand;
+- lagere zoomstanden gebruiken dezelfde tegel door downsampling;
+- gebruikersinteractie heeft altijd voorrang en annuleert speculatief werk.
+
+De cache gebruikt een bytebudget in plaats van alleen een itemaantal. Hiermee
+blijft de geheugenlast voorspelbaar op HiDPI-schermen.
+
+### 4. Retained vectorscene als afzonderlijke vervolgfase
+
+De structurele backendverbetering bewaart ieder herhaald Form-object eenmaal
+en indexeert plaatsingen als instanties met transform en bounding box. Een
+packed ruimtelijke index levert alleen instanties die de gevraagde tegel raken.
+De gevonden instanties worden in oorspronkelijke PDF-tekenvolgorde afgespeeld.
+
+Deze fase is afzonderlijk omdat zij PDF-semantiek raakt. Zij wordt pas gebouwd
+nadat de frontend-cachemeting vaststelt hoeveel latency nog door native
+rasterisatie wordt veroorzaakt.
+
+## Interactiepad
+
+1. Zoominput verandert onmiddellijk de cameratransform.
+2. De bestaande canvas-snapshot verschijnt in hetzelfde frame.
+3. De viewport wordt omgerekend naar PDF-punten en fysieke renderschaal.
+4. De cache zoekt coverage in plaats van een exacte zoomsleutel.
+5. Bij een hit wordt de scherpe bitmap in de eerstvolgende animation frame
+   getoond.
+6. Bij een miss blijven parent/child-data zichtbaar en worden alleen dirty
+   gebieden met viewportprioriteit aangevraagd.
+7. Na rust wordt één toekomstige zoomdekking opgewarmd.
+
+## Meetpoorten
+
+Een productiewijziging blijft alleen behouden wanneer:
+
+- een cache-hit bij 150→300 en 300→150 mediaan maximaal 100 ms tot scherpe
+  viewport kost;
+- de volledige 150–300–150-reeks na opwarming minimaal 80% sneller is;
+- een koude cache niet meer native renderwerk start dan de huidige route;
+- cache-RSS binnen een expliciet bytebudget blijft;
+- beide verificatie-PDF's visueel gelijk blijven;
+- bestaande zoom-, cache- en renderregressietests slagen.
+
+Iedere fase krijgt één benchmarkcommit. Een fase zonder meetbare winst wordt
+teruggedraaid voordat de volgende begint.
+

--- a/docs/superpowers/specs/2026-07-29-vector-pdf-zoom-performance-design.md
+++ b/docs/superpowers/specs/2026-07-29-vector-pdf-zoom-performance-design.md
@@ -1,0 +1,108 @@
+# Vector-PDF zoom performance research
+
+## Doel
+
+Verlaag de zichtbare wachttijd bij inzoomen en pannen in grote vector-PDF's,
+zonder renderkwaliteit, stabiliteit of geheugengebruik te verslechteren.
+
+De primaire verificatiebestanden zijn:
+
+- `MV-03_Mechanische ventilatie, 3e verdieping ontwerp ACH van 1,5 naar 2,0.pdf`
+- `NKD1a_opm_aw.pdf`
+
+## Succescriterium
+
+Een productiewijziging blijft alleen behouden wanneer dezelfde benchmark op
+beide bestanden:
+
+- minimaal 10% reproduceerbare verbetering laat zien in de primaire metric;
+- geen statistisch relevante verslechtering op het andere bestand veroorzaakt;
+- geen zichtbare renderregressie veroorzaakt;
+- geen onaanvaardbare stijging in piekgeheugen veroorzaakt.
+
+De primaire metric is de tijd vanaf een zoomopdracht tot de eerste scherpe,
+juiste weergave van het zichtbare gebied. Open-tijd en tijd tot volledige
+pagina-opbouw zijn secundaire metrics.
+
+## Meetprotocol
+
+Elke kandidaat wordt vergeleken met dezelfde ongewijzigde nulmeting.
+
+Per PDF:
+
+1. Start de development-build schoon.
+2. Open het bestand en wacht tot de actieve pagina stabiel is.
+3. Meet een vaste reeks op de relevante zware pagina:
+   100% naar 150%, 200% en 300%, gevolgd door een pan en terug naar 100%.
+4. Voer minimaal vijf meetruns uit, waarvan de eerste als koude run apart
+   wordt gerapporteerd.
+5. Rapporteer mediaan en p95 voor:
+   queue-wachttijd, page-load/parse, native render, IPC-overdracht,
+   bitmapconversie en totale zichtbare latency.
+6. Registreer piek-RSS van hoofdproces en PDF-workers.
+7. Vergelijk de uiteindelijke render met de nulmeting op dezelfde viewport.
+
+MCP bestuurt de app en verzamelt de bestaande performance-uitvoer. Wanneer
+een fase nog niet afzonderlijk meetbaar is, mag eerst alleen meetinstrumentatie
+worden toegevoegd. Instrumentatie verandert geen enginebeleid.
+
+## Gefaseerde hypotheses
+
+Elke fase test precies één hoofdhypothese. Een volgende fase start pas nadat
+de vorige wijziging is behouden of volledig is teruggedraaid.
+
+### Fase 0 — nulmeting
+
+Leg de huidige zoomlatency, taakverdeling en het geheugenprofiel vast. Er
+wordt nog geen rendergedrag gewijzigd.
+
+### Fase 1 — taakprioriteit en annulering
+
+Hypothese: niet-zichtbare of achterhaalde renders blokkeren werk voor de
+actieve viewport. Test eerst of queue-wachttijd een materieel deel van de
+zoomlatency vormt. Voeg alleen dan prioritering of cancellation toe.
+
+### Fase 2 — adaptieve worker-affinity
+
+Hypothese: MV-03 verliest tijd en geheugen doordat meerdere workers dezelfde
+zware pagina laden, terwijl NKD1a mogelijk profiteert van parallelle tegels.
+Vergelijk één warme worker met de bestaande spreiding en kies per gemeten
+page-profiel.
+
+### Fase 3 — tegelpublicatie
+
+Hypothese: het herhaald maken van een volledige `ImageBitmap` na een gewijzigde
+tegel veroorzaakt merkbare main-thread- en geheugenlatency. Vergelijk de
+huidige accumulator met directe compositie van afzonderlijke tegels.
+
+### Fase 4 — PDFVM-scene-index
+
+Hypothese: iedere tegel scant te veel scenechunks. Voeg alleen een ruimtelijke
+index toe wanneer profiling bevestigt dat chunkselectie/replay dominant is.
+Painter's order en de bestaande renderuitvoer blijven behouden.
+
+### Fase 5 — scene-resources
+
+Hypothese: herhaald decoderen van afbeeldingen en opnieuw opbouwen van clips
+is dominant op pagina's die fase 4 niet voldoende versnelt. Cache resources
+per scene, uitsluitend na afzonderlijk bewijs.
+
+## Kwaliteits- en terugdraairegels
+
+- Eén gedragswijziging per benchmarkcommit.
+- Eerst een falende performance- of gedragstest, daarna minimale productiecode.
+- Een kandidaat zonder overtuigende winst wordt teruggedraaid.
+- Geen brede refactor tijdens het onderzoek.
+- Geen wijziging van de standaardengine zonder corpusbrede renderverificatie.
+- Geen merge of pull request voordat de twee primaire PDF's én de bestaande
+  regressiesuite slagen.
+
+## Verwachting
+
+De voorafgaande statische analyse geeft als onderzoekshypothese:
+
+- NKD1a: 25–45% kortere zichtbare zoomlatency;
+- MV-03: 40–65% kortere zichtbare zoomlatency.
+
+Dit zijn geen acceptatieclaims. De nulmeting en gefaseerde A/B-metingen bepalen
+welke winst daadwerkelijk haalbaar is.

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import {
   aggregatePeak,
   extractZoomPhases,
+  hasRenderCompletion,
   hasStableZoomEvidence,
   percentile,
   summarizeRuns,
@@ -17,7 +18,6 @@ import {
 const DEFAULT_MCP = 'http://127.0.0.1:9223/mcp';
 const ZOOM_SEQUENCE = [1, 1.5, 2, 3];
 const RELEVANT_LOG = /\[render]|\[tile]|\[wheel-zoom]|\[PERF]|\[bitmap-orch]|\[tile-orch]|\[prog]|\[prog-perf]|\[pbc]|\[bo]|STALE|JANK/i;
-const COMPLETION_LOG = /\[prog]\s+klaar|\[pbc]\s+whole-page\s+KLAAR|\[tile-orch]\s+cached|cache-hit-direct|cache-hit bucket/i;
 
 export function parseArgs(argv) {
   const values = new Map();
@@ -143,7 +143,7 @@ async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_0
       lastRelevantSignature = signature;
       lastRelevantAt = performance.now();
     }
-    completionSeen ||= relevant.some((entry) => COMPLETION_LOG.test(entry.text));
+    completionSeen ||= hasRenderCompletion(relevant);
 
     const actualZoom = Number(viewport?.viewport?.zoom ?? viewport?.doc?.scale);
     const zoomMatches = Number.isFinite(actualZoom) && Math.abs(actualZoom - scale) < 0.001;
@@ -239,6 +239,28 @@ async function measurePan(client) {
   };
 }
 
+async function waitForInitialRender(client, since, timeoutMs = 120_000) {
+  const started = performance.now();
+  let latestEntries = [];
+  while (performance.now() - started < timeoutMs) {
+    latestEntries = await recentEntries(client, since);
+    if (hasRenderCompletion(latestEntries)) {
+      return {
+        ok: true,
+        elapsedMs: Math.round(performance.now() - started),
+        entries: latestEntries,
+      };
+    }
+    await sleep(200);
+  }
+  return {
+    ok: false,
+    elapsedMs: Math.round(performance.now() - started),
+    error: `initial render did not complete within ${timeoutMs}ms`,
+    entries: latestEntries,
+  };
+}
+
 async function openIsolatedRun(client, args) {
   const listed = await client.tool('app_list_tabs', {});
   const targetPath = resolve(args.pdf).toLowerCase();
@@ -252,15 +274,23 @@ async function openIsolatedRun(client, args) {
 
   await client.tool('app_clear_caches', {});
   await sleep(250);
+  const openSince = Date.now();
   const openStarted = performance.now();
   const opened = await client.tool('app_open_pdf', { path: args.pdf });
   const openMs = Math.round(performance.now() - openStarted);
   if (!opened?.ok) throw new Error(opened?.error ?? 'app_open_pdf failed');
+  let readySince = openSince;
   if (args.page !== 1) {
+    readySince = Date.now();
     const pageResult = await client.tool('app_go_to_page', { page: args.page });
     if (!pageResult?.ok) throw new Error(pageResult?.error ?? 'app_go_to_page failed');
   }
-  return openMs;
+  const initialRender = await waitForInitialRender(client, readySince);
+  if (!initialRender.ok) throw new Error(initialRender.error);
+  return {
+    openMs,
+    initialReadyMs: openMs + initialRender.elapsedMs,
+  };
 }
 
 function gitIdentity() {
@@ -313,9 +343,11 @@ async function runBenchmark(args) {
   };
 
   for (let runIndex = 1; runIndex <= args.runs; runIndex += 1) {
+    const opened = await openIsolatedRun(client, args);
     const run = {
       index: runIndex,
-      openMs: await openIsolatedRun(client, args),
+      openMs: opened.openMs,
+      initialReadyMs: opened.initialReadyMs,
       zooms: [],
     };
     for (const scale of ZOOM_SEQUENCE) {

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import {
   aggregatePeak,
   extractZoomPhases,
+  hasStableZoomEvidence,
   summarizeRuns,
 } from './vector-zoom-metrics.mjs';
 
@@ -142,7 +143,13 @@ async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_0
     const actualZoom = Number(viewport?.viewport?.zoom ?? viewport?.doc?.scale);
     const zoomMatches = Number.isFinite(actualZoom) && Math.abs(actualZoom - scale) < 0.001;
     const quietForMs = performance.now() - lastRelevantAt;
-    if (zoomMatches && completionSeen && quietForMs >= 800) {
+    const stableEvidence = hasStableZoomEvidence({
+      scale,
+      completionSeen,
+      quietForMs,
+      viewport,
+    });
+    if (zoomMatches && stableEvidence && quietForMs >= 800) {
       return {
         ok: true,
         elapsedMs: Math.round(performance.now() - started),

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -5,7 +5,11 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { extractZoomPhases, summarizeRuns } from './vector-zoom-metrics.mjs';
+import {
+  aggregatePeak,
+  extractZoomPhases,
+  summarizeRuns,
+} from './vector-zoom-metrics.mjs';
 
 const DEFAULT_MCP = 'http://127.0.0.1:9223/mcp';
 const ZOOM_SEQUENCE = [1, 1.5, 2, 3];
@@ -77,7 +81,7 @@ function processSnapshot() {
   const command = [
     "$names = @('open-pdf-studio','pdfium-worker');",
     '$items = Get-Process -Name $names -ErrorAction SilentlyContinue |',
-    "Select-Object Id,ProcessName,@{n='rssMb';e={[math]::Round($_.WorkingSet64/1MB,1)}};",
+    "Select-Object Id,ProcessName,@{n='ParentProcessId';e={(Get-CimInstance Win32_Process -Filter \"ProcessId=$($_.Id)\").ParentProcessId}},@{n='rssMb';e={[math]::Round($_.WorkingSet64/1MB,1)}};",
     'if ($items) { $items | ConvertTo-Json -Compress } else { "[]" }',
   ].join(' ');
 
@@ -94,21 +98,16 @@ function processSnapshot() {
   }
 }
 
-function aggregatePeak(samples) {
-  let mainPeakMb = 0;
-  let workerPeakMb = 0;
-  let workerTotalPeakMb = 0;
-  for (const sample of samples) {
-    const main = sample.processes.filter((item) => item.ProcessName === 'open-pdf-studio');
-    const workers = sample.processes.filter((item) => item.ProcessName === 'pdfium-worker');
-    mainPeakMb = Math.max(mainPeakMb, ...main.map((item) => item.rssMb), 0);
-    workerPeakMb = Math.max(workerPeakMb, ...workers.map((item) => item.rssMb), 0);
-    workerTotalPeakMb = Math.max(
-      workerTotalPeakMb,
-      workers.reduce((sum, item) => sum + item.rssMb, 0),
-    );
-  }
-  return { mainPeakMb, workerPeakMb, workerTotalPeakMb };
+function mcpOwnerPid(port) {
+  const command = `(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction Stop | Select-Object -First 1 -ExpandProperty OwningProcess)`;
+  const value = execFileSync('powershell', ['-NoProfile', '-Command', command], {
+    encoding: 'utf8',
+    timeout: 8_000,
+    windowsHide: true,
+  }).trim();
+  const pid = Number(value);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`cannot resolve MCP owner PID on port ${port}`);
+  return pid;
 }
 
 async function recentEntries(client, since) {
@@ -116,7 +115,7 @@ async function recentEntries(client, since) {
   return Array.isArray(response) ? response : (response?.entries ?? []);
 }
 
-async function waitForStableZoom(client, scale, since, timeoutMs = 120_000) {
+async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_000) {
   const started = performance.now();
   let lastRelevantSignature = '';
   let lastRelevantAt = performance.now();
@@ -180,7 +179,7 @@ async function captureScreenshot(client, outputDir, stem) {
   return { ok: true, sha256: hash, bytes: bytes.length };
 }
 
-async function measureZoom(client, scale, runIndex, outputDir) {
+async function measureZoom(client, scale, runIndex, outputDir, appPid) {
   const since = Date.now();
   const wallStarted = performance.now();
   const setResult = await client.tool('app_set_zoom', { scale });
@@ -188,7 +187,7 @@ async function measureZoom(client, scale, runIndex, outputDir) {
     return { scale, ok: false, error: setResult?.error ?? 'app_set_zoom failed' };
   }
 
-  const stable = await waitForStableZoom(client, scale, since);
+  const stable = await waitForStableZoom(client, scale, since, appPid);
   const visibleSharpMs = Math.round(performance.now() - wallStarted);
   const screenshot = stable.ok
     ? await captureScreenshot(client, outputDir, `run-${runIndex}-zoom-${String(scale).replace('.', '_')}`)
@@ -200,7 +199,7 @@ async function measureZoom(client, scale, runIndex, outputDir) {
     visibleSharpMs: stable.ok ? visibleSharpMs : null,
     stabilization: stable,
     phases: extractZoomPhases(stable.entries ?? [], since),
-    rss: aggregatePeak(stable.rssSamples ?? []),
+    rss: aggregatePeak(stable.rssSamples ?? [], appPid),
     screenshot,
   };
 }
@@ -239,6 +238,8 @@ async function runBenchmark(args) {
   if (outputDir) await mkdir(outputDir, { recursive: true });
 
   const client = new McpClient(process.env.OPS_MCP_URL || DEFAULT_MCP);
+  const endpointPort = Number(new URL(client.endpoint).port || 80);
+  const appPid = mcpOwnerPid(endpointPort);
   const tools = await client.rpc('tools/list');
   const names = new Set((tools?.tools ?? []).map((tool) => tool.name));
   for (const required of [
@@ -271,6 +272,7 @@ async function runBenchmark(args) {
     pdfName: basename(args.pdf),
     page: args.page,
     gitCommit: gitIdentity(),
+    appPid,
     startedAt: new Date().toISOString(),
     openMs,
     runs: [],
@@ -279,10 +281,10 @@ async function runBenchmark(args) {
   for (let runIndex = 1; runIndex <= args.runs; runIndex += 1) {
     const run = { index: runIndex, zooms: [] };
     for (const scale of ZOOM_SEQUENCE) {
-      run.zooms.push(await measureZoom(client, scale, runIndex, outputDir));
+      run.zooms.push(await measureZoom(client, scale, runIndex, outputDir, appPid));
     }
     run.pan = await measurePan(client);
-    run.returnTo100 = await measureZoom(client, 1, runIndex, outputDir);
+    run.returnTo100 = await measureZoom(client, 1, runIndex, outputDir, appPid);
     run.visibleSharpMs = run.zooms
       .filter((zoom) => zoom.scale > 1 && Number.isFinite(zoom.visibleSharpMs))
       .reduce((sum, zoom) => sum + zoom.visibleSharpMs, 0);

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -80,9 +80,8 @@ class McpClient {
 
 function processSnapshot() {
   const command = [
-    "$names = @('open-pdf-studio','pdfium-worker');",
-    '$items = Get-Process -Name $names -ErrorAction SilentlyContinue |',
-    "Select-Object Id,ProcessName,@{n='ParentProcessId';e={(Get-CimInstance Win32_Process -Filter \"ProcessId=$($_.Id)\").ParentProcessId}},@{n='rssMb';e={[math]::Round($_.WorkingSet64/1MB,1)}};",
+    `$items = Get-CimInstance Win32_Process -Filter "Name='open-pdf-studio.exe' OR Name='pdfium-worker.exe'" |`,
+    "Select-Object @{n='Id';e={[int]$_.ProcessId}},@{n='ProcessName';e={[IO.Path]::GetFileNameWithoutExtension($_.Name)}},ParentProcessId,@{n='rssMb';e={[math]::Round([double]$_.WorkingSetSize/1MB,1)}};",
     'if ($items) { $items | ConvertTo-Json -Compress } else { "[]" }',
   ].join(' ');
 
@@ -123,6 +122,7 @@ async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_0
   let completionSeen = false;
   let latestEntries = [];
   const rssSamples = [];
+  let nextRssSampleAt = started;
 
   while (performance.now() - started < timeoutMs) {
     const [viewport, entries] = await Promise.all([
@@ -130,7 +130,10 @@ async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_0
       recentEntries(client, since),
     ]);
     latestEntries = entries;
-    rssSamples.push({ atMs: Math.round(performance.now() - started), processes: processSnapshot() });
+    if (performance.now() >= nextRssSampleAt) {
+      rssSamples.push({ atMs: Math.round(performance.now() - started), processes: processSnapshot() });
+      nextRssSampleAt = performance.now() + 1_000;
+    }
 
     const relevant = entries.filter((entry) => RELEVANT_LOG.test(entry.text));
     const signature = relevant.map((entry) => `${entry.t}:${entry.text}`).join('\n');
@@ -150,9 +153,16 @@ async function waitForStableZoom(client, scale, since, appPid, timeoutMs = 120_0
       viewport,
     });
     if (zoomMatches && stableEvidence && quietForMs >= 800) {
+      const tileZoom = Number(viewport?.tile?.meta?.zoom);
+      const reason = completionSeen
+        ? 'completion-log'
+        : Number.isFinite(tileZoom)
+          ? 'matching-sharp-tile'
+          : 'quiet-cache-hit';
       return {
         ok: true,
         elapsedMs: Math.round(performance.now() - started),
+        reason,
         viewport,
         entries: latestEntries,
         rssSamples,

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -9,7 +9,9 @@ import {
   aggregatePeak,
   extractZoomPhases,
   hasStableZoomEvidence,
+  percentile,
   summarizeRuns,
+  totalSuccessfulZoomMs,
 } from './vector-zoom-metrics.mjs';
 
 const DEFAULT_MCP = 'http://127.0.0.1:9223/mcp';
@@ -237,6 +239,30 @@ async function measurePan(client) {
   };
 }
 
+async function openIsolatedRun(client, args) {
+  const listed = await client.tool('app_list_tabs', {});
+  const targetPath = resolve(args.pdf).toLowerCase();
+  const matchingTabs = (listed?.tabs ?? [])
+    .filter((tab) => resolve(tab.filePath ?? '').toLowerCase() === targetPath)
+    .toSorted((left, right) => right.index - left.index);
+  for (const tab of matchingTabs) {
+    const closed = await client.tool('app_close_tab', { index: tab.index, force: true });
+    if (!closed?.ok) throw new Error(closed?.error ?? `could not close benchmark tab ${tab.index}`);
+  }
+
+  await client.tool('app_clear_caches', {});
+  await sleep(250);
+  const openStarted = performance.now();
+  const opened = await client.tool('app_open_pdf', { path: args.pdf });
+  const openMs = Math.round(performance.now() - openStarted);
+  if (!opened?.ok) throw new Error(opened?.error ?? 'app_open_pdf failed');
+  if (args.page !== 1) {
+    const pageResult = await client.tool('app_go_to_page', { page: args.page });
+    if (!pageResult?.ok) throw new Error(pageResult?.error ?? 'app_go_to_page failed');
+  }
+  return openMs;
+}
+
 function gitIdentity() {
   try {
     return execFileSync('git', ['rev-parse', 'HEAD'], {
@@ -268,22 +294,14 @@ async function runBenchmark(args) {
     'app_get_viewport_state',
     'app_get_recent_console',
     'app_screenshot_view',
+    'app_list_tabs',
+    'app_close_tab',
   ]) {
     if (!names.has(required)) throw new Error(`MCP tool unavailable: ${required}`);
   }
 
-  await client.tool('app_clear_caches', {});
-  const openStarted = performance.now();
-  const opened = await client.tool('app_open_pdf', { path: args.pdf });
-  const openMs = Math.round(performance.now() - openStarted);
-  if (!opened?.ok) throw new Error(opened?.error ?? 'app_open_pdf failed');
-  if (args.page !== 1) {
-    const pageResult = await client.tool('app_go_to_page', { page: args.page });
-    if (!pageResult?.ok) throw new Error(pageResult?.error ?? 'app_go_to_page failed');
-  }
-
   const result = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     label: args.label,
     pdf: resolve(args.pdf),
     pdfName: basename(args.pdf),
@@ -291,23 +309,24 @@ async function runBenchmark(args) {
     gitCommit: gitIdentity(),
     appPid,
     startedAt: new Date().toISOString(),
-    openMs,
     runs: [],
   };
 
   for (let runIndex = 1; runIndex <= args.runs; runIndex += 1) {
-    const run = { index: runIndex, zooms: [] };
+    const run = {
+      index: runIndex,
+      openMs: await openIsolatedRun(client, args),
+      zooms: [],
+    };
     for (const scale of ZOOM_SEQUENCE) {
       run.zooms.push(await measureZoom(client, scale, runIndex, outputDir, appPid));
     }
     run.pan = await measurePan(client);
-    run.returnTo100 = await measureZoom(client, 1, runIndex, outputDir, appPid);
-    run.visibleSharpMs = run.zooms
-      .filter((zoom) => zoom.scale > 1 && Number.isFinite(zoom.visibleSharpMs))
-      .reduce((sum, zoom) => sum + zoom.visibleSharpMs, 0);
+    run.visibleSharpMs = totalSuccessfulZoomMs(run.zooms);
     result.runs.push(run);
   }
 
+  result.openMs = percentile(result.runs.map((run) => run.openMs), 0.5);
   result.summary = summarizeRuns(result.runs);
   result.finishedAt = new Date().toISOString();
   if (outputDir) {

--- a/mcp-server/vector-zoom-benchmark.mjs
+++ b/mcp-server/vector-zoom-benchmark.mjs
@@ -1,0 +1,320 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { extractZoomPhases, summarizeRuns } from './vector-zoom-metrics.mjs';
+
+const DEFAULT_MCP = 'http://127.0.0.1:9223/mcp';
+const ZOOM_SEQUENCE = [1, 1.5, 2, 3];
+const RELEVANT_LOG = /\[render]|\[tile]|\[wheel-zoom]|\[PERF]|\[bitmap-orch]|\[tile-orch]|\[prog]|\[prog-perf]|\[pbc]|\[bo]|STALE|JANK/i;
+const COMPLETION_LOG = /\[prog]\s+klaar|\[pbc]\s+whole-page\s+KLAAR|\[tile-orch]\s+cached|cache-hit-direct|cache-hit bucket/i;
+
+export function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith('--') || value === undefined) {
+      throw new Error(`invalid argument near ${flag ?? '<end>'}`);
+    }
+    values.set(flag.slice(2), value);
+  }
+
+  const pdf = values.get('pdf');
+  if (!pdf) throw new Error('--pdf is required');
+
+  const page = Number(values.get('page') ?? 1);
+  const runs = Number(values.get('runs') ?? 5);
+  if (!Number.isInteger(page) || page < 1) throw new Error('--page must be a positive integer');
+  if (!Number.isInteger(runs) || runs < 1) throw new Error('--runs must be a positive integer');
+
+  return {
+    pdf,
+    label: values.get('label') ?? 'baseline',
+    page,
+    runs,
+    output: values.get('output') ?? null,
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+class McpClient {
+  constructor(endpoint = DEFAULT_MCP) {
+    this.endpoint = endpoint;
+    this.id = 1;
+  }
+
+  async rpc(method, params = {}) {
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: this.id++, method, params }),
+    });
+    if (!response.ok) throw new Error(`MCP HTTP ${response.status}`);
+    const payload = await response.json();
+    if (payload.error) throw new Error(payload.error.message ?? JSON.stringify(payload.error));
+    return payload.result;
+  }
+
+  async tool(name, args = {}) {
+    const result = await this.rpc('tools/call', { name, arguments: args });
+    const text = result?.content?.[0]?.text;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+}
+
+function processSnapshot() {
+  const command = [
+    "$names = @('open-pdf-studio','pdfium-worker');",
+    '$items = Get-Process -Name $names -ErrorAction SilentlyContinue |',
+    "Select-Object Id,ProcessName,@{n='rssMb';e={[math]::Round($_.WorkingSet64/1MB,1)}};",
+    'if ($items) { $items | ConvertTo-Json -Compress } else { "[]" }',
+  ].join(' ');
+
+  try {
+    const stdout = execFileSync('powershell', ['-NoProfile', '-Command', command], {
+      encoding: 'utf8',
+      timeout: 8_000,
+      windowsHide: true,
+    }).trim();
+    const parsed = JSON.parse(stdout || '[]');
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return [];
+  }
+}
+
+function aggregatePeak(samples) {
+  let mainPeakMb = 0;
+  let workerPeakMb = 0;
+  let workerTotalPeakMb = 0;
+  for (const sample of samples) {
+    const main = sample.processes.filter((item) => item.ProcessName === 'open-pdf-studio');
+    const workers = sample.processes.filter((item) => item.ProcessName === 'pdfium-worker');
+    mainPeakMb = Math.max(mainPeakMb, ...main.map((item) => item.rssMb), 0);
+    workerPeakMb = Math.max(workerPeakMb, ...workers.map((item) => item.rssMb), 0);
+    workerTotalPeakMb = Math.max(
+      workerTotalPeakMb,
+      workers.reduce((sum, item) => sum + item.rssMb, 0),
+    );
+  }
+  return { mainPeakMb, workerPeakMb, workerTotalPeakMb };
+}
+
+async function recentEntries(client, since) {
+  const response = await client.tool('app_get_recent_console', { since });
+  return Array.isArray(response) ? response : (response?.entries ?? []);
+}
+
+async function waitForStableZoom(client, scale, since, timeoutMs = 120_000) {
+  const started = performance.now();
+  let lastRelevantSignature = '';
+  let lastRelevantAt = performance.now();
+  let completionSeen = false;
+  let latestEntries = [];
+  const rssSamples = [];
+
+  while (performance.now() - started < timeoutMs) {
+    const [viewport, entries] = await Promise.all([
+      client.tool('app_get_viewport_state', {}),
+      recentEntries(client, since),
+    ]);
+    latestEntries = entries;
+    rssSamples.push({ atMs: Math.round(performance.now() - started), processes: processSnapshot() });
+
+    const relevant = entries.filter((entry) => RELEVANT_LOG.test(entry.text));
+    const signature = relevant.map((entry) => `${entry.t}:${entry.text}`).join('\n');
+    if (signature !== lastRelevantSignature) {
+      lastRelevantSignature = signature;
+      lastRelevantAt = performance.now();
+    }
+    completionSeen ||= relevant.some((entry) => COMPLETION_LOG.test(entry.text));
+
+    const actualZoom = Number(viewport?.viewport?.zoom ?? viewport?.doc?.scale);
+    const zoomMatches = Number.isFinite(actualZoom) && Math.abs(actualZoom - scale) < 0.001;
+    const quietForMs = performance.now() - lastRelevantAt;
+    if (zoomMatches && completionSeen && quietForMs >= 800) {
+      return {
+        ok: true,
+        elapsedMs: Math.round(performance.now() - started),
+        viewport,
+        entries: latestEntries,
+        rssSamples,
+      };
+    }
+    await sleep(200);
+  }
+
+  return {
+    ok: false,
+    elapsedMs: Math.round(performance.now() - started),
+    error: `zoom ${scale} did not stabilize within ${timeoutMs}ms`,
+    entries: latestEntries,
+    rssSamples,
+  };
+}
+
+async function captureScreenshot(client, outputDir, stem) {
+  const shot = await client.tool('app_screenshot_view', { width: 2000 });
+  const encoded = shot?.png_base64 ?? shot?.base64 ?? shot?.data;
+  if (!shot?.ok || typeof encoded !== 'string') {
+    return { ok: false, error: shot?.error ?? 'screenshot returned no PNG data' };
+  }
+  const bytes = Buffer.from(encoded, 'base64');
+  const hash = createHash('sha256').update(bytes).digest('hex');
+  if (outputDir) {
+    const file = join(outputDir, `${stem}.png`);
+    await writeFile(file, bytes);
+    return { ok: true, sha256: hash, bytes: bytes.length, file };
+  }
+  return { ok: true, sha256: hash, bytes: bytes.length };
+}
+
+async function measureZoom(client, scale, runIndex, outputDir) {
+  const since = Date.now();
+  const wallStarted = performance.now();
+  const setResult = await client.tool('app_set_zoom', { scale });
+  if (!setResult?.ok) {
+    return { scale, ok: false, error: setResult?.error ?? 'app_set_zoom failed' };
+  }
+
+  const stable = await waitForStableZoom(client, scale, since);
+  const visibleSharpMs = Math.round(performance.now() - wallStarted);
+  const screenshot = stable.ok
+    ? await captureScreenshot(client, outputDir, `run-${runIndex}-zoom-${String(scale).replace('.', '_')}`)
+    : null;
+
+  return {
+    scale,
+    ok: stable.ok,
+    visibleSharpMs: stable.ok ? visibleSharpMs : null,
+    stabilization: stable,
+    phases: extractZoomPhases(stable.entries ?? [], since),
+    rss: aggregatePeak(stable.rssSamples ?? []),
+    screenshot,
+  };
+}
+
+async function measurePan(client) {
+  const viewport = await client.tool('app_get_viewport_state', {});
+  const x = Math.round((viewport?.container?.left ?? 0) + (viewport?.container?.width ?? 800) / 2);
+  const y = Math.round((viewport?.container?.top ?? 0) + (viewport?.container?.height ?? 600) / 2);
+  const since = Date.now();
+  const started = performance.now();
+  const response = await client.tool('app_scroll', { x, y, dx: 240, dy: 180 });
+  await sleep(800);
+  const entries = await recentEntries(client, since);
+  return {
+    ok: response?.ok !== false,
+    elapsedMs: Math.round(performance.now() - started),
+    phases: extractZoomPhases(entries, since),
+  };
+}
+
+function gitIdentity() {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function runBenchmark(args) {
+  if (!existsSync(args.pdf)) throw new Error(`PDF does not exist: ${args.pdf}`);
+  const outputDir = args.output ? resolve(args.output, args.label) : null;
+  if (outputDir) await mkdir(outputDir, { recursive: true });
+
+  const client = new McpClient(process.env.OPS_MCP_URL || DEFAULT_MCP);
+  const tools = await client.rpc('tools/list');
+  const names = new Set((tools?.tools ?? []).map((tool) => tool.name));
+  for (const required of [
+    'app_clear_caches',
+    'app_open_pdf',
+    'app_go_to_page',
+    'app_set_zoom',
+    'app_scroll',
+    'app_get_viewport_state',
+    'app_get_recent_console',
+    'app_screenshot_view',
+  ]) {
+    if (!names.has(required)) throw new Error(`MCP tool unavailable: ${required}`);
+  }
+
+  await client.tool('app_clear_caches', {});
+  const openStarted = performance.now();
+  const opened = await client.tool('app_open_pdf', { path: args.pdf });
+  const openMs = Math.round(performance.now() - openStarted);
+  if (!opened?.ok) throw new Error(opened?.error ?? 'app_open_pdf failed');
+  if (args.page !== 1) {
+    const pageResult = await client.tool('app_go_to_page', { page: args.page });
+    if (!pageResult?.ok) throw new Error(pageResult?.error ?? 'app_go_to_page failed');
+  }
+
+  const result = {
+    schemaVersion: 1,
+    label: args.label,
+    pdf: resolve(args.pdf),
+    pdfName: basename(args.pdf),
+    page: args.page,
+    gitCommit: gitIdentity(),
+    startedAt: new Date().toISOString(),
+    openMs,
+    runs: [],
+  };
+
+  for (let runIndex = 1; runIndex <= args.runs; runIndex += 1) {
+    const run = { index: runIndex, zooms: [] };
+    for (const scale of ZOOM_SEQUENCE) {
+      run.zooms.push(await measureZoom(client, scale, runIndex, outputDir));
+    }
+    run.pan = await measurePan(client);
+    run.returnTo100 = await measureZoom(client, 1, runIndex, outputDir);
+    run.visibleSharpMs = run.zooms
+      .filter((zoom) => zoom.scale > 1 && Number.isFinite(zoom.visibleSharpMs))
+      .reduce((sum, zoom) => sum + zoom.visibleSharpMs, 0);
+    result.runs.push(run);
+  }
+
+  result.summary = summarizeRuns(result.runs);
+  result.finishedAt = new Date().toISOString();
+  if (outputDir) {
+    const resultFile = join(outputDir, 'result.json');
+    await writeFile(resultFile, `${JSON.stringify(result, null, 2)}\n`);
+    result.resultFile = resultFile;
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await runBenchmark(args);
+  console.log(JSON.stringify({
+    label: result.label,
+    pdf: result.pdfName,
+    openMs: result.openMs,
+    summary: result.summary,
+    resultFile: result.resultFile ?? null,
+  }, null, 2));
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    console.error(`VECTOR_ZOOM_BENCHMARK_ERROR: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -1,0 +1,49 @@
+export function percentile(values, fraction) {
+  const sorted = values.filter(Number.isFinite).toSorted((a, b) => a - b);
+  if (!sorted.length) return null;
+  const rank = Math.ceil(fraction * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(sorted.length - 1, rank))];
+}
+
+export function summarizeRuns(runs) {
+  const values = runs
+    .map((run) => run.visibleSharpMs)
+    .filter(Number.isFinite);
+
+  return {
+    count: values.length,
+    medianMs: percentile(values, 0.5),
+    p95Ms: percentile(values, 0.95),
+  };
+}
+
+function firstNumber(entries, pattern) {
+  for (const entry of entries) {
+    const match = entry.text.match(pattern);
+    if (match) return Number(match[1]);
+  }
+  return null;
+}
+
+export function extractZoomPhases(entries, sinceMs) {
+  const raw = entries
+    .filter((entry) => entry.t >= sinceMs)
+    .filter((entry) => /\[prog-perf]|\[prog]|\[bo]|\[bitmap-orch]|\[pbc]/.test(entry.text));
+
+  const tileDurations = raw
+    .map((entry) => entry.text.match(/tegel-invoke\b.*?\b(\d+)ms\b/))
+    .filter(Boolean)
+    .map((match) => Number(match[1]));
+
+  return {
+    firstTileMs: firstNumber(raw, /\[prog]\s+eerste tegel\s+@(\d+)ms/),
+    completeMs: firstNumber(raw, /\[prog]\s+klaar\b.*?@(\d+)ms/),
+    firstPublishMs: firstNumber(raw, /publish createImageBitmap\b.*?\b(\d+)ms/),
+    maxTileInvokeMs: tileDurations.length ? Math.max(...tileDurations) : null,
+    bitmapOrchestratorMs: firstNumber(
+      raw,
+      /(?:\[bo]|\[bitmap-orch]).*?(?:klaar|done|paint).*?\b(\d+)ms\b/i,
+    ),
+    raw,
+  };
+}

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -68,3 +68,15 @@ export function aggregatePeak(samples, appPid) {
 
   return { mainPeakMb, workerPeakMb, workerTotalPeakMb };
 }
+
+export function hasStableZoomEvidence({
+  scale,
+  completionSeen,
+  quietForMs,
+  viewport,
+}) {
+  const tileZoom = Number(viewport?.tile?.meta?.zoom);
+  const matchingSharpTile = Number.isFinite(tileZoom) && Math.abs(tileZoom - scale) < 0.001;
+  const quietCacheHit = quietForMs >= 1_500;
+  return completionSeen || matchingSharpTile || quietCacheHit;
+}

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -77,6 +77,6 @@ export function hasStableZoomEvidence({
 }) {
   const tileZoom = Number(viewport?.tile?.meta?.zoom);
   const matchingSharpTile = Number.isFinite(tileZoom) && Math.abs(tileZoom - scale) < 0.001;
-  const quietCacheHit = quietForMs >= 1_500;
+  const quietCacheHit = !Number.isFinite(tileZoom) && quietForMs >= 1_500;
   return completionSeen || matchingSharpTile || quietCacheHit;
 }

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -99,7 +99,24 @@ export function hasStableZoomEvidence({
   viewport,
 }) {
   const tileZoom = Number(viewport?.tile?.meta?.zoom);
-  const matchingSharpTile = Number.isFinite(tileZoom) && Math.abs(tileZoom - scale) < 0.001;
-  const quietCacheHit = !Number.isFinite(tileZoom) && quietForMs >= 1_500;
-  return completionSeen || matchingSharpTile || quietCacheHit;
+  const tileRenderScale = Number(viewport?.tile?.meta?.renderScale);
+  const devicePixelRatio = Number(viewport?.devicePixelRatio) || 1;
+  const effectiveRenderScale = Number.isFinite(tileRenderScale)
+    ? tileRenderScale
+    : tileZoom;
+  const bucketTileSupportsZoom =
+    Number.isFinite(effectiveRenderScale)
+    && effectiveRenderScale + 0.001 >= scale * devicePixelRatio;
+  const pageW = Number(viewport?.viewport?.pageW);
+  const pageH = Number(viewport?.viewport?.pageH);
+  const maxAxisPt = Math.max(pageW, pageH);
+  const wholePageCap = Number.isFinite(maxAxisPt) && maxAxisPt > 0
+    ? 4_096 / maxAxisPt
+    : 1;
+  const wholePageIsSharp = scale <= wholePageCap + 0.001;
+  const quietCacheHit =
+    !Number.isFinite(tileZoom)
+    && wholePageIsSharp
+    && quietForMs >= 1_500;
+  return bucketTileSupportsZoom || (wholePageIsSharp && completionSeen) || quietCacheHit;
 }

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -17,6 +17,22 @@ export function summarizeRuns(runs) {
   };
 }
 
+export function totalSuccessfulZoomMs(zooms) {
+  const targets = zooms.filter((zoom) => zoom.scale > 1);
+  if (
+    targets.length === 0
+    || targets.some((zoom) => !zoom.ok || !Number.isFinite(zoom.visibleSharpMs))
+    || targets.some((zoom) => !zoom.screenshot?.ok || !zoom.screenshot.sha256)
+  ) {
+    return null;
+  }
+
+  const screenshotHashes = new Set(targets.map((zoom) => zoom.screenshot.sha256));
+  if (screenshotHashes.size < 2) return null;
+
+  return targets.reduce((sum, zoom) => sum + zoom.visibleSharpMs, 0);
+}
+
 function firstNumber(entries, pattern) {
   for (const entry of entries) {
     const match = entry.text.match(pattern);

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -47,3 +47,24 @@ export function extractZoomPhases(entries, sinceMs) {
     raw,
   };
 }
+
+export function aggregatePeak(samples, appPid) {
+  let mainPeakMb = 0;
+  let workerPeakMb = 0;
+  let workerTotalPeakMb = 0;
+
+  for (const sample of samples) {
+    const main = sample.processes.filter((item) => item.Id === appPid);
+    const workers = sample.processes.filter(
+      (item) => item.ProcessName === 'pdfium-worker' && item.ParentProcessId === appPid,
+    );
+    mainPeakMb = Math.max(mainPeakMb, ...main.map((item) => item.rssMb), 0);
+    workerPeakMb = Math.max(workerPeakMb, ...workers.map((item) => item.rssMb), 0);
+    workerTotalPeakMb = Math.max(
+      workerTotalPeakMb,
+      workers.reduce((sum, item) => sum + item.rssMb, 0),
+    );
+  }
+
+  return { mainPeakMb, workerPeakMb, workerTotalPeakMb };
+}

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -33,6 +33,13 @@ export function totalSuccessfulZoomMs(zooms) {
   return targets.reduce((sum, zoom) => sum + zoom.visibleSharpMs, 0);
 }
 
+const RENDER_COMPLETION_LOG =
+  /\[prog]\s+klaar|\[pbc]\s+whole-page\s+KLAAR|\[tile-orch]\s+cached|cache-hit-direct|cache-hit bucket/i;
+
+export function hasRenderCompletion(entries) {
+  return entries.some((entry) => RENDER_COMPLETION_LOG.test(entry.text));
+}
+
 function firstNumber(entries, pattern) {
   for (const entry of entries) {
     const match = entry.text.match(pattern);

--- a/mcp-server/vector-zoom-metrics.mjs
+++ b/mcp-server/vector-zoom-metrics.mjs
@@ -113,7 +113,7 @@ export function hasStableZoomEvidence({
   const wholePageCap = Number.isFinite(maxAxisPt) && maxAxisPt > 0
     ? 4_096 / maxAxisPt
     : 1;
-  const wholePageIsSharp = scale <= wholePageCap + 0.001;
+  const wholePageIsSharp = scale * devicePixelRatio <= wholePageCap + 0.001;
   const quietCacheHit =
     !Number.isFinite(tileZoom)
     && wholePageIsSharp

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -7,6 +7,7 @@ import {
   extractZoomPhases,
   aggregatePeak,
   hasStableZoomEvidence,
+  totalSuccessfulZoomMs,
 } from './vector-zoom-metrics.mjs';
 import { parseArgs } from './vector-zoom-benchmark.mjs';
 
@@ -148,4 +149,25 @@ test('hasStableZoomEvidence rejects a quiet viewport with a stale tile from anot
     quietForMs: 8_000,
     viewport: { tile: { meta: { zoom: 1.5 } } },
   }), false);
+});
+
+test('totalSuccessfulZoomMs rejects failed or visually stale zoom runs', () => {
+  const valid = [
+    { scale: 1, ok: true, visibleSharpMs: 100, screenshot: { ok: true, sha256: 'base' } },
+    { scale: 1.5, ok: true, visibleSharpMs: 200, screenshot: { ok: true, sha256: 'zoom-a' } },
+    { scale: 2, ok: true, visibleSharpMs: 300, screenshot: { ok: true, sha256: 'zoom-b' } },
+    { scale: 3, ok: true, visibleSharpMs: 400, screenshot: { ok: true, sha256: 'zoom-c' } },
+  ];
+  assert.equal(totalSuccessfulZoomMs(valid), 900);
+
+  const failed = structuredClone(valid);
+  failed[2].ok = false;
+  failed[2].visibleSharpMs = null;
+  assert.equal(totalSuccessfulZoomMs(failed), null);
+
+  const stale = structuredClone(valid);
+  stale.slice(1).forEach((zoom) => {
+    zoom.screenshot.sha256 = 'same-blank-frame';
+  });
+  assert.equal(totalSuccessfulZoomMs(stale), null);
 });

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -7,6 +7,7 @@ import {
   extractZoomPhases,
   aggregatePeak,
   hasStableZoomEvidence,
+  hasRenderCompletion,
   totalSuccessfulZoomMs,
 } from './vector-zoom-metrics.mjs';
 import { parseArgs } from './vector-zoom-benchmark.mjs';
@@ -170,4 +171,17 @@ test('totalSuccessfulZoomMs rejects failed or visually stale zoom runs', () => {
     zoom.screenshot.sha256 = 'same-blank-frame';
   });
   assert.equal(totalSuccessfulZoomMs(stale), null);
+});
+
+test('hasRenderCompletion herkent alleen een afgeronde render of cache-hit', () => {
+  assert.equal(hasRenderCompletion([
+    { text: '[prog] eerste tegel @500ms' },
+    { text: '[prog] klaar @2400ms (12 tegels)' },
+  ]), true);
+  assert.equal(hasRenderCompletion([
+    { text: '[tile-orch] cached visible tile' },
+  ]), true);
+  assert.equal(hasRenderCompletion([
+    { text: '[prog-guard] zware pagina → progressief pad' },
+  ]), false);
 });

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  percentile,
+  summarizeRuns,
+  extractZoomPhases,
+} from './vector-zoom-metrics.mjs';
+
+test('percentile selects deterministic nearest-rank values', () => {
+  const values = [900, 100, 700, 300, 500];
+  assert.equal(percentile(values, 0.5), 500);
+  assert.equal(percentile(values, 0.95), 900);
+  assert.equal(percentile([], 0.5), null);
+});
+
+test('summarizeRuns ignores failed runs and reports median and p95', () => {
+  const summary = summarizeRuns([
+    { visibleSharpMs: 100 },
+    { visibleSharpMs: null },
+    { visibleSharpMs: 300 },
+    { visibleSharpMs: 200 },
+  ]);
+
+  assert.deepEqual(summary, {
+    count: 3,
+    medianMs: 200,
+    p95Ms: 300,
+  });
+});
+
+test('extractZoomPhases retains explicit timings and leaves absent phases null', () => {
+  const sinceMs = 1_000;
+  const result = extractZoomPhases([
+    { t: 900, text: '[prog] oude run klaar' },
+    { t: 1_010, text: '[prog-perf] @50 run-start 4096x2896 12 tegels p1 scale=3.000' },
+    { t: 1_130, text: '[prog-perf] @170 tegel-invoke 1024x1024 120ms (4.0MB)' },
+    { t: 1_145, text: '[prog] eerste tegel @135ms' },
+    { t: 1_190, text: '[prog-perf] @230 publish createImageBitmap 4096x2896 45ms' },
+    { t: 1_510, text: '[prog] klaar 12 tegels @500ms' },
+  ], sinceMs);
+
+  assert.equal(result.firstTileMs, 135);
+  assert.equal(result.completeMs, 500);
+  assert.equal(result.firstPublishMs, 45);
+  assert.equal(result.maxTileInvokeMs, 120);
+  assert.equal(result.bitmapOrchestratorMs, null);
+  assert.equal(result.raw.length, 5);
+});
+
+test('extractZoomPhases does not turn missing timings into zeroes', () => {
+  const result = extractZoomPhases([
+    { t: 2_000, text: '[bo] render gestart' },
+  ], 2_000);
+
+  assert.deepEqual(result, {
+    firstTileMs: null,
+    completeMs: null,
+    firstPublishMs: null,
+    maxTileInvokeMs: null,
+    bitmapOrchestratorMs: null,
+    raw: [{ t: 2_000, text: '[bo] render gestart' }],
+  });
+});

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -6,6 +6,7 @@ import {
   summarizeRuns,
   extractZoomPhases,
   aggregatePeak,
+  hasStableZoomEvidence,
 } from './vector-zoom-metrics.mjs';
 import { parseArgs } from './vector-zoom-benchmark.mjs';
 
@@ -111,4 +112,31 @@ test('aggregatePeak isolates the measured app and its workers', () => {
     workerPeakMb: 300,
     workerTotalPeakMb: 500,
   });
+});
+
+test('hasStableZoomEvidence accepts completion, matching sharp tile, or a quiet cache hit', () => {
+  assert.equal(hasStableZoomEvidence({
+    scale: 2,
+    completionSeen: true,
+    quietForMs: 800,
+    viewport: { tile: null },
+  }), true);
+  assert.equal(hasStableZoomEvidence({
+    scale: 1.5,
+    completionSeen: false,
+    quietForMs: 800,
+    viewport: { tile: { meta: { zoom: 1.5 } } },
+  }), true);
+  assert.equal(hasStableZoomEvidence({
+    scale: 1,
+    completionSeen: false,
+    quietForMs: 1_500,
+    viewport: { tile: null },
+  }), true);
+  assert.equal(hasStableZoomEvidence({
+    scale: 3,
+    completionSeen: false,
+    quietForMs: 900,
+    viewport: { tile: { meta: { zoom: 1.5 } } },
+  }), false);
 });

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -145,6 +145,16 @@ test('hasStableZoomEvidence accepts completion, matching sharp tile, or a quiet 
     },
   }), true);
   assert.equal(hasStableZoomEvidence({
+    scale: 1,
+    completionSeen: true,
+    quietForMs: 8_000,
+    viewport: {
+      devicePixelRatio: 1.5,
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: null,
+    },
+  }), false);
+  assert.equal(hasStableZoomEvidence({
     scale: 1.5,
     completionSeen: false,
     quietForMs: 8_000,

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -140,3 +140,12 @@ test('hasStableZoomEvidence accepts completion, matching sharp tile, or a quiet 
     viewport: { tile: { meta: { zoom: 1.5 } } },
   }), false);
 });
+
+test('hasStableZoomEvidence rejects a quiet viewport with a stale tile from another zoom', () => {
+  assert.equal(hasStableZoomEvidence({
+    scale: 3,
+    completionSeen: false,
+    quietForMs: 8_000,
+    viewport: { tile: { meta: { zoom: 1.5 } } },
+  }), false);
+});

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -6,6 +6,7 @@ import {
   summarizeRuns,
   extractZoomPhases,
 } from './vector-zoom-metrics.mjs';
+import { parseArgs } from './vector-zoom-benchmark.mjs';
 
 test('percentile selects deterministic nearest-rank values', () => {
   const values = [900, 100, 700, 300, 500];
@@ -61,4 +62,34 @@ test('extractZoomPhases does not turn missing timings into zeroes', () => {
     bitmapOrchestratorMs: null,
     raw: [{ t: 2_000, text: '[bo] render gestart' }],
   });
+});
+
+test('parseArgs preserves PDF paths with spaces and commas', () => {
+  const pdf = 'C:/PDF-bestanden/MV-03 Mechanische ventilatie, ontwerp.pdf';
+  const args = parseArgs([
+    '--pdf', pdf,
+    '--label', 'baseline-mv03',
+    '--page', '2',
+    '--runs', '7',
+    '--output', 'C:/metingen/vector zoom',
+  ]);
+
+  assert.deepEqual(args, {
+    pdf,
+    label: 'baseline-mv03',
+    page: 2,
+    runs: 7,
+    output: 'C:/metingen/vector zoom',
+  });
+});
+
+test('parseArgs defaults to five runs and rejects a missing PDF', () => {
+  assert.deepEqual(parseArgs(['--pdf', 'C:/test.pdf']), {
+    pdf: 'C:/test.pdf',
+    label: 'baseline',
+    page: 1,
+    runs: 5,
+    output: null,
+  });
+  assert.throws(() => parseArgs([]), /--pdf is required/);
 });

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -5,6 +5,7 @@ import {
   percentile,
   summarizeRuns,
   extractZoomPhases,
+  aggregatePeak,
 } from './vector-zoom-metrics.mjs';
 import { parseArgs } from './vector-zoom-benchmark.mjs';
 
@@ -92,4 +93,22 @@ test('parseArgs defaults to five runs and rejects a missing PDF', () => {
     output: null,
   });
   assert.throws(() => parseArgs([]), /--pdf is required/);
+});
+
+test('aggregatePeak isolates the measured app and its workers', () => {
+  const samples = [{
+    processes: [
+      { Id: 10, ParentProcessId: 1, ProcessName: 'open-pdf-studio', rssMb: 500 },
+      { Id: 11, ParentProcessId: 10, ProcessName: 'pdfium-worker', rssMb: 300 },
+      { Id: 12, ParentProcessId: 10, ProcessName: 'pdfium-worker', rssMb: 200 },
+      { Id: 20, ParentProcessId: 2, ProcessName: 'open-pdf-studio', rssMb: 900 },
+      { Id: 21, ParentProcessId: 20, ProcessName: 'pdfium-worker', rssMb: 800 },
+    ],
+  }];
+
+  assert.deepEqual(aggregatePeak(samples, 10), {
+    mainPeakMb: 500,
+    workerPeakMb: 300,
+    workerTotalPeakMb: 500,
+  });
 });

--- a/mcp-server/vector-zoom-metrics.test.mjs
+++ b/mcp-server/vector-zoom-metrics.test.mjs
@@ -118,22 +118,69 @@ test('aggregatePeak isolates the measured app and its workers', () => {
 
 test('hasStableZoomEvidence accepts completion, matching sharp tile, or a quiet cache hit', () => {
   assert.equal(hasStableZoomEvidence({
-    scale: 2,
+    scale: 1,
     completionSeen: true,
     quietForMs: 800,
-    viewport: { tile: null },
+    viewport: {
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: null,
+    },
   }), true);
   assert.equal(hasStableZoomEvidence({
     scale: 1.5,
     completionSeen: false,
     quietForMs: 800,
-    viewport: { tile: { meta: { zoom: 1.5 } } },
+    viewport: {
+      devicePixelRatio: 1.5,
+      tile: { meta: { zoom: 1.5, renderScale: 2.25 } },
+    },
   }), true);
   assert.equal(hasStableZoomEvidence({
     scale: 1,
     completionSeen: false,
     quietForMs: 1_500,
-    viewport: { tile: null },
+    viewport: {
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: null,
+    },
+  }), true);
+  assert.equal(hasStableZoomEvidence({
+    scale: 1.5,
+    completionSeen: false,
+    quietForMs: 8_000,
+    viewport: {
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: null,
+    },
+  }), false);
+  assert.equal(hasStableZoomEvidence({
+    scale: 2,
+    completionSeen: true,
+    quietForMs: 8_000,
+    viewport: {
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: { meta: { zoom: 1.5 } },
+    },
+  }), false);
+  assert.equal(hasStableZoomEvidence({
+    scale: 1.5,
+    completionSeen: false,
+    quietForMs: 8_000,
+    viewport: {
+      devicePixelRatio: 1.5,
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: { meta: { zoom: 1.5 } },
+    },
+  }), false);
+  assert.equal(hasStableZoomEvidence({
+    scale: 2,
+    completionSeen: false,
+    quietForMs: 800,
+    viewport: {
+      devicePixelRatio: 1.5,
+      viewport: { pageW: 3_370, pageH: 2_384 },
+      tile: { meta: { zoom: 1.5, renderScale: 4 } },
+    },
   }), true);
   assert.equal(hasStableZoomEvidence({
     scale: 3,

--- a/open-pdf-studio/js/pdf/bitmap-orchestrator.js
+++ b/open-pdf-studio/js/pdf/bitmap-orchestrator.js
@@ -16,7 +16,8 @@
 
 import { viewport } from './pdf-viewport.js';
 import { computeZoomBucket, ensureBitmap, getBestAvailableBitmap } from './page-bitmap-cache.js';
-import { tileCacheGet, tileCacheSet } from './tile-cache.js';
+import { tileCacheFindCovering, tileCacheGet, tileCacheSet } from './tile-cache.js';
+import { visiblePdfRegion } from './tile-coverage.js';
 import { state } from '../core/state.js';
 import {
     ensureProgressiveBitmapForCurrentView,
@@ -278,27 +279,14 @@ export async function ensureTileForCurrentView(canvas) {
     const cssW = canvas.width / dpr;
     const cssH = canvas.height / dpr;
 
-    // Visible page region in CSS pixels.
-    const visScreenLeft = Math.max(0, -viewport.offsetX);
-    const visScreenTop = Math.max(0, -viewport.offsetY);
-    const visScreenRight = Math.min(viewport.pageW * viewport.zoom, cssW - viewport.offsetX);
-    const visScreenBottom = Math.min(viewport.pageH * viewport.zoom, cssH - viewport.offsetY);
-    const visW = visScreenRight - visScreenLeft;
-    const visH = visScreenBottom - visScreenTop;
-    if (visW < 1 || visH < 1) {
+    const visRegion = visiblePdfRegion(viewport, cssW, cssH);
+    if (visRegion.w * viewport.zoom < 1 || visRegion.h * viewport.zoom < 1) {
         viewport.currentTile = null;
         viewport.currentTileMeta = null;
         return;
     }
 
-    // Convert visible region to PDF points and add buffer for pan-within-
-    // buffer cache hits.
-    const visRegion = {
-        x: visScreenLeft / viewport.zoom,
-        y: visScreenTop / viewport.zoom,
-        w: visW / viewport.zoom,
-        h: visH / viewport.zoom,
-    };
+    // Add buffer for pan-within-buffer cache hits.
     const bufW = visRegion.w * TILE_BUFFER_FRACTION;
     const bufH = visRegion.h * TILE_BUFFER_FRACTION;
     const bufferedRegion = {
@@ -321,6 +309,25 @@ export async function ensureTileForCurrentView(canvas) {
     const rotation = viewport.rotation || 0;
     const requestedZoom = viewport.zoom;
     const requestKey = `${filePath}|${pageNum}|${zoomBucket}|${rotation}|${regionBucket}`;
+
+    // GIS-style tile-cover lookup: zoom buckets describe how a tile was
+    // produced, not where it may be reused. A tile from another zoom level is
+    // immediately valid when it covers the complete visible PDF region and
+    // has enough physical pixels for the current screen.
+    const covering = tileCacheFindCovering(filePath, pageNum, rotation, {
+        regionXpt: visRegion.x,
+        regionYpt: visRegion.y,
+        regionWpt: visRegion.w,
+        regionHpt: visRegion.h,
+        requiredScale: requestedZoom * dpr,
+    });
+    if (covering?.bitmap) {
+        _tileRequests.cancel();
+        viewport.currentTile = covering.bitmap;
+        viewport.currentTileMeta = covering.regionMeta;
+        viewport.dirty = true;
+        return;
+    }
 
     // Cache hit?
     const hit = tileCacheGet(filePath, pageNum, zoomBucket, rotation, regionBucket);

--- a/open-pdf-studio/js/pdf/bitmap-orchestrator.js
+++ b/open-pdf-studio/js/pdf/bitmap-orchestrator.js
@@ -17,7 +17,7 @@
 import { viewport } from './pdf-viewport.js';
 import { computeZoomBucket, ensureBitmap, getBestAvailableBitmap } from './page-bitmap-cache.js';
 import { tileCacheFindCovering, tileCacheGet, tileCacheSet } from './tile-cache.js';
-import { visiblePdfRegion } from './tile-coverage.js';
+import { tileCoversViewport, visiblePdfRegion } from './tile-coverage.js';
 import { state } from '../core/state.js';
 import {
     ensureProgressiveBitmapForCurrentView,
@@ -27,7 +27,9 @@ import {
 import { createInflightKeyGate } from './inflight-key-gate.js';
 import {
     needsVisibleTile,
+    prewarmCoveragePlan,
     prewarmTileRenderScale,
+    tileCoverageRenderScale,
     tileRenderScaleForZoom,
     tileSupportsZoom,
 } from './tile-render-policy.js';
@@ -175,6 +177,92 @@ export async function prewarmZoomTiles(filePath, pageNum) {
     const centerXpt = (cssW / 2 - viewport.offsetX) / viewport.zoom;
     const centerYpt = (cssH / 2 - viewport.offsetY) / viewport.zoom;
 
+    // Eén brede 150%-regio op 300%-resolutie dekt alle tussenliggende
+    // zoomstanden in beide richtingen. Gebruik deze route zolang de bitmap
+    // binnen de bestaande aslimiet past. De tweeregio-route hieronder blijft
+    // de terugval voor bredere schermen totdat de vaste tegelmatrix gereed is.
+    const coveragePlan = prewarmCoveragePlan({
+        zooms: [1.5, 2, 3],
+        devicePixelRatio: dpr,
+    });
+    if (coveragePlan && needsVisibleTile(coveragePlan.supportZoom, dpr, capScale)) {
+        const zoom = coveragePlan.regionZoom;
+        const visW = Math.min(viewport.pageW, cssW / zoom);
+        const visH = Math.min(viewport.pageH, cssH / zoom);
+        const visX = Math.max(0, Math.min(viewport.pageW - visW, centerXpt - visW / 2));
+        const visY = Math.max(0, Math.min(viewport.pageH - visH, centerYpt - visH / 2));
+        const bufW = visW * TILE_BUFFER_FRACTION;
+        const bufH = visH * TILE_BUFFER_FRACTION;
+        const region = {
+            x: Math.max(0, visX - bufW),
+            y: Math.max(0, visY - bufH),
+            w: Math.min(viewport.pageW, visW + 2 * bufW),
+            h: Math.min(viewport.pageH, visH + 2 * bufH),
+        };
+        const renderScale = coveragePlan.renderScale;
+        const outputW = Math.ceil(region.w * renderScale);
+        const outputH = Math.ceil(region.h * renderScale);
+
+        if (outputW <= MAX_BITMAP_AXIS_PX && outputH <= MAX_BITMAP_AXIS_PX) {
+            const zoomBucket = computeZoomBucket(renderScale);
+            const stepX = viewport.pageW * TILE_BUFFER_FRACTION;
+            const stepY = viewport.pageH * TILE_BUFFER_FRACTION;
+            const regionBucket = `${Math.round(Math.floor(region.x / stepX) * stepX * 100)},${Math.round(Math.floor(region.y / stepY) * stepY * 100)}`;
+            const covering = tileCacheFindCovering(filePath, pageNum, viewport.rotation, {
+                regionXpt: region.x,
+                regionYpt: region.y,
+                regionWpt: region.w,
+                regionHpt: region.h,
+                requiredScale: renderScale,
+            });
+            if (covering) return;
+
+            try {
+                const { invokeTileRegion, perfMark } = await import('./progressive-render.js');
+                const started = performance.now();
+                const raw = await invokeTileRegion({
+                    path: filePath,
+                    pageIndex: pageNum - 1,
+                    scale: renderScale,
+                    rotation: viewport.rotation || 0,
+                    regionXPt: region.x,
+                    regionYPt: region.y,
+                    regionWPt: region.w,
+                    regionHPt: region.h,
+                });
+                if (!viewport.active || viewport.filePath !== filePath || viewport.pageNum !== pageNum) return;
+                const bytes = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
+                perfMark(`prewarm-coverage-invoke z=${zoom}-${coveragePlan.supportZoom} ${Math.round(performance.now() - started)}ms (${(bytes.length / 1048576).toFixed(1)}MB)`);
+                if (bytes?.length > 8) {
+                    const dv = new DataView(bytes.buffer, bytes.byteOffset, 8);
+                    const w = dv.getUint32(0, true);
+                    const h = dv.getUint32(4, true);
+                    if (w * h * 4 === bytes.length - 8) {
+                        const cacheStarted = performance.now();
+                        const imageData = new ImageData(
+                            new Uint8ClampedArray(bytes.buffer, bytes.byteOffset + 8, w * h * 4),
+                            w,
+                            h,
+                        );
+                        await tileCacheSet(filePath, pageNum, zoomBucket, viewport.rotation, regionBucket, imageData, {
+                            regionXpt: region.x,
+                            regionYpt: region.y,
+                            regionWpt: region.w,
+                            regionHpt: region.h,
+                            zoom,
+                            renderScale,
+                        });
+                        perfMark(`prewarm-coverage-cacheSet ${w}x${h} ${Math.round(performance.now() - cacheStarted)}ms`);
+                        console.log(`[tile-orch] prewarm coverage z=${zoom}-${coveragePlan.supportZoom} bucket=${zoomBucket} reg=${regionBucket} (${w}x${h})`);
+                        return;
+                    }
+                }
+            } catch (e) {
+                console.warn('[tile-orch] prewarm coverage faalde:', e);
+            }
+        }
+    }
+
     // 1.5 en 3.0 landen (met dpr ~1.25) in zoom-buckets 2 en 4 — dat dekt
     // inzoomen tot ruim 300%.
     for (const zoom of [1.5, 3.0]) {
@@ -286,6 +374,19 @@ export async function ensureTileForCurrentView(canvas) {
         return;
     }
 
+    // Houd een al zichtbare scherpe tegel vast. De algemene cache-selector
+    // kiest terecht de minst oversamplede kandidaat, maar tijdens herhaald
+    // zoomen zou dat een brede 300%-coverage bij 150% vervangen door een
+    // smallere tegel die de volgende zoomstap niet meer aankan.
+    if (
+        viewport.currentTile
+        && tileCoversViewport(viewport.currentTileMeta, viewport, cssW, cssH, dpr)
+    ) {
+        _tileRequests.cancel();
+        viewport.dirty = true;
+        return;
+    }
+
     // Add buffer for pan-within-buffer cache hits.
     const bufW = visRegion.w * TILE_BUFFER_FRACTION;
     const bufH = visRegion.h * TILE_BUFFER_FRACTION;
@@ -344,7 +445,13 @@ export async function ensureTileForCurrentView(canvas) {
     if (!requestToken) return;
     try {
         const { invokeTileRegion } = await import('./progressive-render.js');
-        const renderScale = tileRenderScaleForZoom(requestedZoom, dpr);
+        const renderScale = tileCoverageRenderScale({
+            zoom: requestedZoom,
+            devicePixelRatio: dpr,
+            regionWpt: bufferedRegion.w,
+            regionHpt: bufferedRegion.h,
+            maxBitmapAxisPx: MAX_BITMAP_AXIS_PX,
+        });
         const rgbaData = await invokeTileRegion({
             path: filePath,
             pageIndex: pageNum - 1,

--- a/open-pdf-studio/js/pdf/bitmap-orchestrator.js
+++ b/open-pdf-studio/js/pdf/bitmap-orchestrator.js
@@ -18,9 +18,14 @@ import { viewport } from './pdf-viewport.js';
 import { computeZoomBucket, ensureBitmap, getBestAvailableBitmap } from './page-bitmap-cache.js';
 import { tileCacheGet, tileCacheSet } from './tile-cache.js';
 import { state } from '../core/state.js';
-import { isHeavyPage, ensureProgressiveBitmapForCurrentView } from './progressive-render.js';
+import {
+    ensureProgressiveBitmapForCurrentView,
+    isExtremePage,
+    isHeavyPage,
+} from './progressive-render.js';
 import { createInflightKeyGate } from './inflight-key-gate.js';
 import {
+    needsVisibleTile,
     prewarmTileRenderScale,
     tileRenderScaleForZoom,
     tileSupportsZoom,
@@ -50,19 +55,8 @@ export async function ensureBitmapForCurrentView() {
     // Additief pad: een ZWARE raster-pagina (grote content-stream) met de voorkeur
     // aan, vullen we progressief tegel-voor-tegel in i.p.v. één trage whole-page
     // render. Niet-zware pagina's of voorkeur uit → exact het bestaande pad hieronder.
-    const _prefOn = !!(state.preferences && state.preferences.progressiveRender);
-    const _heavy = _prefOn ? await isHeavyPage(viewport.filePath, viewport.pageNum) : false;
-    if (_prefOn && _heavy) {
-        console.log(`[prog-guard] zware pagina p${viewport.pageNum} → progressief pad`);
-        _bitmapGen++; // maak een eventuele in-flight gewone render stale
-        return ensureProgressiveBitmapForCurrentView();
-    }
-
-    const myGen = ++_bitmapGen;
     const dpr = window.devicePixelRatio || 1;
     const targetScale = viewport.zoom * dpr;
-
-    // Cap so PDFium never has to render above the 4096 px axis limit.
     const maxAxisPt = Math.max(viewport.pageW, viewport.pageH);
     if (maxAxisPt <= 0) {
         viewport.currentBitmap = null;
@@ -70,6 +64,34 @@ export async function ensureBitmapForCurrentView() {
         return;
     }
     const capScale = MAX_BITMAP_AXIS_PX / maxAxisPt;
+
+    const _prefOn = !!(state.preferences && state.preferences.progressiveRender);
+    const _heavy = _prefOn ? await isHeavyPage(viewport.filePath, viewport.pageNum) : false;
+    const _extreme = _heavy ? await isExtremePage(viewport.filePath, viewport.pageNum) : false;
+    if (_prefOn && _heavy && (!_extreme || !needsVisibleTile(viewport.zoom, dpr, capScale))) {
+        console.log(`[prog-guard] zware pagina p${viewport.pageNum} → progressief pad`);
+        _bitmapGen++; // maak een eventuele in-flight gewone render stale
+        return ensureProgressiveBitmapForCurrentView();
+    }
+
+    if (_prefOn && _extreme) {
+        _bitmapGen++;
+        const fallback = getBestAvailableBitmap(
+            viewport.filePath,
+            viewport.pageNum,
+            viewport.rotation,
+            computeZoomBucket(capScale),
+        );
+        if (fallback) {
+            viewport.currentBitmap = fallback.bitmap;
+            viewport.dirty = true;
+        }
+        return;
+    }
+
+    const myGen = ++_bitmapGen;
+
+    // Cap so PDFium never has to render above the 4096 px axis limit.
     const cappedBucket = computeZoomBucket(Math.min(targetScale, capScale));
     // computeZoomBucket is monotonic, so the capped bucket is always <= the requested one
     const useBucket = cappedBucket;
@@ -155,7 +177,7 @@ export async function prewarmZoomTiles(filePath, pageNum) {
     // 1.5 en 3.0 landen (met dpr ~1.25) in zoom-buckets 2 en 4 — dat dekt
     // inzoomen tot ruim 300%.
     for (const zoom of [1.5, 3.0]) {
-        if (zoom <= capScale) continue; // whole-page bitmap dekt dit bereik al
+        if (!needsVisibleTile(zoom, dpr, capScale)) continue;
         if (!viewport.active || viewport.filePath !== filePath || viewport.pageNum !== pageNum) return;
         // Gebruiker weer bezig (view gewijzigd of nieuwe progressieve run)?
         // Dan direct stoppen — de interactie-render heeft voorrang op de
@@ -243,7 +265,8 @@ export async function ensureTileForCurrentView(canvas) {
     const maxAxisPt = Math.max(viewport.pageW, viewport.pageH);
     if (maxAxisPt <= 0) return;
     const capScale = MAX_BITMAP_AXIS_PX / maxAxisPt;
-    if (viewport.zoom <= capScale) {
+    const dpr = window.devicePixelRatio || 1;
+    if (!needsVisibleTile(viewport.zoom, dpr, capScale)) {
         _tileRequests.cancel();
         // Whole-page bitmap is sufficient; clear any stale tile so the
         // renderer doesn't draw a low-zoom tile on top of a fresh raster.
@@ -252,7 +275,6 @@ export async function ensureTileForCurrentView(canvas) {
         return;
     }
 
-    const dpr = window.devicePixelRatio || 1;
     const cssW = canvas.width / dpr;
     const cssH = canvas.height / dpr;
 

--- a/open-pdf-studio/js/pdf/bitmap-orchestrator.js
+++ b/open-pdf-studio/js/pdf/bitmap-orchestrator.js
@@ -19,6 +19,12 @@ import { computeZoomBucket, ensureBitmap, getBestAvailableBitmap } from './page-
 import { tileCacheGet, tileCacheSet } from './tile-cache.js';
 import { state } from '../core/state.js';
 import { isHeavyPage, ensureProgressiveBitmapForCurrentView } from './progressive-render.js';
+import { createInflightKeyGate } from './inflight-key-gate.js';
+import {
+    prewarmTileRenderScale,
+    tileRenderScaleForZoom,
+    tileSupportsZoom,
+} from './tile-render-policy.js';
 
 
 // PDFium / browser canvas axis limit. Above this, we cap the whole-page
@@ -32,7 +38,7 @@ const MAX_BITMAP_AXIS_PX = 4096;
 const TILE_BUFFER_FRACTION = 0.25;
 
 let _bitmapGen = 0;
-let _tileGen = 0;
+const _tileRequests = createInflightKeyGate();
 
 export async function ensureBitmapForCurrentView() {
     if (!viewport.active || !viewport.filePath || viewport.pageType !== 'raster') {
@@ -173,7 +179,19 @@ export async function prewarmZoomTiles(filePath, pageNum) {
         const stepY = viewport.pageH * TILE_BUFFER_FRACTION;
         const regionBucket = `${Math.round(Math.floor(region.x / stepX) * stepX * 100)},${Math.round(Math.floor(region.y / stepY) * stepY * 100)}`;
         const zoomBucket = computeZoomBucket(zoom * dpr);
-        if (tileCacheGet(filePath, pageNum, zoomBucket, viewport.rotation, regionBucket)) continue;
+        const cached = tileCacheGet(filePath, pageNum, zoomBucket, viewport.rotation, regionBucket);
+        if (cached && tileSupportsZoom(cached.regionMeta?.renderScale, zoom, dpr)) continue;
+
+        // The 150% and 200% views often share one power-of-two bucket. Render
+        // the wider 150%-region once at enough density for 200%, but only when
+        // both zoom levels actually belong to the same bucket at this DPR.
+        const supportZoom = zoom === 1.5 ? 2 : zoom;
+        const renderScale = prewarmTileRenderScale({
+            regionZoom: zoom,
+            supportZoom,
+            devicePixelRatio: dpr,
+            zoomBucket,
+        });
 
         try {
             const { invokeTileRegion, perfMark } = await import('./progressive-render.js');
@@ -181,7 +199,7 @@ export async function prewarmZoomTiles(filePath, pageNum) {
             const raw = await invokeTileRegion({
                 path: filePath,
                 pageIndex: pageNum - 1,
-                scale: zoom,
+                scale: renderScale,
                 rotation: viewport.rotation || 0,
                 regionXPt: region.x,
                 regionYPt: region.y,
@@ -204,6 +222,7 @@ export async function prewarmZoomTiles(filePath, pageNum) {
                 regionWpt: region.w,
                 regionHpt: region.h,
                 zoom,
+                renderScale,
             });
             perfMark(`prewarm-cacheSet z=${zoom} ${w}x${h} ${Math.round(performance.now() - _pw1)}ms`);
             console.log(`[tile-orch] prewarm z=${zoom} bucket=${zoomBucket} reg=${regionBucket} (${w}x${h})`);
@@ -216,6 +235,7 @@ export async function prewarmZoomTiles(filePath, pageNum) {
 
 export async function ensureTileForCurrentView(canvas) {
     if (!viewport.active || !viewport.filePath || viewport.pageType !== 'raster' || !canvas) {
+        _tileRequests.cancel();
         viewport.currentTile = null;
         viewport.currentTileMeta = null;
         return;
@@ -224,6 +244,7 @@ export async function ensureTileForCurrentView(canvas) {
     if (maxAxisPt <= 0) return;
     const capScale = MAX_BITMAP_AXIS_PX / maxAxisPt;
     if (viewport.zoom <= capScale) {
+        _tileRequests.cancel();
         // Whole-page bitmap is sufficient; clear any stale tile so the
         // renderer doesn't draw a low-zoom tile on top of a fresh raster.
         viewport.currentTile = null;
@@ -231,7 +252,6 @@ export async function ensureTileForCurrentView(canvas) {
         return;
     }
 
-    const myGen = ++_tileGen;
     const dpr = window.devicePixelRatio || 1;
     const cssW = canvas.width / dpr;
     const cssH = canvas.height / dpr;
@@ -274,10 +294,16 @@ export async function ensureTileForCurrentView(canvas) {
     const regionBucket = `${Math.round(snappedX * 100)},${Math.round(snappedY * 100)}`;
 
     const zoomBucket = computeZoomBucket(viewport.zoom * dpr);
+    const filePath = viewport.filePath;
+    const pageNum = viewport.pageNum;
+    const rotation = viewport.rotation || 0;
+    const requestedZoom = viewport.zoom;
+    const requestKey = `${filePath}|${pageNum}|${zoomBucket}|${rotation}|${regionBucket}`;
 
     // Cache hit?
-    const hit = tileCacheGet(viewport.filePath, viewport.pageNum, zoomBucket, viewport.rotation, regionBucket);
-    if (hit) {
+    const hit = tileCacheGet(filePath, pageNum, zoomBucket, rotation, regionBucket);
+    if (hit && tileSupportsZoom(hit.regionMeta?.renderScale, requestedZoom, dpr)) {
+        _tileRequests.cancel();
         viewport.currentTile = hit.bitmap;
         viewport.currentTileMeta = hit.regionMeta;
         viewport.dirty = true;
@@ -285,19 +311,22 @@ export async function ensureTileForCurrentView(canvas) {
     }
 
     // Cache miss: async Rust render of the region at the requested zoom.
+    const requestToken = _tileRequests.begin(requestKey);
+    if (!requestToken) return;
     try {
         const { invokeTileRegion } = await import('./progressive-render.js');
+        const renderScale = tileRenderScaleForZoom(requestedZoom, dpr);
         const rgbaData = await invokeTileRegion({
-            path: viewport.filePath,
-            pageIndex: viewport.pageNum - 1,
-            scale: viewport.zoom,
-            rotation: viewport.rotation || 0,
+            path: filePath,
+            pageIndex: pageNum - 1,
+            scale: renderScale,
+            rotation,
             regionXPt: bufferedRegion.x,
             regionYPt: bufferedRegion.y,
             regionWPt: bufferedRegion.w,
             regionHPt: bufferedRegion.h,
         });
-        if (myGen !== _tileGen) return;
+        if (!_tileRequests.isCurrent(requestToken)) return;
         const bytes = rgbaData instanceof Uint8Array ? rgbaData : new Uint8Array(rgbaData);
         if (!bytes || bytes.length <= 8) return;
         const view = new DataView(bytes.buffer, bytes.byteOffset, 8);
@@ -314,18 +343,21 @@ export async function ensureTileForCurrentView(canvas) {
             regionYpt: bufferedRegion.y,
             regionWpt: bufferedRegion.w,
             regionHpt: bufferedRegion.h,
-            zoom: viewport.zoom,
+            zoom: requestedZoom,
+            renderScale,
         };
-        await tileCacheSet(viewport.filePath, viewport.pageNum, zoomBucket, viewport.rotation, regionBucket, imageData, regionMeta);
-        if (myGen !== _tileGen) return;
-        const cached = tileCacheGet(viewport.filePath, viewport.pageNum, zoomBucket, viewport.rotation, regionBucket);
+        await tileCacheSet(filePath, pageNum, zoomBucket, rotation, regionBucket, imageData, regionMeta);
+        if (!_tileRequests.isCurrent(requestToken)) return;
+        const cached = tileCacheGet(filePath, pageNum, zoomBucket, rotation, regionBucket);
         if (cached && cached.bitmap) {
             viewport.currentTile = cached.bitmap;
             viewport.currentTileMeta = cached.regionMeta;
             viewport.dirty = true;
-            console.log(`[tile-orch] cached p${viewport.pageNum} @ z=${viewport.zoom.toFixed(2)} reg=${regionBucket}`);
+            console.log(`[tile-orch] cached p${pageNum} @ z=${requestedZoom.toFixed(2)} reg=${regionBucket}`);
         }
     } catch (e) {
         console.warn('[tile-orch] render failed:', e);
+    } finally {
+        _tileRequests.finish(requestToken);
     }
 }

--- a/open-pdf-studio/js/pdf/inflight-key-gate.js
+++ b/open-pdf-studio/js/pdf/inflight-key-gate.js
@@ -1,0 +1,27 @@
+export function createInflightKeyGate() {
+  let generation = 0;
+  let current = null;
+
+  return {
+    begin(key) {
+      if (current?.key === key) return null;
+      current = { key, generation: ++generation };
+      return current;
+    },
+
+    cancel() {
+      generation++;
+      current = null;
+    },
+
+    isCurrent(token) {
+      return current === token && token.generation === generation;
+    },
+
+    finish(token) {
+      if (!this.isCurrent(token)) return false;
+      current = null;
+      return true;
+    },
+  };
+}

--- a/open-pdf-studio/js/pdf/pdf-viewport.js
+++ b/open-pdf-studio/js/pdf/pdf-viewport.js
@@ -12,6 +12,7 @@ import {
   ensureBitmap,
   getCachedBitmap,
 } from './page-bitmap-cache.js';
+import { tileCoversViewport } from './tile-coverage.js';
 
 // ─── Viewport State (singleton via window to survive HMR/dynamic imports) ───
 if (!window.__pdfViewport) {
@@ -1072,17 +1073,42 @@ function nextZoomStep(current, direction) {
 // for fit / center-anchored zooms where keeping the page fully visible is
 // preferable.
 function _anchorAt(screenX, screenY, oldZoom, newZoom, strict = false) {
-  // Snapshot BEFORE mutating viewport.zoom/offset so the freeze-render below
-  // can stretch the captured pixels per the new transform. Idempotent —
-  // additional zoom steps within the debounce window reuse the same snapshot
-  // (so the page still anchors to its ORIGINAL appearance, not the previous
-  // stretched freeze frame, which would compound rounding drift).
-  _captureZoomFreeze();
-
+  // Bereken eerst de toekomstige viewport. Als de huidige tegel die al scherp
+  // dekt, tekenen we hem direct. Alleen een echte cache-miss gebruikt de
+  // uitgerekte snapshot als tijdelijk vangnet.
   const wx = (screenX - viewport.offsetX) / oldZoom;
   const wy = (screenY - viewport.offsetY) / oldZoom;
-  viewport.offsetX = screenX - wx * newZoom;
-  viewport.offsetY = screenY - wy * newZoom;
+  const nextOffsetX = screenX - wx * newZoom;
+  const nextOffsetY = screenY - wy * newZoom;
+  const dpr = _getDpr();
+  const sharpTileReady =
+    viewport.pageType === 'raster'
+    && viewport.currentTile
+    && _canvas
+    && tileCoversViewport(
+      viewport.currentTileMeta,
+      {
+        pageW: viewport.pageW,
+        pageH: viewport.pageH,
+        zoom: newZoom,
+        offsetX: nextOffsetX,
+        offsetY: nextOffsetY,
+      },
+      _canvas.width / dpr,
+      _canvas.height / dpr,
+      dpr,
+    );
+
+  if (sharpTileReady) {
+    if (_zoomFreezeTimer) clearTimeout(_zoomFreezeTimer);
+    _zoomFreezeTimer = null;
+    _zoomFreezeBitmap = null;
+  } else {
+    _captureZoomFreeze();
+  }
+
+  viewport.offsetX = nextOffsetX;
+  viewport.offsetY = nextOffsetY;
   viewport.zoom = newZoom;
   // The user has explicitly placed the view at this anchor point.
   // Tell clampAndCenter() not to override it with auto-centering even if
@@ -1093,7 +1119,9 @@ function _anchorAt(screenX, screenY, oldZoom, newZoom, strict = false) {
 
   // Extend the freeze window for another 150 ms (debounce). Final cleanup
   // (drop snapshot, force one fresh render) happens in the scheduled timer.
-  _scheduleZoomFreezeRelease();
+  if (!sharpTileReady) {
+    _scheduleZoomFreezeRelease();
+  }
 
   // For raster pages, kick the orchestrator so the new zoom-bucket's bitmap
   // and (if zoom > cap) tile get async-fetched. ensureBitmap dedups

--- a/open-pdf-studio/js/pdf/progressive-render.js
+++ b/open-pdf-studio/js/pdf/progressive-render.js
@@ -169,15 +169,14 @@ export async function invokeTileRegion(args) {
       return res;
     }
   }
-  // Tegels SPREIDEN over de pool (parallel). Het pinnen-op-één-worker was
-  // bedoeld voor extreme bladen waar een koude worker seconden aan
-  // content-stream moet parsen — MAAR die (MV-03-klasse, content > 6 MB) gaan
-  // hierboven al naar de scene-engine. Dit PDFium-tegelpad wordt dus alleen
-  // geraakt door gematigde bladen (content 1-6 MB, bv. NKD1a) waar het openen
-  // van de pagina goedkoop is (~0,2 s) en de rendertijd per tegel domineert;
-  // daar wint parallelisme over 4 workers ruim van serieel pinnen (gemeten
-  // NKD1a p2: ~6 s serieel -> ~1,5 s gespreid).
-  const res = await invoke('render_pdf_page_region', { ...args, spread: true });
+  // Gematigde bladen spreiden over de pool. Extreme bladen die door de
+  // scene-engine zijn afgewezen pinnen juist op één affinity-worker: anders
+  // parsen vier processen elk dezelfde enorme content-stream en groeit de
+  // worker-RSS tot meerdere gigabytes.
+  const res = await invoke('render_pdf_page_region', {
+    ...args,
+    spread: shouldSpreadPdfiumFallback(sceneWorthIt),
+  });
   try {
     const { reportActiveEngine } = await import('../solid/stores/engineStatusStore.js');
     reportActiveEngine('pdfium', args.path, args.pageIndex + 1);
@@ -245,6 +244,10 @@ export async function isHeavyPage(filePath, pageNum) {
 // randgevallen) en de drempel zakt pas wanneer de corpus-benchmark
 // (examples/corpus_diff.rs) dat per bladklasse aantoont.
 const SCENE_CONTENT_BYTES = 6_000_000;
+
+export function shouldSpreadPdfiumFallback(sceneWorthIt) {
+  return !sceneWorthIt;
+}
 
 // Generatie-teller voor stale-guards: elke start bumpt hem; na elke await checken
 // we of onze generatie nog actueel is voor we viewport-state muteren. Zo kan een

--- a/open-pdf-studio/js/pdf/progressive-render.js
+++ b/open-pdf-studio/js/pdf/progressive-render.js
@@ -77,9 +77,68 @@ export async function perfDump(reason) {
 }
 // ── einde instrumentatie ──
 
+/**
+ * Coördineert de eerste scene-aanroep per pagina. Tegels voor dezelfde nieuwe
+ * pagina arriveren parallel; zonder deze poort starten ze allemaal tegelijk
+ * dezelfde dure scene-extractie. Eén tegel voert de probe uit. De overige
+ * tegels wachten en gaan na succes via de gecachete scene verder, of vallen na
+ * één gedeelde fout meteen terug op PDFium.
+ */
+export function createSceneAttemptCoordinator() {
+  const broken = new Set();
+  const ready = new Set();
+  const probes = new Map();
+
+  const markBroken = (key, error, onFailure) => {
+    const firstFailure = !broken.has(key);
+    broken.add(key);
+    ready.delete(key);
+    if (firstFailure) onFailure(error);
+  };
+
+  const renderKnownScene = async (key, args, render, onFailure) => {
+    try {
+      return await render(args);
+    } catch (error) {
+      markBroken(key, error, onFailure);
+      return null;
+    }
+  };
+
+  return {
+    async tryRegion(key, args, render, onFailure) {
+      if (broken.has(key)) return null;
+      if (ready.has(key)) return renderKnownScene(key, args, render, onFailure);
+
+      const existing = probes.get(key);
+      if (existing) {
+        const outcome = await existing;
+        if (!outcome.ok || broken.has(key)) return null;
+        return renderKnownScene(key, args, render, onFailure);
+      }
+
+      const probe = (async () => {
+        try {
+          const value = await render(args);
+          ready.add(key);
+          return { ok: true, value };
+        } catch (error) {
+          markBroken(key, error, onFailure);
+          return { ok: false, value: null };
+        } finally {
+          probes.delete(key);
+        }
+      })();
+      probes.set(key, probe);
+      const outcome = await probe;
+      return outcome.ok ? outcome.value : null;
+    },
+  };
+}
+
 // Route A: pagina's waarvoor de display-list-scene niet werkt (image-zwaar,
 // exotische features) vallen blijvend terug op het PDFium-pool-pad.
-const _sceneBroken = new Set();
+const _sceneAttempts = createSceneAttemptCoordinator();
 
 /**
  * Tegel-invoke met scene-first en per-pagina PDFium-fallback. De eigen
@@ -92,18 +151,22 @@ export async function invokeTileRegion(args) {
   const { invoke } = await import('../core/platform.js');
   const key = `${args.path}|${args.pageIndex}|${args.rotation || 0}`;
   const sceneWorthIt = (await pageContentBytes(args.path, args.pageIndex + 1)) > SCENE_CONTENT_BYTES;
-  if (sceneWorthIt && !_sceneBroken.has(key)) {
-    try {
-      const res = await invoke('render_tile_scene_region', args);
+  if (sceneWorthIt) {
+    const res = await _sceneAttempts.tryRegion(
+      key,
+      args,
+      (regionArgs) => invoke('render_tile_scene_region', regionArgs),
+      (error) => {
+        perfMark(`scene-fallback p${args.pageIndex + 1}: ${String(error).slice(0, 80)}`);
+        console.log(`[prog] scene-fallback p${args.pageIndex + 1}: ${String(error).slice(0, 140)}`);
+      },
+    );
+    if (res !== null) {
       try {
         const { reportActiveEngine } = await import('../solid/stores/engineStatusStore.js');
         reportActiveEngine('scene', args.path, args.pageIndex + 1);
       } catch {}
       return res;
-    } catch (e) {
-      _sceneBroken.add(key);
-      perfMark(`scene-fallback p${args.pageIndex + 1}: ${String(e).slice(0, 80)}`);
-      console.log(`[prog] scene-fallback p${args.pageIndex + 1}: ${String(e).slice(0, 140)}`);
     }
   }
   // Tegels SPREIDEN over de pool (parallel). Het pinnen-op-één-worker was

--- a/open-pdf-studio/js/pdf/progressive-render.js
+++ b/open-pdf-studio/js/pdf/progressive-render.js
@@ -245,6 +245,14 @@ export async function isHeavyPage(filePath, pageNum) {
 // (examples/corpus_diff.rs) dat per bladklasse aantoont.
 const SCENE_CONTENT_BYTES = 6_000_000;
 
+export function isSceneCandidateBytes(bytes) {
+  return typeof bytes === 'number' && bytes > SCENE_CONTENT_BYTES;
+}
+
+export async function isExtremePage(filePath, pageNum) {
+  return isSceneCandidateBytes(await pageContentBytes(filePath, pageNum));
+}
+
 export function shouldSpreadPdfiumFallback(sceneWorthIt) {
   return !sceneWorthIt;
 }

--- a/open-pdf-studio/js/pdf/progressive-render.test.mjs
+++ b/open-pdf-studio/js/pdf/progressive-render.test.mjs
@@ -4,6 +4,7 @@ import {
   isHeavyBytes,
   computeTileGrid,
   createSceneAttemptCoordinator,
+  shouldSpreadPdfiumFallback,
 } from './progressive-render.js';
 
 test('isHeavyBytes: drempel = 1MB gecomprimeerde content', () => {
@@ -95,4 +96,9 @@ test('scene coordinator laat na een geslaagde probe de overige regio’s door', 
   assert.equal(await first, 'regio-1');
   assert.equal(await second, 'regio-2');
   assert.deepEqual(calls, [1, 2]);
+});
+
+test('PDFium-fallback spreidt normale pagina’s maar pint extreme scene-fallbacks', () => {
+  assert.equal(shouldSpreadPdfiumFallback(false), true);
+  assert.equal(shouldSpreadPdfiumFallback(true), false);
 });

--- a/open-pdf-studio/js/pdf/progressive-render.test.mjs
+++ b/open-pdf-studio/js/pdf/progressive-render.test.mjs
@@ -6,6 +6,12 @@ import {
   createSceneAttemptCoordinator,
   shouldSpreadPdfiumFallback,
 } from './progressive-render.js';
+import { createInflightKeyGate } from './inflight-key-gate.js';
+import {
+  prewarmTileRenderScale,
+  tileRenderScaleForZoom,
+  tileSupportsZoom,
+} from './tile-render-policy.js';
 
 test('isHeavyBytes: drempel = 1MB gecomprimeerde content', () => {
   assert.equal(isHeavyBytes(2_000_000), true);
@@ -101,4 +107,44 @@ test('scene coordinator laat na een geslaagde probe de overige regio’s door', 
 test('PDFium-fallback spreidt normale pagina’s maar pint extreme scene-fallbacks', () => {
   assert.equal(shouldSpreadPdfiumFallback(false), true);
   assert.equal(shouldSpreadPdfiumFallback(true), false);
+});
+
+test('in-flight key gate dedupliceert dezelfde tegel en maakt alleen oudere keys stale', () => {
+  const gate = createInflightKeyGate();
+  const first = gate.begin('doc|p1|z2|region-a');
+  assert.ok(first);
+  assert.equal(gate.begin('doc|p1|z2|region-a'), null);
+  assert.equal(gate.isCurrent(first), true);
+
+  const second = gate.begin('doc|p1|z3|region-a');
+  assert.ok(second);
+  assert.equal(gate.isCurrent(first), false);
+  assert.equal(gate.finish(first), false);
+  assert.equal(gate.isCurrent(second), true);
+  assert.equal(gate.finish(second), true);
+
+  const third = gate.begin('doc|p1|z3|region-b');
+  gate.cancel();
+  assert.equal(gate.isCurrent(third), false);
+});
+
+test('tegelcache bewaakt de werkelijke schermresolutie', () => {
+  assert.equal(tileRenderScaleForZoom(2, 1.5), 3);
+  assert.equal(tileSupportsZoom(3, 2, 1.5), true);
+  assert.equal(tileSupportsZoom(2, 2, 1.5), false);
+});
+
+test('prewarm dekt 200% alleen mee wanneer 150% dezelfde bucket gebruikt', () => {
+  assert.equal(prewarmTileRenderScale({
+    regionZoom: 1.5,
+    supportZoom: 2,
+    devicePixelRatio: 1.5,
+    zoomBucket: 4,
+  }), 3);
+  assert.equal(prewarmTileRenderScale({
+    regionZoom: 1.5,
+    supportZoom: 2,
+    devicePixelRatio: 1.25,
+    zoomBucket: 2,
+  }), 1.875);
 });

--- a/open-pdf-studio/js/pdf/progressive-render.test.mjs
+++ b/open-pdf-studio/js/pdf/progressive-render.test.mjs
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { isHeavyBytes, computeTileGrid } from './progressive-render.js';
+import {
+  isHeavyBytes,
+  computeTileGrid,
+  createSceneAttemptCoordinator,
+} from './progressive-render.js';
 
 test('isHeavyBytes: drempel = 1MB gecomprimeerde content', () => {
   assert.equal(isHeavyBytes(2_000_000), true);
@@ -37,4 +41,58 @@ test('computeTileGrid: kleiner dan één tegel = één tegel', () => {
   const tiles = computeTileGrid(100, 80, 256);
   assert.equal(tiles.length, 1);
   assert.deepEqual(tiles[0], { px: 0, py: 0, pw: 100, ph: 80 });
+});
+
+test('scene coordinator voert een falende eerste extractiepoging maar één keer uit', async () => {
+  let rejectProbe;
+  const probe = new Promise((resolve, reject) => {
+    rejectProbe = reject;
+  });
+  const calls = [];
+  const failures = [];
+  const render = async (args) => {
+    calls.push(args.tile);
+    return probe;
+  };
+  const coordinator = createSceneAttemptCoordinator();
+
+  const first = coordinator.tryRegion('document|0|0', { tile: 1 }, render, (error) => failures.push(error.message));
+  const second = coordinator.tryRegion('document|0|0', { tile: 2 }, render, (error) => failures.push(error.message));
+  await Promise.resolve();
+  assert.deepEqual(calls, [1]);
+
+  rejectProbe(new Error('commandobudget overschreden'));
+  assert.equal(await first, null);
+  assert.equal(await second, null);
+  assert.deepEqual(failures, ['commandobudget overschreden']);
+
+  assert.equal(
+    await coordinator.tryRegion('document|0|0', { tile: 3 }, render, () => {}),
+    null,
+  );
+  assert.deepEqual(calls, [1]);
+});
+
+test('scene coordinator laat na een geslaagde probe de overige regio’s door', async () => {
+  let resolveProbe;
+  const probe = new Promise((resolve) => {
+    resolveProbe = resolve;
+  });
+  const calls = [];
+  const render = async (args) => {
+    calls.push(args.tile);
+    if (args.tile === 1) return probe;
+    return `regio-${args.tile}`;
+  };
+  const coordinator = createSceneAttemptCoordinator();
+
+  const first = coordinator.tryRegion('document|0|0', { tile: 1 }, render, () => {});
+  const second = coordinator.tryRegion('document|0|0', { tile: 2 }, render, () => {});
+  await Promise.resolve();
+  assert.deepEqual(calls, [1]);
+
+  resolveProbe('regio-1');
+  assert.equal(await first, 'regio-1');
+  assert.equal(await second, 'regio-2');
+  assert.deepEqual(calls, [1, 2]);
 });

--- a/open-pdf-studio/js/pdf/progressive-render.test.mjs
+++ b/open-pdf-studio/js/pdf/progressive-render.test.mjs
@@ -10,7 +10,9 @@ import {
 import { createInflightKeyGate } from './inflight-key-gate.js';
 import {
   needsVisibleTile,
+  prewarmCoveragePlan,
   prewarmTileRenderScale,
+  tileCoverageRenderScale,
   tileRenderScaleForZoom,
   tileSupportsZoom,
 } from './tile-render-policy.js';
@@ -162,4 +164,42 @@ test('prewarm dekt 200% alleen mee wanneer 150% dezelfde bucket gebruikt', () =>
     devicePixelRatio: 1.25,
     zoomBucket: 2,
   }), 1.875);
+});
+
+test('coverage-prewarm rendert één brede lage-zoomregio op de hoogste zoomresolutie', () => {
+  assert.deepEqual(prewarmCoveragePlan({
+    zooms: [1.5, 2, 3],
+    devicePixelRatio: 1.5,
+  }), {
+    regionZoom: 1.5,
+    supportZoom: 3,
+    renderScale: 4.5,
+  });
+});
+
+test('interactive 150% tile covers 300% sharply when the bitmap fits', () => {
+  assert.equal(tileCoverageRenderScale({
+    zoom: 1.5,
+    devicePixelRatio: 1.5,
+    regionWpt: 615,
+    regionHpt: 597,
+  }), 4.5);
+});
+
+test('interactive coverage falls back at the bitmap axis limit', () => {
+  assert.equal(tileCoverageRenderScale({
+    zoom: 1.5,
+    devicePixelRatio: 1.5,
+    regionWpt: 1000,
+    regionHpt: 1000,
+  }), 2.25);
+});
+
+test('interactive coverage does not cap zoom above its support range', () => {
+  assert.equal(tileCoverageRenderScale({
+    zoom: 4,
+    devicePixelRatio: 1.5,
+    regionWpt: 400,
+    regionHpt: 400,
+  }), 6);
 });

--- a/open-pdf-studio/js/pdf/progressive-render.test.mjs
+++ b/open-pdf-studio/js/pdf/progressive-render.test.mjs
@@ -2,12 +2,14 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import {
   isHeavyBytes,
+  isSceneCandidateBytes,
   computeTileGrid,
   createSceneAttemptCoordinator,
   shouldSpreadPdfiumFallback,
 } from './progressive-render.js';
 import { createInflightKeyGate } from './inflight-key-gate.js';
 import {
+  needsVisibleTile,
   prewarmTileRenderScale,
   tileRenderScaleForZoom,
   tileSupportsZoom,
@@ -20,6 +22,12 @@ test('isHeavyBytes: drempel = 1MB gecomprimeerde content', () => {
   assert.equal(isHeavyBytes(500_000), false);
   assert.equal(isHeavyBytes(undefined), false);
   assert.equal(isHeavyBytes(NaN), false);
+});
+
+test('scene-kandidaat begint pas boven de extreme-contentgrens', () => {
+  assert.equal(isSceneCandidateBytes(6_000_000), false);
+  assert.equal(isSceneCandidateBytes(6_000_001), true);
+  assert.equal(isSceneCandidateBytes(undefined), false);
 });
 
 test('computeTileGrid dekt de hele bitmap aaneensluitend, laatste kolom/rij = rest', () => {
@@ -132,6 +140,13 @@ test('tegelcache bewaakt de werkelijke schermresolutie', () => {
   assert.equal(tileRenderScaleForZoom(2, 1.5), 3);
   assert.equal(tileSupportsZoom(3, 2, 1.5), true);
   assert.equal(tileSupportsZoom(2, 2, 1.5), false);
+});
+
+test('zichttegelgrens houdt rekening met schermresolutie', () => {
+  assert.equal(needsVisibleTile(1, 1.5, 1.215), true);
+  assert.equal(needsVisibleTile(0.8, 1.5, 1.215), false);
+  assert.equal(needsVisibleTile(1.3, 1, 1.215), true);
+  assert.equal(needsVisibleTile(0.81, 1.5, 1.215), false);
 });
 
 test('prewarm dekt 200% alleen mee wanneer 150% dezelfde bucket gebruikt', () => {

--- a/open-pdf-studio/js/pdf/tile-cache.js
+++ b/open-pdf-studio/js/pdf/tile-cache.js
@@ -3,6 +3,8 @@
 // regionBucket = "x,y" in PDF points snapped to 25%-viewport buffer grid.
 // Smaller than bitmap-cache because tiles are bigger; LRU max 8.
 
+import { findBestCoveringTile } from './tile-coverage.js';
+
 const CACHE = new Map();
 const MAX = 8;
 
@@ -18,6 +20,25 @@ export function tileCacheGet(filePath, pageNum, zoomBucket, rotation, regionBuck
     CACHE.set(key, entry);
   }
   return entry || null;
+}
+
+export function tileCacheFindCovering(filePath, pageNum, rotation, request) {
+  const pagePrefix = `${filePath}|p${pageNum}|`;
+  const rotationPart = `|r${rotation || 0}|`;
+  const candidates = [];
+
+  for (const [key, entry] of CACHE) {
+    if (key.startsWith(pagePrefix) && key.includes(rotationPart)) {
+      candidates.push({ key, entry, regionMeta: entry.regionMeta });
+    }
+  }
+
+  const hit = findBestCoveringTile(candidates, request);
+  if (!hit) return null;
+
+  CACHE.delete(hit.key);
+  CACHE.set(hit.key, hit.entry);
+  return hit.entry;
 }
 
 export async function tileCacheSet(filePath, pageNum, zoomBucket, rotation, regionBucket, imageData, regionMeta) {

--- a/open-pdf-studio/js/pdf/tile-cache.js
+++ b/open-pdf-studio/js/pdf/tile-cache.js
@@ -22,7 +22,8 @@ export function tileCacheGet(filePath, pageNum, zoomBucket, rotation, regionBuck
 
 export async function tileCacheSet(filePath, pageNum, zoomBucket, rotation, regionBucket, imageData, regionMeta) {
   const key = makeKey(filePath, pageNum, zoomBucket, rotation, regionBucket);
-  while (CACHE.size >= MAX) {
+  const replaced = CACHE.get(key);
+  while (!replaced && CACHE.size >= MAX) {
     const firstKey = CACHE.keys().next().value;
     if (!firstKey) break;
     const old = CACHE.get(firstKey);
@@ -31,6 +32,8 @@ export async function tileCacheSet(filePath, pageNum, zoomBucket, rotation, regi
   }
   try {
     const bitmap = await createImageBitmap(imageData);
+    try { replaced?.bitmap?.close?.(); } catch {}
+    CACHE.delete(key);
     CACHE.set(key, { bitmap, w: imageData.width, h: imageData.height, regionMeta });
   } catch (e) {
     console.warn('[tile-cache] createImageBitmap failed:', e);

--- a/open-pdf-studio/js/pdf/tile-coverage.js
+++ b/open-pdf-studio/js/pdf/tile-coverage.js
@@ -51,3 +51,21 @@ export function visiblePdfRegion(viewport, cssWidth, cssHeight) {
     h: Math.max(0, visibleScreenBottom - visibleScreenTop) / viewport.zoom,
   };
 }
+
+export function tileCoversViewport(
+  tileMeta,
+  viewport,
+  cssWidth,
+  cssHeight,
+  devicePixelRatio,
+) {
+  if (!tileMeta) return false;
+  const region = visiblePdfRegion(viewport, cssWidth, cssHeight);
+  return findBestCoveringTile([{ regionMeta: tileMeta }], {
+    regionXpt: region.x,
+    regionYpt: region.y,
+    regionWpt: region.w,
+    regionHpt: region.h,
+    requiredScale: viewport.zoom * devicePixelRatio,
+  }) !== null;
+}

--- a/open-pdf-studio/js/pdf/tile-coverage.js
+++ b/open-pdf-studio/js/pdf/tile-coverage.js
@@ -1,0 +1,33 @@
+const SCALE_EPSILON = 0.001;
+const BOUNDS_EPSILON_PT = 0.5;
+
+function coversRequest(meta, request, epsilon) {
+  return Number.isFinite(meta.renderScale)
+    && meta.renderScale + SCALE_EPSILON >= request.requiredScale
+    && meta.regionXpt <= request.regionXpt + epsilon
+    && meta.regionYpt <= request.regionYpt + epsilon
+    && meta.regionXpt + meta.regionWpt
+      >= request.regionXpt + request.regionWpt - epsilon
+    && meta.regionYpt + meta.regionHpt
+      >= request.regionYpt + request.regionHpt - epsilon;
+}
+
+/**
+ * Return the cheapest cached tile that is already sharp enough and fully
+ * covers the requested PDF-point viewport.
+ */
+export function findBestCoveringTile(entries, request, epsilon = BOUNDS_EPSILON_PT) {
+  const candidates = entries.filter((entry) =>
+    entry?.regionMeta && coversRequest(entry.regionMeta, request, epsilon));
+
+  candidates.sort((a, b) => {
+    const scaleDifference = a.regionMeta.renderScale - b.regionMeta.renderScale;
+    if (Math.abs(scaleDifference) > SCALE_EPSILON) return scaleDifference;
+
+    const aArea = a.regionMeta.regionWpt * a.regionMeta.regionHpt;
+    const bArea = b.regionMeta.regionWpt * b.regionMeta.regionHpt;
+    return aArea - bArea;
+  });
+
+  return candidates[0] || null;
+}

--- a/open-pdf-studio/js/pdf/tile-coverage.js
+++ b/open-pdf-studio/js/pdf/tile-coverage.js
@@ -31,3 +31,23 @@ export function findBestCoveringTile(entries, request, epsilon = BOUNDS_EPSILON_
 
   return candidates[0] || null;
 }
+
+export function visiblePdfRegion(viewport, cssWidth, cssHeight) {
+  const visibleScreenLeft = Math.max(0, -viewport.offsetX);
+  const visibleScreenTop = Math.max(0, -viewport.offsetY);
+  const visibleScreenRight = Math.min(
+    viewport.pageW * viewport.zoom,
+    cssWidth - viewport.offsetX,
+  );
+  const visibleScreenBottom = Math.min(
+    viewport.pageH * viewport.zoom,
+    cssHeight - viewport.offsetY,
+  );
+
+  return {
+    x: visibleScreenLeft / viewport.zoom,
+    y: visibleScreenTop / viewport.zoom,
+    w: Math.max(0, visibleScreenRight - visibleScreenLeft) / viewport.zoom,
+    h: Math.max(0, visibleScreenBottom - visibleScreenTop) / viewport.zoom,
+  };
+}

--- a/open-pdf-studio/js/pdf/tile-coverage.test.mjs
+++ b/open-pdf-studio/js/pdf/tile-coverage.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findBestCoveringTile } from './tile-coverage.js';
+
+test('reuses a high-resolution tile when zooming out to a covered viewport', () => {
+  const entries = [{
+    id: 'wide-high-res',
+    regionMeta: {
+      regionXpt: 0,
+      regionYpt: 0,
+      regionWpt: 1000,
+      regionHpt: 700,
+      renderScale: 4.5,
+    },
+  }];
+
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100,
+    regionYpt: 100,
+    regionWpt: 800,
+    regionHpt: 500,
+    requiredScale: 2.25,
+  });
+
+  assert.equal(hit?.id, 'wide-high-res');
+});
+
+test('rejects a sharp tile that does not cover the complete viewport', () => {
+  const entries = [{
+    id: 'narrow',
+    regionMeta: {
+      regionXpt: 200,
+      regionYpt: 100,
+      regionWpt: 400,
+      regionHpt: 500,
+      renderScale: 8,
+    },
+  }];
+
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100,
+    regionYpt: 100,
+    regionWpt: 800,
+    regionHpt: 500,
+    requiredScale: 2.25,
+  });
+
+  assert.equal(hit, null);
+});
+
+test('rejects a covering tile below the physical screen resolution', () => {
+  const entries = [{
+    id: 'blurry',
+    regionMeta: {
+      regionXpt: 0,
+      regionYpt: 0,
+      regionWpt: 1000,
+      regionHpt: 700,
+      renderScale: 2,
+    },
+  }];
+
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100,
+    regionYpt: 100,
+    regionWpt: 800,
+    regionHpt: 500,
+    requiredScale: 2.25,
+  });
+
+  assert.equal(hit, null);
+});
+
+test('chooses the least oversampled covering tile', () => {
+  const entries = [
+    {
+      id: 'scale-8',
+      regionMeta: {
+        regionXpt: 0,
+        regionYpt: 0,
+        regionWpt: 1000,
+        regionHpt: 700,
+        renderScale: 8,
+      },
+    },
+    {
+      id: 'scale-4',
+      regionMeta: {
+        regionXpt: 0,
+        regionYpt: 0,
+        regionWpt: 1000,
+        regionHpt: 700,
+        renderScale: 4,
+      },
+    },
+  ];
+
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100,
+    regionYpt: 100,
+    regionWpt: 800,
+    regionHpt: 500,
+    requiredScale: 3,
+  });
+
+  assert.equal(hit?.id, 'scale-4');
+});
+
+test('chooses the smallest covering area when render scales match', () => {
+  const entries = [
+    {
+      id: 'whole-page',
+      regionMeta: {
+        regionXpt: 0,
+        regionYpt: 0,
+        regionWpt: 1200,
+        regionHpt: 800,
+        renderScale: 4,
+      },
+    },
+    {
+      id: 'viewport',
+      regionMeta: {
+        regionXpt: 50,
+        regionYpt: 50,
+        regionWpt: 1000,
+        regionHpt: 650,
+        renderScale: 4,
+      },
+    },
+  ];
+
+  const hit = findBestCoveringTile(entries, {
+    regionXpt: 100,
+    regionYpt: 100,
+    regionWpt: 800,
+    regionHpt: 500,
+    requiredScale: 3,
+  });
+
+  assert.equal(hit?.id, 'viewport');
+});

--- a/open-pdf-studio/js/pdf/tile-coverage.test.mjs
+++ b/open-pdf-studio/js/pdf/tile-coverage.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { findBestCoveringTile } from './tile-coverage.js';
+import { findBestCoveringTile, visiblePdfRegion } from './tile-coverage.js';
 
 test('reuses a high-resolution tile when zooming out to a covered viewport', () => {
   const entries = [{
@@ -140,4 +140,38 @@ test('chooses the smallest covering area when render scales match', () => {
   });
 
   assert.equal(hit?.id, 'viewport');
+});
+
+test('computes the larger PDF cover after zooming out around the same center', () => {
+  const region = visiblePdfRegion({
+    pageW: 1200,
+    pageH: 800,
+    zoom: 1.5,
+    offsetX: -300,
+    offsetY: -150,
+  }, 1200, 750);
+
+  assert.deepEqual(region, {
+    x: 200,
+    y: 100,
+    w: 800,
+    h: 500,
+  });
+});
+
+test('clips the visible PDF region to the page bounds', () => {
+  const region = visiblePdfRegion({
+    pageW: 1000,
+    pageH: 600,
+    zoom: 2,
+    offsetX: 100,
+    offsetY: 50,
+  }, 1200, 800);
+
+  assert.deepEqual(region, {
+    x: 0,
+    y: 0,
+    w: 550,
+    h: 375,
+  });
 });

--- a/open-pdf-studio/js/pdf/tile-coverage.test.mjs
+++ b/open-pdf-studio/js/pdf/tile-coverage.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { findBestCoveringTile, visiblePdfRegion } from './tile-coverage.js';
+import {
+  findBestCoveringTile,
+  tileCoversViewport,
+  visiblePdfRegion,
+} from './tile-coverage.js';
 
 test('reuses a high-resolution tile when zooming out to a covered viewport', () => {
   const entries = [{
@@ -174,4 +178,40 @@ test('clips the visible PDF region to the page bounds', () => {
     w: 550,
     h: 375,
   });
+});
+
+test('recognizes that the current sharp tile covers the future zoom viewport', () => {
+  const covered = tileCoversViewport({
+    regionXpt: 0,
+    regionYpt: 0,
+    regionWpt: 1000,
+    regionHpt: 700,
+    renderScale: 4.5,
+  }, {
+    pageW: 1000,
+    pageH: 700,
+    zoom: 3,
+    offsetX: -900,
+    offsetY: -600,
+  }, 1200, 750, 1.5);
+
+  assert.equal(covered, true);
+});
+
+test('rejects freeze bypass when the current tile misses part of the future viewport', () => {
+  const covered = tileCoversViewport({
+    regionXpt: 400,
+    regionYpt: 250,
+    regionWpt: 200,
+    regionHpt: 150,
+    renderScale: 8,
+  }, {
+    pageW: 1000,
+    pageH: 700,
+    zoom: 3,
+    offsetX: -900,
+    offsetY: -600,
+  }, 1200, 750, 1.5);
+
+  assert.equal(covered, false);
 });

--- a/open-pdf-studio/js/pdf/tile-render-policy.js
+++ b/open-pdf-studio/js/pdf/tile-render-policy.js
@@ -1,0 +1,23 @@
+export function tileRenderScaleForZoom(zoom, devicePixelRatio) {
+  return zoom * devicePixelRatio;
+}
+
+export function prewarmTileRenderScale({
+  regionZoom,
+  supportZoom = regionZoom,
+  devicePixelRatio,
+  zoomBucket,
+}) {
+  const regionScale = tileRenderScaleForZoom(regionZoom, devicePixelRatio);
+  const supportScale = tileRenderScaleForZoom(supportZoom, devicePixelRatio);
+  const lowerBucketBound = zoomBucket / 2;
+  const sharesBucket =
+    supportScale > lowerBucketBound + 0.001
+    && supportScale <= zoomBucket + 0.001;
+  return sharesBucket ? supportScale : regionScale;
+}
+
+export function tileSupportsZoom(renderScale, zoom, devicePixelRatio) {
+  return Number.isFinite(renderScale)
+    && renderScale + 0.001 >= zoom * devicePixelRatio;
+}

--- a/open-pdf-studio/js/pdf/tile-render-policy.js
+++ b/open-pdf-studio/js/pdf/tile-render-policy.js
@@ -2,6 +2,10 @@ export function tileRenderScaleForZoom(zoom, devicePixelRatio) {
   return zoom * devicePixelRatio;
 }
 
+export function needsVisibleTile(zoom, devicePixelRatio, wholePageCapScale) {
+  return tileRenderScaleForZoom(zoom, devicePixelRatio) > wholePageCapScale + 0.001;
+}
+
 export function prewarmTileRenderScale({
   regionZoom,
   supportZoom = regionZoom,

--- a/open-pdf-studio/js/pdf/tile-render-policy.js
+++ b/open-pdf-studio/js/pdf/tile-render-policy.js
@@ -6,6 +6,40 @@ export function needsVisibleTile(zoom, devicePixelRatio, wholePageCapScale) {
   return tileRenderScaleForZoom(zoom, devicePixelRatio) > wholePageCapScale + 0.001;
 }
 
+export function prewarmCoveragePlan({ zooms, devicePixelRatio }) {
+  const sortedZooms = zooms
+    .filter((zoom) => Number.isFinite(zoom) && zoom > 0)
+    .sort((a, b) => a - b);
+  if (!sortedZooms.length) return null;
+
+  const regionZoom = sortedZooms[0];
+  const supportZoom = sortedZooms[sortedZooms.length - 1];
+  return {
+    regionZoom,
+    supportZoom,
+    renderScale: tileRenderScaleForZoom(supportZoom, devicePixelRatio),
+  };
+}
+
+export function tileCoverageRenderScale({
+  zoom,
+  devicePixelRatio,
+  regionWpt,
+  regionHpt,
+  regionZoom = 1.5,
+  supportZoom = 3,
+  maxBitmapAxisPx = 4096,
+}) {
+  const currentScale = tileRenderScaleForZoom(zoom, devicePixelRatio);
+  if (zoom < regionZoom || zoom > supportZoom) return currentScale;
+
+  const coverageScale = tileRenderScaleForZoom(supportZoom, devicePixelRatio);
+  const coverageFits =
+    regionWpt * coverageScale <= maxBitmapAxisPx
+    && regionHpt * coverageScale <= maxBitmapAxisPx;
+  return coverageFits ? coverageScale : currentScale;
+}
+
 export function prewarmTileRenderScale({
   regionZoom,
   supportZoom = regionZoom,

--- a/open-pdf-studio/package.json
+++ b/open-pdf-studio/package.json
@@ -15,7 +15,7 @@
     "tauri:build": "npm run build && tauri build",
     "bump": "node scripts/bump-version.js",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --test scripts/test-nen-ifc-map.mjs scripts/test-systeemraster.mjs js/drafting/tekeningtype.test.mjs js/annotations/editable-numbers.test.mjs js/symbols/templates/wapeningskorf.test.mjs js/pdf/progressive-render.test.mjs js/quantities/engine.test.mjs js/quantities/schedule-image.test.mjs js/quantities/takeoff.test.mjs js/text/text-edit-appearance.test.mjs js/tools/embedded-image-parser.test.mjs",
+    "test:unit": "node --test scripts/test-nen-ifc-map.mjs scripts/test-systeemraster.mjs js/drafting/tekeningtype.test.mjs js/annotations/editable-numbers.test.mjs js/symbols/templates/wapeningskorf.test.mjs js/pdf/progressive-render.test.mjs js/pdf/tile-coverage.test.mjs js/quantities/engine.test.mjs js/quantities/schedule-image.test.mjs js/quantities/takeoff.test.mjs js/text/text-edit-appearance.test.mjs js/tools/embedded-image-parser.test.mjs",
     "test:render": "..\\scripts\\.venv-test\\Scripts\\python.exe ../scripts/render-regression-test.py",
     "test:render:auto": "node ../scripts/run-render-regression.mjs",
     "test:quality": "node --test scripts/native-runtime.test.mjs scripts/release-config.test.mjs scripts/square-image-annotation.test.mjs"


### PR DESCRIPTION
## Samenvatting

Versnelt herhaald in- en uitzoomen op grote vector-PDF's door een scherpe zichtregio als herbruikbare coverage-tegel in het geheugen te houden. De branch bevat daarnaast de gefaseerde benchmark- en stabiliteitsverbeteringen die nodig waren om alleen aantoonbare winst te behouden.

## Wat is gewijzigd

- selecteer gecachte tegels op volledige viewportdekking én fysieke schermresolutie, niet alleen op een exacte zoombucket;
- bouw een brede 150%-zichtregio, wanneer die binnen de bestaande 4096px-aslimiet past, met voldoende dichtheid voor 300%;
- behoud dezelfde scherpe coverage-tegel bij zowel in- als uitzoomen;
- sla de 150ms freeze/snapshot over als de huidige tegel de toekomstige viewport al volledig en scherp dekt;
- dedupliceer zware scene-probes en voorkom dat extreme fallback-parses over meerdere workers worden vermenigvuldigd;
- maak de benchmark HiDPI- en viewportdekkingbewust;
- behoud het bestaande begrensde renderpad als een coverage-bitmap niet binnen de aslimiet past.

## Oorzaak

De eerdere cache was primair georganiseerd rond zoombuckets. Daardoor kon een tegel met voldoende pixels toch worden verworpen omdat hij uit een andere bucket kwam, of kon bij uitzoomen een brede scherpe tegel worden vervangen door een smallere tegel. Vervolgens werd opnieuw gerenderd en bleef ook de vaste freeze-wachttijd actief.

## Praktijkresultaten

Na het gereedkomen van de eerste scherpe zichtregio, gemeten over twintig opeenvolgende sprongen 150% ↔ 300% per bestand:

| Bestand | Mediaan | p95 | Maximum | Cachemissers |
|---|---:|---:|---:|---:|
| MV-03, pagina 1 | 38,9 ms | 47,2 ms | 62,1 ms | 0 |
| NKD1a, pagina 2 | 31,4 ms | 32,4 ms | 67,6 ms | 0 |

De eerste render van een nog niet gecachte zichtregio blijft afhankelijk van de PDF-complexiteit. Deze wijziging voorkomt dat dit werk bij iedere volgende zoomstap opnieuw gebeurt.

## Validatie

- `npm run test:unit`: 87/87 geslaagd;
- `npm run build`: geslaagd;
- live dev-build getest op beide verificatie-PDF's;
- twintig afwisselende 150%/300%-sprongen per bestand zonder cachemissers;
- meetmethode vereist correcte zoom, volledige viewportdekking en `renderScale >= zoom × devicePixelRatio`.

Het volledige meetrapport stond in `docs/performance/2026-07-29-vector-pdf-zoom-results.md`. De latere praktijkregressie en revert worden afgehandeld in PR #321.