### PR TITLE
fix(snap): deb lives at the workspace root, not open-pdf-studio/

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -63,11 +63,13 @@ jobs:
       - name: Prepare snap build
         run: |
           # Find the built deb
-          # De Tauri-bundle landt op de workspace-root ($GITHUB_WORKSPACE/open-pdf-studio/target/...),
-          # NIET onder src-tauri/ — dat extra path-segment liet deze stap de deb
-          # nooit vinden, ongeacht credentials (root cause van de vastgelopen
-          # Snap Store-versie).
-          DEB_FILE=$(find open-pdf-studio/target/release/bundle/deb -name "*.deb" | head -1)
+          # De Tauri-bundle landt op $GITHUB_WORKSPACE/target/... (repo-ROOT,
+          # ondanks dat de build zelf met working-directory: open-pdf-studio
+          # draait — een gedeelde Cargo target-dir voor de hele monorepo).
+          # Eerdere paden (met src-tauri/ of een open-pdf-studio/-prefix erbij)
+          # vonden de deb dus nooit, ongeacht credentials (root cause van de
+          # vastgelopen Snap Store-versie).
+          DEB_FILE=$(find target/release/bundle/deb -name "*.deb" | head -1)
           echo "Found deb: $DEB_FILE"
 
           # Copy deb to repo root for snapcraft


### PR DESCRIPTION
## Summary
Follow-up to #322. That fix removed the wrong `src-tauri/` path segment but left an `open-pdf-studio/` prefix that also doesn't belong — re-ran the workflow against `v1.84.0` after merging #322 and it still failed at the same step (`find: 'open-pdf-studio/target/release/bundle/deb': No such file or directory`), while the "Build Tauri app" step's own log shows the bundler writing to `$GITHUB_WORKSPACE/target/release/bundle/deb/...` (no `open-pdf-studio/` in that path at all).

Root cause confirmed via the repo's own `Cargo.toml`: it's a Cargo **workspace** with `open-pdf-studio/src-tauri` as a member. Cargo places `target/` at the workspace root by default, not inside the member crate — so the correct path is just `target/release/bundle/deb`, no prefix.

## Test plan
- [ ] Merge, then re-run `workflow_dispatch` with `version: v1.84.0` and confirm the deb is now found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)