### PR TITLE
fix(i18n): Dutch strings and unresolved keys reaching the English UI

### DIFF
--- a/open-pdf-studio/js/annotations/image-drop.js
+++ b/open-pdf-studio/js/annotations/image-drop.js
@@ -6,6 +6,7 @@ import { redrawAnnotations, redrawContinuous } from './rendering.js';
 import { updateStatusMessage } from '../ui/chrome/status-bar.js';
 import { visibleCenterOnPage } from './clipboard.js';
 import { readBinaryFile } from '../core/platform.js';
+import i18next from '../i18n/config.js';
 
 const MIME_BY_EXT = {
   png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
@@ -45,10 +46,10 @@ export async function refreshLinkedImage(annotation, { silent = false } = {}) {
     annotation.originalHeight = img.naturalHeight;
     if (getActiveDocument()?.viewMode === 'continuous') redrawContinuous();
     else redrawAnnotations();
-    if (!silent) updateStatusMessage(`Gelinkte afbeelding vernieuwd: ${annotation.linkedPath.split(/[\\/]/).pop()}`);
+    if (!silent) updateStatusMessage(i18next.t('linkedImage.refreshed', { filename: annotation.linkedPath.split(/[\\/]/).pop() }));
     return true;
   } catch (e) {
-    if (!silent) updateStatusMessage('Gelinkt bestand niet leesbaar — ingesloten versie blijft staan');
+    if (!silent) updateStatusMessage(i18next.t('linkedImage.unreadable'));
     console.warn('[linked-image] refresh failed:', annotation.linkedPath, e);
     return false;
   }

--- a/open-pdf-studio/js/compare/compare-annotations.js
+++ b/open-pdf-studio/js/compare/compare-annotations.js
@@ -10,6 +10,7 @@
 
 import { state } from '../core/state.js';
 import { getAnnotationBounds } from '../core/stores/selection-helpers.js';
+import i18next from '../i18n/config.js';
 
 // Twee annotaties "matchen" als ze hetzelfde type hebben én hun middelpunt
 // binnen deze tolerantie ligt (in pagina-eenheden/punten). Ruim genoeg voor
@@ -42,15 +43,8 @@ function _sig(ann, b) {
 }
 
 function _label(ann) {
-  const t = ann.type || 'annotatie';
-  const nl = {
-    line: 'Lijn', arrow: 'Pijl', draw: 'Vrije tekening', box: 'Rechthoek',
-    circle: 'Ellips', polygon: 'Polygoon', polyline: 'Polylijn', cloud: 'Wolk',
-    highlight: 'Markering', text: 'Tekst', textbox: 'Tekstvak', callout: 'Bijschrift',
-    comment: 'Notitie', image: 'Afbeelding', stamp: 'Stempel', signature: 'Handtekening',
-    measureDistance: 'Afstand', measureArea: 'Oppervlak', measurePerimeter: 'Omtrek',
-  };
-  const base = nl[t] || t;
+  const t = ann.type || 'annotation';
+  const base = i18next.t(`compareAnnType.${t}`, { ns: 'ribbon', defaultValue: t });
   const txt = (ann.text || ann.content || '').trim();
   return txt ? `${base}: ${txt.slice(0, 30)}` : base;
 }

--- a/open-pdf-studio/js/i18n/locales/en/common.json
+++ b/open-pdf-studio/js/i18n/locales/en/common.json
@@ -137,5 +137,20 @@
   "bcfExportFailed": "BCF export failed.",
   "bcfImportFailed": "Could not read BCF file.",
   "bcfInvalidFile": "Invalid or unsupported BCF file.",
-  "bcfNoTopics": "No topics found in BCF file."
+  "bcfNoTopics": "No topics found in BCF file.",
+  "emailBody": "See attached: {{filename}}\n\n(Attach the file: {{path}})",
+  "emailFailed": "Sending the email failed: {{error}}",
+  "linkedImage": {
+    "refreshed": "Linked image refreshed: {{filename}}",
+    "unreadable": "Linked file could not be read \u2014 the embedded version is kept"
+  },
+  "tabs": {
+    "saveBeforeDetach": "Save the document before dragging it to another window.",
+    "detachFailed": "Could not detach the window: {{error}}",
+    "openInNewWindow": "Open in new window",
+    "closeTab": "Close tab"
+  },
+  "quickAccess": {
+    "exportRaster": "Export as raster PDF (opens in a new tab)"
+  }
 }

--- a/open-pdf-studio/js/i18n/locales/en/context.json
+++ b/open-pdf-studio/js/i18n/locales/en/context.json
@@ -45,7 +45,8 @@
     "exportSubmenu": "Export",
     "exportAsImage": "Export as Image...",
     "addHole": "Add Hole",
-    "properties": "Properties..."
+    "properties": "Properties...",
+    "editViewportScale": "Edit Viewport Scale"
   },
   "multiSelect": {
     "copyAnnotations": "Copy {{count}} Annotations",

--- a/open-pdf-studio/js/i18n/locales/en/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/en/dialogs.json
@@ -10,7 +10,10 @@
     "isoBSeries": "ISO B Series",
     "northAmerican": "North American",
     "other": "Other",
-    "customSize": "Custom..."
+    "customSize": "Custom...",
+    "frameFailed": "Could not create a document from the frame: {{error}}",
+    "noFrame": "None (blank page)",
+    "openFramesFolder": "Open the frames folder — your own frames (same naming) appear here automatically"
   },
   "printQueue": {
     "save": "Save",
@@ -24,7 +27,16 @@
     "moveDown": "Move down",
     "merging": "Merging…",
     "opening": "Opening…",
-    "mergedName": "Merged.pdf"
+    "mergedName": "Merged.pdf",
+    "adding": "Adding…",
+    "selectAll": "Select all",
+    "addFile": "+ Add file…",
+    "delete": "Delete",
+    "close": "Close",
+    "dragToReorder": "Drag to reorder",
+    "dropToAdd": "Drop to add",
+    "mergeAndSave": "Merge & save",
+    "mergeAndOpen": "Merge & open"
   },
   "print": {
     "title": "Print",
@@ -85,6 +97,7 @@
       "sending": "Sending to printer…",
       "sent": "Print job sent",
       "failed": "Printing failed: {{error}}",
+        "failedGeneric": "Printing failed",
       "errNoDocument": "no document open",
       "errTempFile": "could not create temporary file"
     }
@@ -403,7 +416,10 @@
     "action": "Compress",
     "done": "Compressed: {{before}} → {{after}} ({{pct}}% smaller).",
     "doneNoGain": "Compression finished: {{after}} (no size reduction achieved).",
-    "failed": "Compression failed: {{error}}"
+    "failed": "Compression failed: {{error}}",
+    "progressPreparing": "Compressing PDF…",
+    "progressPage": "Compressing page {{page}} of {{total}}…",
+    "fileSuffix": "_compressed"
   },
   "scale": {
     "title": "Set Scale",
@@ -422,5 +438,33 @@
     "setAsDefault": "Set as Default",
     "dontAskAgain": "Don't Ask Again",
     "notNow": "Not Now"
+  },
+  "ifcExport": {
+    "saveTitle": "Save as IFC report",
+    "failed": "Saving the IFC report failed: {{error}}"
+  },
+  "styleType": {
+    "lineTypes": "Line types",
+    "arrowTypes": "Arrow types",
+    "dimensionTypes": "Dimension types",
+    "hatchTypes": "Hatch types",
+    "close": "Close",
+    "preview": "Preview",
+    "color": "Color",
+    "textMm": "Text (mm)",
+    "unit": "Unit",
+    "background": "Backgr.",
+    "scale": "Scale",
+    "noBackground": "No background",
+    "deleteType": "Delete type",
+    "resetDefault": "Reset to default",
+    "name": "Name",
+    "thicknessMm": "Thickness (mm)",
+    "style": "Style",
+    "backgroundColor": "Background color",
+    "newType": "New type",
+    "addNewType": "+ New type",
+    "editTitle": "Edit {{kind}}",
+    "genericTypes": "Types"
   }
 }

--- a/open-pdf-studio/js/i18n/locales/en/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/en/preferences.json
@@ -185,7 +185,8 @@
     "deletion": "Deletion",
     "confirmBeforeDeleting": "Confirm before deleting annotations",
     "navigation": "Navigation",
-    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)"
+    "wheelZoomWithoutCtrl": "Zoom with mouse wheel (without holding Ctrl)",
+    "dynamicScaling": "Auto-scale markups"
   },
   "pageDisplay": {
     "rendering": "Rendering",

--- a/open-pdf-studio/js/i18n/locales/en/properties.json
+++ b/open-pdf-studio/js/i18n/locales/en/properties.json
@@ -154,7 +154,8 @@
     "dimTypeCustom": "Custom",
     "extension": "Extension",
     "searchType": "Search…",
-    "editTypes": "Edit types"
+    "editTypes": "Edit types",
+    "noTypesFound": "No types found"
   },
   "scaleBar": {
     "title": "Scale Bar",
@@ -263,7 +264,9 @@
     "refreshLink": "Refresh",
     "unlink": "Unlink",
     "tint": "Color Tint",
-    "tintNone": "None"
+    "tintNone": "None",
+    "linkImageTitle": "Link image",
+    "imageFilter": "Images"
   },
   "multiSelect": "{{count}} annotations selected",
   "pdfText": "PDF Text",

--- a/open-pdf-studio/js/i18n/locales/en/properties.json
+++ b/open-pdf-studio/js/i18n/locales/en/properties.json
@@ -152,7 +152,9 @@
     "precision": "Precision (Decimals)",
     "dimType": "Type",
     "dimTypeCustom": "Custom",
-    "extension": "Extension"
+    "extension": "Extension",
+    "searchType": "Search…",
+    "editTypes": "Edit types"
   },
   "scaleBar": {
     "title": "Scale Bar",
@@ -360,7 +362,8 @@
     "expandAll": "Expand All",
     "collapseAll": "Collapse All",
     "annotationsMenu": "Menu",
-    "schedules": "Schedules"
+    "schedules": "Schedules",
+    "addPage": "Add page"
   },
   "schedules": {
     "title": "Schedules",

--- a/open-pdf-studio/js/i18n/locales/en/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/en/ribbon.json
@@ -95,7 +95,9 @@
     "find": "Find",
     "findCtrlF": "Find (Ctrl+F)",
     "resizePages": "Resize Pages",
-    "resize": "Resize"
+    "resize": "Resize",
+    "ifcExport": "Save as IFC report (.ifcreport)",
+    "emailPdf": "Send by email (PDF as attachment)"
   },
   "comment": {
     "scaleRegion": "Scale Region",
@@ -186,7 +188,9 @@
     "compareGroup": "Compare",
     "fullscreen": "Fullscreen",
     "window": "Window",
-    "display": "Display"
+    "display": "Display",
+    "keystrokes": "Keystrokes",
+    "keystrokesHint": "Show pressed keyboard shortcuts at the bottom left (for screen recordings)"
   },
   "elementVisibility": {
     "buttonTitle": "Element Visibility — show/hide and dim annotation types",
@@ -478,5 +482,27 @@
     "contrast": "Contrast",
     "resetAdjust": "Reset",
     "resetAdjustHint": "Reset grayscale, brightness and contrast"
+  },
+  "compareAnnType": {
+    "line": "Line",
+    "arrow": "Arrow",
+    "draw": "Freehand",
+    "box": "Rectangle",
+    "circle": "Ellipse",
+    "polygon": "Polygon",
+    "polyline": "Polyline",
+    "cloud": "Cloud",
+    "highlight": "Highlight",
+    "text": "Text",
+    "textbox": "Text box",
+    "callout": "Callout",
+    "comment": "Note",
+    "image": "Image",
+    "stamp": "Stamp",
+    "signature": "Signature",
+    "measureDistance": "Distance",
+    "measureArea": "Area",
+    "measurePerimeter": "Perimeter",
+    "annotation": "Annotation"
   }
 }

--- a/open-pdf-studio/js/i18n/locales/en/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/en/ribbon.json
@@ -261,7 +261,9 @@
     "manageWatermarks": "Manage Watermarks",
     "manage": "Manage",
     "compressPdf": "Compress PDF (reduce file size)",
-    "compressLabel": "Compress"
+    "compressLabel": "Compress",
+    "reorderPages": "Reorder",
+    "reorderPagesTitle": "Open thumbnails to drag pages into a new order"
   },
   "help": {
     "settings": "Settings",

--- a/open-pdf-studio/js/i18n/locales/nl/common.json
+++ b/open-pdf-studio/js/i18n/locales/nl/common.json
@@ -137,5 +137,20 @@
   "bcfExportFailed": "BCF-export mislukt.",
   "bcfImportFailed": "BCF-bestand kon niet worden gelezen.",
   "bcfInvalidFile": "Ongeldig of niet-ondersteund BCF-bestand.",
-  "bcfNoTopics": "Geen topics gevonden in BCF-bestand."
+  "bcfNoTopics": "Geen topics gevonden in BCF-bestand.",
+  "emailBody": "Zie bijlage: {{filename}}\n\n(Voeg het bestand toe als bijlage: {{path}})",
+  "emailFailed": "E-mailen mislukt: {{error}}",
+  "linkedImage": {
+    "refreshed": "Gelinkte afbeelding vernieuwd: {{filename}}",
+    "unreadable": "Gelinkt bestand niet leesbaar — ingesloten versie blijft staan"
+  },
+  "tabs": {
+    "saveBeforeDetach": "Sla het document eerst op voor je het naar een ander venster sleept.",
+    "detachFailed": "Window losmaken mislukt: {{error}}",
+    "openInNewWindow": "Open in nieuw venster",
+    "closeTab": "Tab sluiten"
+  },
+  "quickAccess": {
+    "exportRaster": "Exporteer als raster-PDF (opent in nieuw tabblad)"
+  }
 }

--- a/open-pdf-studio/js/i18n/locales/nl/context.json
+++ b/open-pdf-studio/js/i18n/locales/nl/context.json
@@ -45,7 +45,8 @@
     "addHole": "Sparing toevoegen",
     "properties": "Eigenschappen...",
     "calibrateFromLine": "Kalibreren vanuit deze lijn...",
-    "setScale": "Schaal instellen..."
+    "setScale": "Schaal instellen...",
+    "editViewportScale": "Viewport-schaal bewerken"
   },
   "multiSelect": {
     "copyAnnotations": "{{count}} annotaties kopiëren",

--- a/open-pdf-studio/js/i18n/locales/nl/dialogs.json
+++ b/open-pdf-studio/js/i18n/locales/nl/dialogs.json
@@ -10,7 +10,10 @@
     "isoBSeries": "ISO B-reeks",
     "northAmerican": "Noord-Amerikaans",
     "other": "Overig",
-    "customSize": "Aangepast..."
+    "customSize": "Aangepast...",
+    "frameFailed": "Kon document niet aanmaken van kader: {{error}}",
+    "noFrame": "Geen (blanco pagina)",
+    "openFramesFolder": "Kaders-map openen — eigen kaders (zelfde naamgeving) verschijnen hier automatisch"
   },
   "printQueue": {
     "save": "Opslaan",
@@ -24,7 +27,16 @@
     "moveDown": "Omlaag",
     "merging": "Samenvoegen…",
     "opening": "Openen…",
-    "mergedName": "Samengevoegd.pdf"
+    "mergedName": "Samengevoegd.pdf",
+    "adding": "Toevoegen…",
+    "selectAll": "Alles selecteren",
+    "addFile": "+ Bestand toevoegen…",
+    "delete": "Verwijderen",
+    "close": "Sluiten",
+    "dragToReorder": "Sleep om te ordenen",
+    "dropToAdd": "Laat los om toe te voegen",
+    "mergeAndSave": "Samenvoegen & opslaan",
+    "mergeAndOpen": "Samenvoegen & openen"
   },
   "print": {
     "title": "Afdrukken",
@@ -85,6 +97,7 @@
       "sending": "Verzenden naar printer…",
       "sent": "Afdruktaak verzonden",
       "failed": "Afdrukken mislukt: {{error}}",
+        "failedGeneric": "Afdrukken mislukt",
       "errNoDocument": "geen document",
       "errTempFile": "kon tijdelijk bestand niet maken"
     }
@@ -411,7 +424,10 @@
     "action": "Comprimeren",
     "done": "Gecomprimeerd: {{before}} → {{after}} ({{pct}}% kleiner).",
     "doneNoGain": "Comprimeren voltooid: {{after}} (geen verkleining behaald).",
-    "failed": "Comprimeren mislukt: {{error}}"
+    "failed": "Comprimeren mislukt: {{error}}",
+    "progressPreparing": "PDF comprimeren…",
+    "progressPage": "Pagina {{page}} van {{total}} comprimeren…",
+    "fileSuffix": "_gecomprimeerd"
   },
   "scale": {
     "title": "Schaal instellen",
@@ -423,5 +439,33 @@
     "invalidLine": "Ongeldige meetlijn.",
     "ok": "OK",
     "cancel": "Annuleren"
+  },
+  "ifcExport": {
+    "saveTitle": "Opslaan als IFC-report",
+    "failed": "IFC-report opslaan mislukt: {{error}}"
+  },
+  "styleType": {
+    "lineTypes": "Lijn-typen",
+    "arrowTypes": "Pijl-typen",
+    "dimensionTypes": "Maatlijn-typen",
+    "hatchTypes": "Arcering-typen",
+    "close": "Sluiten",
+    "preview": "Voorbeeld",
+    "color": "Kleur",
+    "textMm": "Tekst (mm)",
+    "unit": "Eenheid",
+    "background": "Achtergr.",
+    "scale": "Schaal",
+    "noBackground": "Geen achtergrond",
+    "deleteType": "Type verwijderen",
+    "resetDefault": "Terug naar standaard",
+    "name": "Naam",
+    "thicknessMm": "Dikte (mm)",
+    "style": "Stijl",
+    "backgroundColor": "Achtergrondkleur",
+    "newType": "Nieuw type",
+    "addNewType": "+ Nieuw type",
+    "editTitle": "{{kind}} bewerken",
+    "genericTypes": "Typen"
   }
 }

--- a/open-pdf-studio/js/i18n/locales/nl/preferences.json
+++ b/open-pdf-studio/js/i18n/locales/nl/preferences.json
@@ -157,7 +157,8 @@
     "objectSnapRadius": "Uitlijnstraal (pixels)",
     "snapToPdfContent": "Uitlijnen op PDF-tekeninhoud",
     "navigation": "Navigatie",
-    "wheelZoomWithoutCtrl": "Zoomen met muiswiel (zonder Ctrl ingedrukt)"
+    "wheelZoomWithoutCtrl": "Zoomen met muiswiel (zonder Ctrl ingedrukt)",
+    "dynamicScaling": "Markeringen automatisch schalen"
   },
   "fileAssoc": {
     "defaultPdfApplication": "Standaard PDF-toepassing",

--- a/open-pdf-studio/js/i18n/locales/nl/properties.json
+++ b/open-pdf-studio/js/i18n/locales/nl/properties.json
@@ -221,7 +221,9 @@
     "refreshLink": "Vernieuwen",
     "unlink": "Ontkoppelen",
     "tint": "Kleurtint",
-    "tintNone": "Geen"
+    "tintNone": "Geen",
+    "linkImageTitle": "Afbeelding koppelen",
+    "imageFilter": "Afbeeldingen"
   },
   "multiSelect": "{{count}} annotaties geselecteerd",
   "pdfText": "PDF-tekst",
@@ -355,7 +357,8 @@
     "dimTypeCustom": "Aangepast",
     "extension": "Extensie",
     "searchType": "Zoeken…",
-    "editTypes": "Typen bewerken"
+    "editTypes": "Typen bewerken",
+    "noTypesFound": "Geen typen gevonden"
   },
   "measurements": {
     "scale": "Schaal",

--- a/open-pdf-studio/js/i18n/locales/nl/properties.json
+++ b/open-pdf-studio/js/i18n/locales/nl/properties.json
@@ -320,7 +320,8 @@
     "exportComments": "Opmerkingen exporteren naar gegevensbestand...",
     "exportSelectedComments": "Geselecteerde opmerkingen exporteren naar gegevensbestand...",
     "measurements": "Metingen",
-    "schedules": "Staten"
+    "schedules": "Staten",
+    "addPage": "Pagina toevoegen"
   },
   "scaleBar": {
     "title": "Scale Bar",
@@ -352,7 +353,9 @@
     "precision": "Precisie (decimalen)",
     "dimType": "Type",
     "dimTypeCustom": "Aangepast",
-    "extension": "Extensie"
+    "extension": "Extensie",
+    "searchType": "Zoeken…",
+    "editTypes": "Typen bewerken"
   },
   "measurements": {
     "scale": "Schaal",

--- a/open-pdf-studio/js/i18n/locales/nl/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/nl/ribbon.json
@@ -261,7 +261,9 @@
     "manageWatermarks": "Watermerken beheren",
     "manage": "Beheren",
     "compressPdf": "PDF comprimeren (bestandsgrootte verkleinen)",
-    "compressLabel": "Comprimeren"
+    "compressLabel": "Comprimeren",
+    "reorderPages": "Volgorde",
+    "reorderPagesTitle": "Open miniaturen om pagina’s in een nieuwe volgorde te slepen"
   },
   "help": {
     "information": "Informatie",

--- a/open-pdf-studio/js/i18n/locales/nl/ribbon.json
+++ b/open-pdf-studio/js/i18n/locales/nl/ribbon.json
@@ -95,7 +95,9 @@
     "basic": "Basis",
     "select": "Selecteren",
     "resizePages": "Paginaformaat",
-    "resize": "Formaat"
+    "resize": "Formaat",
+    "ifcExport": "Opslaan als IFC-report (.ifcreport)",
+    "emailPdf": "Verzenden per e-mail (PDF als bijlage)"
   },
   "comment": {
     "scaleRegion": "Schaalgebied",
@@ -186,7 +188,9 @@
     "thinLinesTitle": "Dunne lijnen (Ctrl+5)",
     "thinLines": "Dunne lijnen",
     "fullscreen": "Volledig scherm",
-    "display": "Weergave"
+    "display": "Weergave",
+    "keystrokes": "Sneltoetsen",
+    "keystrokesHint": "Toon ingedrukte sneltoetsen links onderin (voor video-opnames)"
   },
   "elementVisibility": {
     "buttonTitle": "Zichtbaarheid Elementen — toon/verberg en dim annotatie-soorten",
@@ -478,5 +482,27 @@
     "contrast": "Contrast",
     "resetAdjust": "Herstellen",
     "resetAdjustHint": "Grijswaarden, helderheid en contrast terugzetten"
+  },
+  "compareAnnType": {
+    "line": "Lijn",
+    "arrow": "Pijl",
+    "draw": "Vrije tekening",
+    "box": "Rechthoek",
+    "circle": "Ellips",
+    "polygon": "Polygoon",
+    "polyline": "Polylijn",
+    "cloud": "Wolk",
+    "highlight": "Markering",
+    "text": "Tekst",
+    "textbox": "Tekstvak",
+    "callout": "Bijschrift",
+    "comment": "Notitie",
+    "image": "Afbeelding",
+    "stamp": "Stempel",
+    "signature": "Handtekening",
+    "measureDistance": "Afstand",
+    "measureArea": "Oppervlak",
+    "measurePerimeter": "Omtrek",
+    "annotation": "Annotatie"
   }
 }

--- a/open-pdf-studio/js/pdf/compress.js
+++ b/open-pdf-studio/js/pdf/compress.js
@@ -26,6 +26,7 @@ import { renderPageOffscreen, canvasToBytes } from './exporter.js';
 import { getCachedPdfBytes } from './loader.js';
 import { getCacheKey } from './page-manager.js';
 import { PDFDocument } from 'pdf-lib';
+import i18next from '../i18n/config.js';
 
 // Quality presets. Each maps to a render resolution (DPI) and a JPEG quality.
 // Lower DPI + lower quality => smaller file, less detail.
@@ -84,20 +85,21 @@ export async function compressPDF({ level = 'medium', dpi, quality } = {}) {
   const origSize = getCurrentDocumentSize();
 
   const baseName = getPdfBaseName();
-  const outputPath = await saveFileDialog(`${baseName}_gecomprimeerd.pdf`, [
+  const suffix = i18next.t('compress.fileSuffix', { ns: 'dialogs' });
+  const outputPath = await saveFileDialog(`${baseName}${suffix}.pdf`, [
     { name: 'PDF Files', extensions: ['pdf'] },
   ]);
   if (!outputPath) return null;
 
   const totalPages = doc.pdfDoc.numPages;
-  showLoading('PDF comprimeren...');
+  showLoading(i18next.t('compress.progressPreparing', { ns: 'dialogs' }));
 
   try {
     const exportScale = targetDpi / 72;
     const newPdf = await PDFDocument.create();
 
     for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
-      showLoading(`Pagina ${pageNum} van ${totalPages} comprimeren...`);
+      showLoading(i18next.t('compress.progressPage', { ns: 'dialogs', page: pageNum, total: totalPages }));
 
       // Re-render the page (with any annotations baked in) at the target DPI,
       // then re-encode as JPEG — this is where the downsampling happens.

--- a/open-pdf-studio/js/pdf/email-pdf.js
+++ b/open-pdf-studio/js/pdf/email-pdf.js
@@ -28,7 +28,7 @@ export function buildMailtoUrl(subject, body) {
 export async function emailCurrentPdf() {
   const doc = getActiveDocument();
   if (!doc?.pdfDoc) {
-    showMessage(i18next.t('noPdfLoaded', { defaultValue: 'Geen PDF geopend.' }));
+    showMessage(i18next.t('noPdfLoaded'));
     return;
   }
   // Eerst opslaan zodat er een actueel bestand op schijf staat om bij te
@@ -39,14 +39,11 @@ export async function emailCurrentPdf() {
   if (!path) return;
 
   const subject = basename(path);
-  const body = i18next.t('emailBody', {
-    path,
-    defaultValue: `Zie bijlage: ${basename(path)}\n\n(Voeg het bestand toe als bijlage: ${path})`,
-  });
+  const body = i18next.t('emailBody', { filename: basename(path), path });
   try {
     await openExternal(buildMailtoUrl(subject, body));
   } catch (e) {
     const msg = String(e?.message ?? e);
-    showMessage(i18next.t('emailFailed', { error: msg, defaultValue: `E-mailen mislukt: ${msg}` }));
+    showMessage(i18next.t('emailFailed', { error: msg }));
   }
 }

--- a/open-pdf-studio/js/pdf/ifc-export.js
+++ b/open-pdf-studio/js/pdf/ifc-export.js
@@ -16,6 +16,7 @@
 import { getActiveDocument } from '../core/state.js';
 import { getTemplate } from '../symbols/registry.js';
 import { ifcCategoryForAnnotation } from '../solid/data/ifcCategoryMap.js';
+import i18next from '../i18n/config.js';
 
 function _ifcClassFor(ann) {
   return ifcCategoryForAnnotation(ann);
@@ -84,7 +85,7 @@ function _b64(bytes) {
 export async function exportIfcReport() {
   const doc = getActiveDocument();
   if (!doc?.pdfDoc) {
-    alert('Geen document geopend.');
+    alert(i18next.t('noDocumentOpen'));
     return;
   }
 
@@ -134,7 +135,7 @@ export async function exportIfcReport() {
     if (!dlg) throw new Error('dialog API unavailable');
     const suggested = (doc.fileName || 'document').replace(/\.pdf$/i, '') + '.ifcreport';
     const target = await dlg.save({
-      title: 'Opslaan als IFC-report',
+      title: i18next.t('ifcExport.saveTitle', { ns: 'dialogs' }),
       defaultPath: suggested,
       filters: [{ name: 'IFC report', extensions: ['ifcreport'] }],
     });
@@ -144,6 +145,6 @@ export async function exportIfcReport() {
     console.log('[ifc-export] geschreven:', target, `(${entities.length} entiteiten)`);
   } catch (e) {
     console.error('[ifc-export] save failed:', e);
-    alert('IFC-report opslaan mislukt: ' + (e?.message ?? e));
+    alert(i18next.t('ifcExport.failed', { ns: 'dialogs', error: e?.message ?? e }));
   }
 }

--- a/open-pdf-studio/js/pdf/link-layer.js
+++ b/open-pdf-studio/js/pdf/link-layer.js
@@ -106,7 +106,7 @@ function createLinkElement(ann, viewport, pageNum) {
   } else if (ann.dest) {
     // Internal destination (named destination or page reference)
     linkEl.href = '#';
-    linkEl.title = i18next.t('goToPageLink', { ns: 'common' });
+    linkEl.title = i18next.t('leftPanel.goToPageLink', { ns: 'common' });
     linkEl.addEventListener('click', async (e) => {
       e.preventDefault();
       e.stopPropagation();
@@ -192,7 +192,7 @@ function setupActionLink(linkEl, action) {
     case 'GoTo':
       if (action.dest) {
         linkEl.href = '#';
-        linkEl.title = i18next.t('goToPageLink', { ns: 'common' });
+        linkEl.title = i18next.t('leftPanel.goToPageLink', { ns: 'common' });
         linkEl.addEventListener('click', async (e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -205,7 +205,7 @@ function setupActionLink(linkEl, action) {
       // GoToR is "Go to Remote" - opens another PDF file
       // For now, just show a tooltip
       if (action.filename) {
-        linkEl.title = i18next.t('openExternalFile', { ns: 'common', filename: action.filename });
+        linkEl.title = i18next.t('leftPanel.openExternalFile', { ns: 'common', filename: action.filename });
         linkEl.addEventListener('click', (e) => {
           e.preventDefault();
           e.stopPropagation();

--- a/open-pdf-studio/js/pdf/loader.js
+++ b/open-pdf-studio/js/pdf/loader.js
@@ -738,7 +738,7 @@ export async function createDocFromTemplate(templatePath) {
     updateWindowTitle();
   } catch (e) {
     console.error('[template-pdf] failed:', e);
-    alert('Kon document niet aanmaken van kader: ' + (e?.message ?? e));
+    alert(i18next.t('newDoc.frameFailed', { ns: 'dialogs', error: e?.message ?? e }));
   } finally {
     hideLoading();
   }

--- a/open-pdf-studio/js/solid/components/DocumentTabs.jsx
+++ b/open-pdf-studio/js/solid/components/DocumentTabs.jsx
@@ -1,6 +1,7 @@
 import { For, Show, createSignal, onCleanup } from 'solid-js';
 import { state } from '../../core/state.js';
 import { useTranslation } from '../../i18n/useTranslation.js';
+import i18next from '../../i18n/config.js';
 import { invoke } from '../../core/platform.js';
 import {
   revealInFileManager,
@@ -46,7 +47,7 @@ async function detachTabToNewWindow(index) {
   // on close — handing it to another process would leave a dangling reference.
   // Require an explicit save first.
   if (!pdfPath || doc.isUntitled) {
-    alert('Sla het document eerst op voor je het naar een ander venster sleept.');
+    alert(i18next.t('tabs.saveBeforeDetach'));
     return;
   }
   try {
@@ -57,7 +58,7 @@ async function detachTabToNewWindow(index) {
     await closeTabAndMaybeCloseWindow(index);
   } catch (e) {
     console.error('[detach] spawn_window_with_pdf failed:', e);
-    alert('Window losmaken mislukt: ' + (e?.message || e));
+    alert(i18next.t('tabs.detachFailed', { error: e?.message || e }));
   }
 }
 
@@ -238,7 +239,7 @@ async function startNativeTabDrag(index) {
   // Untitled docs live in a temp file this window owns — don't drag them to
   // other instances (the temp file would be deleted out from under them).
   if (!pdfPath || doc.isUntitled) {
-    alert('Sla het document eerst op voor je het naar een ander venster sleept.');
+    alert(i18next.t('tabs.saveBeforeDetach'));
     return;
   }
   // Mark THIS instance as the drag source so our own drop handler ignores a
@@ -323,6 +324,7 @@ function onDocMouseUp(e) {
 export default function DocumentTabs() {
   const { t } = useTranslation('statusbar');
   const { t: tCtx } = useTranslation('context');
+  const { t: tCommon } = useTranslation('common');
 
   const baseName = (p) => ((p || '').split(/[\\/]/).pop() || '').replace(/\.pdf$/i, '');
   const compareTabTip = () => {
@@ -430,7 +432,7 @@ export default function DocumentTabs() {
             onMouseEnter={(e) => e.currentTarget.style.background = '#cce4f7'}
             onMouseLeave={(e) => e.currentTarget.style.background = ''}
             onClick={() => { const idx = ctxMenu().index; hideCtxMenu(); detachTabToNewWindow(idx); }}
-          >Open in nieuw venster</div>
+          >{tCommon('tabs.openInNewWindow')}</div>
           {/* Alleen tonen voor documenten met een echt bestandspad — naamloze/
               nieuwe documenten leven in een temp-bestand dat je de gebruiker
               niet wilt laten zien. Label is platform-specifiek (Verkenner/
@@ -452,7 +454,7 @@ export default function DocumentTabs() {
             onMouseEnter={(e) => e.currentTarget.style.background = '#cce4f7'}
             onMouseLeave={(e) => e.currentTarget.style.background = ''}
             onClick={() => { const idx = ctxMenu().index; hideCtxMenu(); import('../../ui/chrome/tabs.js').then(m => m.closeTab(idx)); }}
-          >Tab sluiten</div>
+          >{tCommon('tabs.closeTab')}</div>
         </div>
       </Show>
     </div>

--- a/open-pdf-studio/js/solid/components/PrintQueueWindow.jsx
+++ b/open-pdf-studio/js/solid/components/PrintQueueWindow.jsx
@@ -8,6 +8,7 @@
 import { createSignal, createEffect, For, Show, onMount, onCleanup } from 'solid-js';
 import { printQueueJobs as queueJobs, refreshPrintQueue, deletePrintJob } from '../stores/printQueueStore.js';
 import { isTauri, invoke, readBinaryFile, writeBinaryFile, saveFileDialog } from '../../core/platform.js';
+import { useTranslation } from '../../i18n/useTranslation.js';
 
 const POLL_MS = 2500;
 
@@ -41,6 +42,7 @@ async function getPdfjs() {
 }
 
 export default function PrintQueueWindow() {
+  const { t } = useTranslation('dialogs');
   const [order, setOrder] = createSignal([]);
   const [checked, setChecked] = createSignal(new Set());
   const [thumbs, setThumbs] = createSignal({});   // file -> dataURL
@@ -156,7 +158,7 @@ export default function PrintQueueWindow() {
   async function ingestPaths(paths) {
     const pdfs = (paths || []).filter(p => typeof p === 'string' && /\.pdf$/i.test(p));
     if (!pdfs.length) return;
-    setBusyMsg('Toevoegen…');
+    setBusyMsg(t('printQueue.adding'));
     try {
       const dir = await spoolDir();
       const P = window.__TAURI__?.path;
@@ -189,7 +191,7 @@ export default function PrintQueueWindow() {
 
   async function saveJob(job) {
     if (!isTauri()) return;
-    setBusyMsg('Opslaan…');
+    setBusyMsg(t('printQueue.saving'));
     try {
       const dest = await saveFileDialog(displayName(job), [{ name: 'PDF', extensions: ['pdf'] }]);
       if (!dest) { setBusyMsg(''); return; }
@@ -204,7 +206,7 @@ export default function PrintQueueWindow() {
   async function mergeAndSave() {
     const targets = checkedJobs();
     if (targets.length === 0) return;
-    setBusyMsg('Samenvoegen…');
+    setBusyMsg(t('printQueue.merging'));
     try {
       const { PDFDocument } = await import('pdf-lib');
       const out = await PDFDocument.create();
@@ -227,7 +229,7 @@ export default function PrintQueueWindow() {
   async function mergeOpen() {
     const targets = checkedJobs();
     if (targets.length === 0) return;
-    setBusyMsg('Samenvoegen…');
+    setBusyMsg(t('printQueue.merging'));
     try {
       const { PDFDocument } = await import('pdf-lib');
       const out = await PDFDocument.create();
@@ -256,12 +258,12 @@ export default function PrintQueueWindow() {
         <span class="pq-title">Open PDF Printer</span>
       </div>
       <div class="pq-toolbar">
-        <label class="pq-selectall" title="Alles selecteren">
+        <label class="pq-selectall" title={t('printQueue.selectAll')}>
           <input type="checkbox" checked={allChecked()} onChange={toggleAll} />
-          Alles selecteren
+          {t('printQueue.selectAll')}
         </label>
         <div class="pq-toolbar-spacer" />
-        <button class="pref-btn" onClick={addFile}>+ Bestand toevoegen…</button>
+        <button class="pref-btn" onClick={addFile}>{t('printQueue.addFile')}</button>
       </div>
       <div class="pq-body">
         <Show when={ordered().length > 0} fallback={
@@ -282,7 +284,7 @@ export default function PrintQueueWindow() {
                   onDrop={(e) => onDropRow(job.file, e)}
                   onDragEnd={() => { setDragFile(null); setOverFile(null); }}
                 >
-                  <span class="pq-grip" title="Sleep om te ordenen">⠿</span>
+                  <span class="pq-grip" title={t('printQueue.dragToReorder')}>⠿</span>
                   <input type="checkbox" checked={checked().has(job.file)} onChange={() => toggle(job.file)} />
                   <div class="pq-tile">
                     <Show when={thumbs()[job.file]} fallback={<span class="pq-tile-ph">PDF</span>}>
@@ -291,14 +293,14 @@ export default function PrintQueueWindow() {
                   </div>
                   <div class="pq-info">
                     <div class="pq-name">{displayName(job)}</div>
-                    <div class="pq-meta">Bladzijden: {job.pages || '?'} · {fmtSize(job.size)} · {fmtTime(job.modifiedMs)}</div>
+                    <div class="pq-meta">{t('printQueue.pages')}: {job.pages || '?'} · {fmtSize(job.size)} · {fmtTime(job.modifiedMs)}</div>
                   </div>
                   <div class="pq-actions">
-                    <button class="pref-btn" title="Omhoog" onClick={() => move(job.file, -1)}>▲</button>
-                    <button class="pref-btn" title="Omlaag" onClick={() => move(job.file, 1)}>▼</button>
-                    <button class="pref-btn" onClick={() => openInStudio(job)}>Openen</button>
-                    <button class="pref-btn" onClick={() => saveJob(job)}>Opslaan</button>
-                    <button class="pref-btn" title="Verwijderen" onClick={() => deletePrintJob(job.file)}>🗑</button>
+                    <button class="pref-btn" title={t('printQueue.moveUp')} onClick={() => move(job.file, -1)}>▲</button>
+                    <button class="pref-btn" title={t('printQueue.moveDown')} onClick={() => move(job.file, 1)}>▼</button>
+                    <button class="pref-btn" onClick={() => openInStudio(job)}>{t('printQueue.open')}</button>
+                    <button class="pref-btn" onClick={() => saveJob(job)}>{t('printQueue.save')}</button>
+                    <button class="pref-btn" title={t('printQueue.delete')} onClick={() => deletePrintJob(job.file)}>🗑</button>
                   </div>
                 </div>
               )}
@@ -306,19 +308,19 @@ export default function PrintQueueWindow() {
           </div>
         </Show>
         <Show when={extHover()}>
-          <div class="pq-drop-overlay">Laat los om toe te voegen</div>
+          <div class="pq-drop-overlay">{t('printQueue.dropToAdd')}</div>
         </Show>
       </div>
       <div class="pq-footer">
         <span class="pq-status">{busyMsg()}</span>
         <div class="pq-footer-btns">
           <button class="pref-btn" disabled={checkedJobs().length === 0} onClick={mergeOpen}>
-            Samenvoegen &amp; openen
+            {t('printQueue.mergeAndOpen')}
           </button>
           <button class="pref-btn pref-btn-primary" disabled={checkedJobs().length === 0} onClick={mergeAndSave}>
-            Samenvoegen &amp; opslaan{checkedJobs().length > 1 ? ` (${checkedJobs().length})` : ''}
+            {t('printQueue.mergeAndSave')}{checkedJobs().length > 1 ? ` (${checkedJobs().length})` : ''}
           </button>
-          <button class="pref-btn pref-btn-secondary" onClick={closeWindow}>Sluiten</button>
+          <button class="pref-btn pref-btn-secondary" onClick={closeWindow}>{t('printQueue.close')}</button>
         </div>
       </div>
     </div>

--- a/open-pdf-studio/js/solid/components/TitleBar.jsx
+++ b/open-pdf-studio/js/solid/components/TitleBar.jsx
@@ -105,7 +105,7 @@ export default function TitleBar() {
             </svg>
           </button>
 
-          <button class="quick-access-btn" title="Exporteer als raster-PDF (opent in nieuw tabblad)" disabled={!hasPdf()}
+          <button class="quick-access-btn" title={tCommon('quickAccess.exportRaster')} disabled={!hasPdf()}
             onClick={handleExportRaster}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
               <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>

--- a/open-pdf-studio/js/solid/components/dialogs/NewDocDialog.jsx
+++ b/open-pdf-studio/js/solid/components/dialogs/NewDocDialog.jsx
@@ -272,13 +272,13 @@ export default function NewDocDialog() {
             onChange={(e) => setStijl(e.target.value)}
             style="flex:1"
           >
-            <option value="">Geen (blanco pagina)</option>
+            <option value="">{t('newDoc.noFrame')}</option>
             <For each={frameIndex()?.stijlen || []}>{(s) => (
               <option value={s}>{_cap(s)}</option>
             )}</For>
           </select>
           <button
-            title="Kaders-map openen — eigen kaders (zelfde naamgeving) verschijnen hier automatisch"
+            title={t('newDoc.openFramesFolder')}
             style="margin-left:6px;padding:2px 8px;border:1px solid var(--theme-border,#acacac);background:var(--theme-surface,#fff);color:var(--theme-text,#333);cursor:pointer;height:24px"
             onClick={() => openFramesFolder()}
           >&#128193;</button>

--- a/open-pdf-studio/js/solid/components/dialogs/StyleTypeEditorDialog.jsx
+++ b/open-pdf-studio/js/solid/components/dialogs/StyleTypeEditorDialog.jsx
@@ -5,6 +5,7 @@ import { state } from '../../../core/state.js';
 import { savePreferences } from '../../../core/preferences.js';
 import { styleTypesFor, STYLE_TYPES } from '../../../annotations/style-types.js';
 import { PreviewSwatch } from '../properties-panel/DimensionTypeSection.jsx';
+import { useTranslation } from '../../../i18n/useTranslation.js';
 
 // Style-type editor — "Bewerken…" from the type picker. Edits are stored as
 // per-id OVERRIDES on top of the built-in presets (preferences
@@ -14,12 +15,13 @@ import { PreviewSwatch } from '../properties-panel/DimensionTypeSection.jsx';
 // Windows dialog pattern (scale-btn footer buttons, surface inputs).
 
 const MM_TO_PT = 72 / 25.4;
-const KIND_TITLES = {
-  line: 'Lijn-typen', arrow: 'Pijl-typen',
-  measureDistance: 'Maatlijn-typen', filledArea: 'Arcering-typen',
+const KIND_TITLE_KEYS = {
+  line: 'styleType.lineTypes', arrow: 'styleType.arrowTypes',
+  measureDistance: 'styleType.dimensionTypes', filledArea: 'styleType.hatchTypes',
 };
 
 export default function StyleTypeEditorDialog(props) {
+  const { t } = useTranslation('dialogs');
   const annType = props.data?.annType || 'line';
   const [version, setVersion] = createSignal(0); // bump to refresh list
 
@@ -81,7 +83,7 @@ export default function StyleTypeEditorDialog(props) {
     const id = `custom-${Date.now().toString(36)}`;
     p.customStyleTypesExtra[annType].push({
       id,
-      label: 'Nieuw type',
+      label: t('styleType.newType'),
       color: base?.color || '#000000',
       props: { ...(base?.props || {}), styleType: undefined },
     });
@@ -99,33 +101,35 @@ export default function StyleTypeEditorDialog(props) {
       ? '68px 1fr 44px 64px 60px 28px' // preview | naam | kleur | tekst | unit | acties
       : '68px 1fr 44px 64px 92px 28px'; // preview | naam | kleur | dikte | stijl | acties
 
+  const kindTitle = () => (KIND_TITLE_KEYS[annType] ? t(KIND_TITLE_KEYS[annType]) : t('styleType.genericTypes'));
+
   return (
     <Dialog
-      title={`${KIND_TITLES[annType] || 'Typen'} bewerken`}
+      title={t('styleType.editTitle', { kind: kindTitle() })}
       dialogClass="style-type-editor-dialog"
       onClose={() => closeDialog('style-type-editor')}
       footer={
         <>
-          <button class="scale-btn" onClick={addNew}>+ Nieuw type</button>
+          <button class="scale-btn" onClick={addNew}>{t('styleType.addNewType')}</button>
           <button class="scale-btn scale-btn-ok"
-            onClick={() => closeDialog('style-type-editor')}>Sluiten</button>
+            onClick={() => closeDialog('style-type-editor')}>{t('styleType.close')}</button>
         </>
       }
     >
       <div class="ste-table">
         {/* Column headers */}
         <div class="ste-row ste-head" style={`grid-template-columns:${gridCols}`}>
-          <span class="ste-col-lbl">Voorbeeld</span>
-          <span class="ste-col-lbl">Naam</span>
-          <span class="ste-col-lbl">Kleur</span>
+          <span class="ste-col-lbl">{t('styleType.preview')}</span>
+          <span class="ste-col-lbl">{t('styleType.name')}</span>
+          <span class="ste-col-lbl">{t('styleType.color')}</span>
           <Show when={annType === 'line' || annType === 'arrow'}>
-            <span class="ste-col-lbl">Dikte (mm)</span><span class="ste-col-lbl">Stijl</span>
+            <span class="ste-col-lbl">{t('styleType.thicknessMm')}</span><span class="ste-col-lbl">{t('styleType.style')}</span>
           </Show>
           <Show when={annType === 'measureDistance'}>
-            <span class="ste-col-lbl">Tekst (mm)</span><span class="ste-col-lbl">Eenheid</span>
+            <span class="ste-col-lbl">{t('styleType.textMm')}</span><span class="ste-col-lbl">{t('styleType.unit')}</span>
           </Show>
           <Show when={annType === 'filledArea'}>
-            <span class="ste-col-lbl">Achtergr.</span><span class="ste-col-lbl">Schaal</span>
+            <span class="ste-col-lbl">{t('styleType.background')}</span><span class="ste-col-lbl">{t('styleType.scale')}</span>
           </Show>
           <span />
         </div>
@@ -136,7 +140,7 @@ export default function StyleTypeEditorDialog(props) {
               <PreviewSwatch annType={annType} entry={d} />
               <input type="text" class="ste-field" value={d.label}
                 onChange={(e) => writeEntry(d.id, { label: e.target.value })} />
-              <input type="color" class="ste-color" value={(d.color || '#000000').slice(0, 7)} title="Kleur"
+              <input type="color" class="ste-color" value={(d.color || '#000000').slice(0, 7)} title={t('styleType.color')}
                 onChange={(e) => {
                   const c = e.target.value;
                   const props = annType === 'filledArea'
@@ -169,9 +173,9 @@ export default function StyleTypeEditorDialog(props) {
 
               <Show when={annType === 'filledArea'}>
                 <div class="ste-bg-cell">
-                  <input type="color" class="ste-color" value={(d.props?.fillColor || '#ffffff').slice(0, 7)} title="Achtergrondkleur"
+                  <input type="color" class="ste-color" value={(d.props?.fillColor || '#ffffff').slice(0, 7)} title={t('styleType.backgroundColor')}
                     onChange={(e) => writeEntry(d.id, { props: { fillColor: e.target.value } })} />
-                  <input type="checkbox" title="Geen achtergrond" checked={!d.props?.fillColor}
+                  <input type="checkbox" title={t('styleType.noBackground')} checked={!d.props?.fillColor}
                     onChange={(e) => writeEntry(d.id, { props: { fillColor: e.target.checked ? null : '#ffffff' } })} />
                 </div>
                 <input type="number" class="ste-field" step="5" min="10" max="600" value={d.props?.hatchScale ?? 100}
@@ -179,11 +183,11 @@ export default function StyleTypeEditorDialog(props) {
               </Show>
 
               <Show when={builtinIds.has(d.id)} fallback={
-                <button class="ste-action-btn ste-delete" title="Type verwijderen"
+                <button class="ste-action-btn ste-delete" title={t('styleType.deleteType')}
                   onClick={() => deleteExtra(d.id)}>✕</button>
               }>
                 <Show when={(state.preferences.customStyleTypes?.[annType] || {})[d.id]} fallback={<span />}>
-                  <button class="ste-action-btn" title="Terug naar standaard"
+                  <button class="ste-action-btn" title={t('styleType.resetDefault')}
                     onClick={() => resetEntry(d.id)}>↺</button>
                 </Show>
               </Show>

--- a/open-pdf-studio/js/solid/components/properties-panel/DimensionTypeSection.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/DimensionTypeSection.jsx
@@ -227,7 +227,7 @@ export default function DimensionTypeSection() {
                 )}
               </For>
               <Show when={filtered().length === 0}>
-                <div style={{ padding: '10px', 'font-size': '12px', opacity: 0.7 }}>Geen typen gevonden</div>
+                <div style={{ padding: '10px', 'font-size': '12px', opacity: 0.7 }}>{t('measurement.noTypesFound')}</div>
               </Show>
             </div>
             <div style={{ 'border-top': '1px solid var(--theme-border, #bbb)', padding: '6px' }}>

--- a/open-pdf-studio/js/solid/components/properties-panel/ImageSection.jsx
+++ b/open-pdf-studio/js/solid/components/properties-panel/ImageSection.jsx
@@ -3,6 +3,7 @@ import { annotProps, sectionVis, updateAnnotProp, resetImageSize, cycleSelectNex
 import CollapsibleSection from './CollapsibleSection.jsx';
 import PrefComboBox from '../preferences/PrefComboBox.jsx';
 import { useTranslation } from '../../../i18n/useTranslation.js';
+import i18next from '../../../i18n/config.js';
 import { getActiveDocument } from '../../../core/state.js';
 
 // Linked image actions — the annotation refreshes its bitmap from this file
@@ -20,8 +21,8 @@ async function _linkImageFile() {
     const dlg = window.__TAURI__?.dialog;
     if (!dlg) return;
     const file = await dlg.open({
-      title: 'Afbeelding koppelen',
-      filters: [{ name: 'Afbeeldingen', extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'] }],
+      title: i18next.t('image.linkImageTitle', { ns: 'properties' }),
+      filters: [{ name: i18next.t('image.imageFilter', { ns: 'properties' }), extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'] }],
       multiple: false,
     });
     if (!file) return;

--- a/open-pdf-studio/js/solid/components/ribbon/HomeTab.jsx
+++ b/open-pdf-studio/js/solid/components/ribbon/HomeTab.jsx
@@ -39,13 +39,13 @@ export default function HomeTab() {
           <RibbonButton id="btn-home-new" title={t('home.newDocument') || 'Nieuw document (kader of blanco)'}
             icon={newDocIcon} label={t('home.new') || 'Nieuw'}
             onClick={() => openDialog('new-doc')} />
-          <RibbonButton id="btn-home-ifc-export" title="Opslaan als IFC-report (.ifcreport)"
+          <RibbonButton id="btn-home-ifc-export" title={t('home.ifcExport')}
             icon={ifcExportIcon} label="IFC-report" disabled={noPdf()}
             onClick={async () => {
               const m = await import('../../../pdf/ifc-export.js');
               m.exportIfcReport();
             }} />
-          <RibbonButton id="btn-home-email" title="Verzenden per e-mail (PDF als bijlage)"
+          <RibbonButton id="btn-home-email" title={t('home.emailPdf')}
             icon={emailIcon} label="E-mail" disabled={noPdf()}
             onClick={async () => {
               const m = await import('../../../pdf/email-pdf.js');

--- a/open-pdf-studio/js/solid/components/ribbon/ViewTab.jsx
+++ b/open-pdf-studio/js/solid/components/ribbon/ViewTab.jsx
@@ -136,9 +136,9 @@ export default function ViewTab() {
             active={isFullscreen()}
             onClick={() => toggleFullscreen()} />
           <RibbonButton id="ribbon-keystroke-overlay"
-            title="Toon ingedrukte sneltoetsen links onderin (voor video-opnames)"
+            title={t('view.keystrokesHint')}
             icon={`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="6" width="20" height="12" rx="1"/><line x1="6" y1="10" x2="6" y2="10.01"/><line x1="10" y1="10" x2="10" y2="10.01"/><line x1="14" y1="10" x2="14" y2="10.01"/><line x1="18" y1="10" x2="18" y2="10.01"/><line x1="7" y1="14" x2="17" y2="14"/></svg>`}
-            label="Sneltoetsen"
+            label={t('view.keystrokes')}
             active={keystrokeOverlayVisible()}
             onClick={toggleKeystrokeOverlay} />
         </RibbonGroup>

--- a/open-pdf-studio/js/solid/stores/printProgressStore.js
+++ b/open-pdf-studio/js/solid/stores/printProgressStore.js
@@ -4,6 +4,7 @@
 // signals, so the user keeps working meanwhile.
 
 import { createSignal } from 'solid-js';
+import i18next from '../../i18n/config.js';
 
 const [active, setActive] = createSignal(false);
 const [label, setLabel] = createSignal('');
@@ -37,7 +38,7 @@ export function finishPrintProgress(l) {
 
 export function failPrintProgress(msg) {
   setIsError(true);
-  setLabel(msg || 'Afdrukken mislukt');
+  setLabel(msg || i18next.t('print.progress.failedGeneric', { ns: 'dialogs' }));
   setValue(1);
   setTimeout(() => { setActive(false); setIsError(false); }, 6000);
 }

--- a/open-pdf-studio/src-tauri/src/email.rs
+++ b/open-pdf-studio/src-tauri/src/email.rs
@@ -12,7 +12,7 @@ pub async fn email_pdf(path: String, subject: Option<String>) -> Result<(), Stri
     // it off the async runtime.
     tokio::task::spawn_blocking(move || email_impl(&path, &subject))
         .await
-        .map_err(|e| format!("e-mailtaak mislukt: {e}"))?
+        .map_err(|e| format!("email task failed: {e}"))?
 }
 
 #[cfg(target_os = "windows")]
@@ -101,7 +101,7 @@ fn email_impl(path: &str, subject: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!(
-            "Geen standaard e-mailprogramma gevonden (MAPI-code {r}). Stel een MAPI-mailclient in (bv. Outlook/Thunderbird)."
+            "No default email program found (MAPI code {r}). Set up a MAPI mail client (e.g. Outlook/Thunderbird)."
         ))
     }
 }
@@ -115,7 +115,7 @@ fn email_impl(path: &str, subject: &str) -> Result<(), String> {
         .arg(path)
         .spawn()
         .map(|_| ())
-        .map_err(|e| format!("xdg-email niet beschikbaar: {e}"))
+        .map_err(|e| format!("xdg-email is not available: {e}"))
 }
 
 #[cfg(target_os = "macos")]
@@ -135,10 +135,10 @@ fn email_impl(path: &str, subject: &str) -> Result<(), String> {
         .arg(script)
         .spawn()
         .map(|_| ())
-        .map_err(|e| format!("Mail openen mislukt: {e}"))
+        .map_err(|e| format!("Could not open the mail client: {e}"))
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
 fn email_impl(_path: &str, _subject: &str) -> Result<(), String> {
-    Err("E-mailen wordt op dit platform niet ondersteund.".to_string())
+    Err("Email is not supported on this platform.".to_string())
 }

--- a/open-pdf-studio/src-tauri/src/lib.rs
+++ b/open-pdf-studio/src-tauri/src/lib.rs
@@ -1033,7 +1033,7 @@ Set-Printer -Name 'Open PDF Printer' -PortName $port"#,
     }
     #[cfg(not(target_os = "windows"))]
     {
-        Err("alleen op Windows".into())
+        Err("Windows only".into())
     }
 }
 
@@ -1163,7 +1163,7 @@ fn open_pdf_in_default_viewer(path: String) -> Result<bool, String> {
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         let _ = &path;
-        return Err("Openen in externe viewer wordt op dit platform niet ondersteund".into());
+        return Err("Opening in an external viewer is not supported on this platform".into());
     }
     #[cfg(target_os = "windows")]
     {
@@ -1211,7 +1211,7 @@ fn reveal_in_file_manager(path: String) -> Result<bool, String> {
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         let _ = &path;
-        return Err("Tonen in bestandsbeheer wordt op dit platform niet ondersteund".into());
+        return Err("Showing in the file manager is not supported on this platform".into());
     }
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
Running the app in English, a fair number of strings still come out in Dutch, and a few come out as the raw translation key. This fixes the ones I could find in the core viewing/annotating/page-handling paths.

There turned out to be three separate causes.

### 1. Keys that resolve to nothing

`t()` returns the key itself when the lookup misses, and the key is a truthy string, so the `t('x') || 'fallback'` idiom never reaches its fallback. The key is what lands on screen:

| Where | Rendered |
|---|---|
| every PDF link tooltip | `goToPageLink` / `openExternalFile` |
| Reorder button, Edit & Combine | `organize.reorderPages` |
| thumbnail "+" tile tooltip | `leftPanel.addPage` |
| viewport-scale context item | `annotation.editViewportScale` |
| Auto-scale markups preference | `behavior.dynamicScaling` |
| dimension-type search box | `measurement.searchType` |

The two link-layer ones were only asking at the wrong path — the strings are already there under `leftPanel.`. The rest are added to `en` and `nl`.

### 2. Dutch string literals that never went through i18next

These stayed Dutch in all 37 languages. The ones most likely to be hit:

- **Compress** — `PDF comprimeren…`, `Pagina X van Y comprimeren…`, and a `_gecomprimeerd` default filename in the Save As dialog. The rest of that dialog is already localised under `dialogs:compress`, so it looks like just the progress and the suffix got missed.
- **Print queue window** — most of it: `Openen`, `Opslaan`, `Verwijderen`, `Sluiten`, `Omhoog`, `Omlaag`, `Alles selecteren`, `Bladzijden`, `Samenvoegen…`. Several of the strings it needs already existed under `dialogs:printQueue` and just were not wired up, so this reuses those rather than adding duplicates.
- **View tab** — the keystroke-overlay button, both its label (`Sneltoetsen`) and its tooltip.
- **Compare** — the change list's annotation type names came from a hardcoded Dutch map (`Wolk`, `Bijschrift`, `Vrije tekening`, …).
- Document tab context menu and detach warnings, Home tab IFC/email tooltips, the quick-access raster export tooltip, the style-type editor, the new-document frame picker, linked-image status messages, and the IFC export dialog.

### 3. Dutch error strings on the Rust side

Most errors returned from Rust are already English (`"Printing is only supported on Windows"`, `"PDF has no pages"`). A handful were Dutch, so whichever surfaced arrived in a different language from the rest. These are low-traffic paths — two sit behind `cfg(not(windows/macos/linux))` and `email_pdf` is not currently called from the front end — so it is consistency rather than a fix for something users hit today. No i18n involved, just English literals like the neighbours.

---

**Scope.** New keys go into `en` and `nl` only; the other languages fall back to `en`, which is already how they behave for keys they do not carry. I deliberately left alone the `t('someKey') || 'Dutch'` fallbacks where the key *does* resolve — those never render, and the idiom is common enough that stripping it here would be churn.

I also stopped at the core viewing/annotating/page-handling surface. There is more Dutch in the CAD, quantities, symbol-library and assistant areas, but that looked like ground you are actively working on and I did not want to collide with it. Happy to do a follow-up there if it would help, or to split this PR up if three commits in one is awkward.

**Checks.** `vite build` passes, `tsc --noEmit` is clean, `npm run test:unit` is 87/87. All 312 locale files still parse, and `en`/`nl` stay at key parity for every namespace touched. I do not have a Rust toolchain on this machine, so the `src-tauri` change is string-literal-only and unverified locally — CI will be the first real compile of it.
