### PR TITLE
fix(text): keep the base letter when a diacritic cannot be encoded

### DIFF
--- a/open-pdf-studio/js/text/text-edit-appearance.js
+++ b/open-pdf-studio/js/text/text-edit-appearance.js
@@ -223,6 +223,13 @@ const WINANSI_REPLACEMENTS = new Map([
   ['′', "'"],  // prime
   ['″', '"'],  // double prime
   ['ʼ', "'"],  // modifier apostrophe
+  // Doorstreepte/puntloze letters hebben geen NFD-ontbinding, dus die kunnen
+  // niet door stripDiacritics() worden afgehandeld.
+  ['ı', 'i'],  // dotless i (tr)
+  ['ł', 'l'],  // l with stroke (pl)
+  ['Ł', 'L'],
+  ['đ', 'd'],  // d with stroke (hr/vi)
+  ['Đ', 'D'],
 ]);
 
 export function isWinAnsiCodePoint(cp) {
@@ -230,6 +237,19 @@ export function isWinAnsiCodePoint(cp) {
   if (cp >= 0x20 && cp <= 0x7E) return true;
   if (cp >= 0xA0 && cp <= 0xFF) return true;
   return WINANSI_EXTRA.has(cp);
+}
+
+// Ontbindt een letter met diakritisch teken en houdt alleen het basisteken
+// over, mits dat basisteken zelf WinAnsi is: 'ā' -> 'a', 'č' -> 'c'. Dekt heel
+// Latin Extended zonder een tabel per teken. Retourneert null als er niets
+// bruikbaars overblijft.
+function stripDiacritics(ch) {
+  const base = ch.normalize('NFD').replace(/\p{M}/gu, '');
+  if (!base || base === ch) return null;
+  for (const c of base) {
+    if (!isWinAnsiCodePoint(c.codePointAt(0))) return null;
+  }
+  return base;
 }
 
 // Vervangt niet-WinAnsi-tekens door een naaste equivalent (of '?').
@@ -244,7 +264,9 @@ export function sanitizeWinAnsiText(text) {
       out += ch;
       continue;
     }
-    const repl = WINANSI_REPLACEMENTS.has(ch) ? WINANSI_REPLACEMENTS.get(ch) : '?';
+    const repl = WINANSI_REPLACEMENTS.has(ch)
+      ? WINANSI_REPLACEMENTS.get(ch)
+      : (stripDiacritics(ch) ?? '?');
     out += repl;
     replaced.push(ch);
   }

--- a/open-pdf-studio/js/text/text-edit-appearance.test.mjs
+++ b/open-pdf-studio/js/text/text-edit-appearance.test.mjs
@@ -145,6 +145,24 @@ test('WinAnsi sanitizer falls back to ? for unmapped characters', () => {
   assert.equal(sanitizeWinAnsiText('a\nb').text, 'a\nb');
 });
 
+test('WinAnsi sanitizer keeps the base letter of a diacritic it cannot encode', () => {
+  // Latin Extended letters decompose to a WinAnsi base, so the word stays
+  // readable instead of collapsing to '?'.
+  assert.equal(sanitizeWinAnsiText('M\u0101ori wh\u0101nau').text, 'Maori whanau');
+  assert.equal(sanitizeWinAnsiText('\u0100\u0101 \u0112\u0113 \u012a\u012b \u014c\u014d \u016a\u016b').text, 'Aa Ee Ii Oo Uu');
+  // 'C with caron' has no WinAnsi slot so it degrades to 'C'; 's with caron'
+  // is in WINANSI_EXTRA and survives untouched.
+  assert.equal(sanitizeWinAnsiText('\u010ce\u0161tina').text, 'Ce\u0161tina');
+
+  // Stroke and dotless letters have no decomposition, so they are mapped.
+  assert.equal(sanitizeWinAnsiText('\u0141\u00f3d\u017a').text, 'L\u00f3dz');
+  assert.equal(sanitizeWinAnsiText('\u0110\u00e0 N\u1eb5ng').text, 'D\u00e0 Nang');
+  assert.equal(sanitizeWinAnsiText('\u0131\u011f\u015f').text, 'igs');
+
+  // Non-Latin scripts still have no sensible base letter.
+  assert.equal(sanitizeWinAnsiText('\u042c').text, '?');
+});
+
 test('text angle is derived from the span matrix and snapped to right angles', () => {
   assert.equal(textEditAngleFromTransform([11, 0, 0, 11, 100, 200]), 0);
   // 90° CCW authored text (as on /Rotate 90 pages): [0, fs, -fs, 0]


### PR DESCRIPTION
`sanitizeWinAnsiText` falls back to `'?'` for anything outside WinAnsi with no entry in `WINANSI_REPLACEMENTS`. That map covers maths symbols, arrows, spaces and ligatures, but no accented letters — so every letter in Latin Extended is currently lost. Editing a line that reads `Čeština` saves it as `?e?tina`.

I went looking for how wide this is, and ran the current sanitizer over the app's own locale files:

- **all 39 shipped languages** contain at least one character that becomes `?`
- **4,662** Latin-script occurrences in total
- 45 distinct Latin letters, the most common being `ı` (620), `ť` (413), `č` (413), `ř` (295), `ž` (274), `š` (217)
- worst affected: Czech, Turkish, Polish, Hungarian, Croatian, Romanian, Slovak, Vietnamese

So anyone editing text in their own language in most of the locales you ship gets `?` back.

### The change

Rather than grow the table one letter at a time, decompose with NFD and drop the combining marks — `ā` → `a`, `č` → `c`. That covers all of Latin Extended in a few lines:

```js
function stripDiacritics(ch) {
  const base = ch.normalize('NFD').replace(/\p{M}/gu, '');
  if (!base || base === ch) return null;
  for (const c of base) {
    if (!isWinAnsiCodePoint(c.codePointAt(0))) return null;
  }
  return base;
}
```

It only applies when every resulting base character is itself WinAnsi, so non-Latin scripts still fall through to `'?'` exactly as before — the existing `'hobЬi �'` test passes unchanged.

Five letters have no decomposition (`ı`, `ł`, `Ł`, `đ`, `Đ`), so they get explicit map entries. After that, none of the 4,662 occurrences degrade to `?`. Characters already in `WINANSI_EXTRA` such as `š` are untouched, which is why `Čeština` comes out as `Ceština` rather than `Cestina`.

### Worth being clear about

This is lossy by design. The accent is dropped, not preserved — rendering the real glyph needs an embedded Unicode font, which is a much bigger change and a bundle-size decision that is yours to make. Dropping the accent at least leaves the word readable, which `?` does not. Happy to look at the font route separately if you would want it.

41 lines added across the module and its test file, no new dependencies. `npm run test:unit` is 230/230 with the new case, `vite build` and `tsc --noEmit` are clean.
