### PR TITLE
fix(snap): correct deb search path + pin ref on manual dispatch

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -18,7 +18,12 @@ jobs:
       contents: write
 
     steps:
+      # Zonder expliciete `ref:` checkt workflow_dispatch altijd de default
+      # branch uit, niet de opgegeven versie-tag — dat bouwde tot nu toe
+      # stilzwijgend de hoofdbranch i.p.v. de gevraagde historische release.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref }}
 
       - name: Get version
         id: get-version
@@ -58,7 +63,11 @@ jobs:
       - name: Prepare snap build
         run: |
           # Find the built deb
-          DEB_FILE=$(find open-pdf-studio/src-tauri/target/release/bundle/deb -name "*.deb" | head -1)
+          # De Tauri-bundle landt op de workspace-root ($GITHUB_WORKSPACE/open-pdf-studio/target/...),
+          # NIET onder src-tauri/ — dat extra path-segment liet deze stap de deb
+          # nooit vinden, ongeacht credentials (root cause van de vastgelopen
+          # Snap Store-versie).
+          DEB_FILE=$(find open-pdf-studio/target/release/bundle/deb -name "*.deb" | head -1)
           echo "Found deb: $DEB_FILE"
 
           # Copy deb to repo root for snapcraft


### PR DESCRIPTION
## Summary
Found while trying to bring the Snap Store listing up to date (it's been stuck at v1.47.13 since May while the repo is at v1.84.0):

1. **Root cause of the stuck version**: `Prepare snap build` searches `open-pdf-studio/src-tauri/target/release/bundle/deb`, but the actual Tauri bundle output lands at `open-pdf-studio/target/release/bundle/deb` (workspace-root `target/`, not nested under `src-tauri/`). The `find` has been coming up empty and failing this step on every run I could check (confirmed on the v1.83.0 and v1.84.0 tag-triggered runs, and reproduced again just now) — completely independent of whether `SNAPCRAFT_STORE_CREDENTIALS` is set.
2. `workflow_dispatch` had no explicit checkout `ref:`, so a manual run always built whatever's on the default branch instead of the requested version tag — I hit this myself testing against `v1.84.0` and it silently built `main` (1.85.0-nightly) instead.

## Test plan
- [ ] Merge, then re-run `workflow_dispatch` with `version: v1.84.0` and confirm the deb is found and a `.snap` gets built.
- [ ] Confirm the built snap gets uploaded to the `v1.84.0` release and (since `SNAPCRAFT_STORE_CREDENTIALS` is already set) published to the Snap Store's `stable` channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)