### PR TITLE
fix(i18n): translate filled-area sketch toolbar and box-size labels

### DIFF
--- a/open-pdf-studio/js/i18n/locales/ar/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ar/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "خط",
+    "lineTitle": "مقطع مستقيم",
+    "arc": "قوس",
+    "arcTitle": "مقطع قوس (مفتاح A، عجلة الفأرة = التحدّب)",
+    "closeOuter": "إغلاق المحيط",
+    "closeOuterTitle": "أغلق المحيط الخارجي (≥ 3 نقاط) — يمكنك بعدها رسم فتحات",
+    "closeHole": "إغلاق الفتحة",
+    "closeHoleTitle": "إغلاق الفتحة (≥ 3 نقاط)",
+    "done": "تم",
+    "doneTitle": "يتحقق من إغلاق المحيطات، يرسم التظليل، ويخرج من الوضع (Enter)",
+    "cancelTitle": "إلغاء (Esc)",
+    "outerClosed": "المحيط الخارجي مغلق ✓ · الفتحات: {{count}}",
+    "drawingHole": " · جارٍ رسم الفتحة ({{count}} نقطة)",
+    "outerOpenClosable": "المحيط الخارجي مفتوح — {{count}} نقاط (قابل للإغلاق)",
+    "outerOpen": "المحيط الخارجي مفتوح — {{count}} نقطة"
+  },
+  "boxWidthAbbr": "ع",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/bg/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/bg/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Линия",
+    "lineTitle": "Прав сегмент",
+    "arc": "Дъга",
+    "arcTitle": "Сегмент от дъга (клавиш A, колелце на мишката = изпъкналост)",
+    "closeOuter": "Затвори контура",
+    "closeOuterTitle": "Затвори външния контур (≥ 3 точки) — после можете да чертаете отвори (донът)",
+    "closeHole": "Затвори отвора",
+    "closeHoleTitle": "Затвори отвора (≥ 3 точки)",
+    "done": "Готово",
+    "doneTitle": "Проверява дали контурите са затворени, чертае щриховката и излиза от режима (Enter)",
+    "cancelTitle": "Отказ (Esc)",
+    "outerClosed": "Външен контур затворен ✓ · отвори: {{count}}",
+    "drawingHole": " · чертане на отвор ({{count}} точка/и)",
+    "outerOpenClosable": "Външен контур отворен — {{count}} точки (може да се затвори)",
+    "outerOpen": "Външен контур отворен — {{count}} точка/и"
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/bn/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/bn/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "রেখা",
+    "lineTitle": "সরল অংশ",
+    "arc": "চাপ",
+    "arcTitle": "চাপ অংশ (কী A, মাউস হুইল = স্ফীতি)",
+    "closeOuter": "রূপরেখা বন্ধ করুন",
+    "closeOuterTitle": "বাইরের রূপরেখা বন্ধ করুন (≥ 3 পয়েন্ট) — তারপর আপনি খোলা অংশ আঁকতে পারবেন",
+    "closeHole": "খোলা অংশ বন্ধ করুন",
+    "closeHoleTitle": "খোলা অংশ বন্ধ করুন (≥ 3 পয়েন্ট)",
+    "done": "সম্পন্ন",
+    "doneTitle": "রূপরেখা বন্ধ কিনা যাচাই করে, হ্যাচিং আঁকে এবং মোড থেকে বেরিয়ে যায় (Enter)",
+    "cancelTitle": "বাতিল (Esc)",
+    "outerClosed": "বাইরের রূপরেখা বন্ধ ✓ · খোলা অংশ: {{count}}",
+    "drawingHole": " · খোলা অংশ আঁকা হচ্ছে ({{count}} পয়েন্ট)",
+    "outerOpenClosable": "বাইরের রূপরেখা খোলা — {{count}} পয়েন্ট (বন্ধ করা যাবে)",
+    "outerOpen": "বাইরের রূপরেখা খোলা — {{count}} পয়েন্ট"
+  },
+  "boxWidthAbbr": "প",
+  "boxHeightAbbr": "উ"
 }

--- a/open-pdf-studio/js/i18n/locales/ca/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ca/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Línia",
+    "lineTitle": "Segment recte",
+    "arc": "Arc",
+    "arcTitle": "Segment d'arc (tecla A, roda del ratolí = bombament)",
+    "closeOuter": "Tanca el contorn",
+    "closeOuterTitle": "Tanca el contorn exterior (≥ 3 punts) — després pots dibuixar obertures (donut)",
+    "closeHole": "Tanca l'obertura",
+    "closeHoleTitle": "Tanca l'obertura (≥ 3 punts)",
+    "done": "Fet",
+    "doneTitle": "Comprova que els contorns estiguin tancats, dibuixa el ratllat i surt del mode (Retorn)",
+    "cancelTitle": "Cancel·la (Esc)",
+    "outerClosed": "Contorn exterior tancat ✓ · obertures: {{count}}",
+    "drawingHole": " · dibuixant obertura ({{count}} punt(s))",
+    "outerOpenClosable": "Contorn exterior obert — {{count}} punts (tancable)",
+    "outerOpen": "Contorn exterior obert — {{count}} punt(s)"
+  },
+  "boxWidthAbbr": "A",
+  "boxHeightAbbr": "Al"
 }

--- a/open-pdf-studio/js/i18n/locales/cs/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/cs/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Čára",
+    "lineTitle": "Přímý segment",
+    "arc": "Oblouk",
+    "arcTitle": "Obloukový segment (klávesa A, kolečko myši = vypuklost)",
+    "closeOuter": "Zavřít obrys",
+    "closeOuterTitle": "Zavřít vnější obrys (≥ 3 body) — poté můžete kreslit otvory (donut)",
+    "closeHole": "Zavřít otvor",
+    "closeHoleTitle": "Zavřít otvor (≥ 3 body)",
+    "done": "Hotovo",
+    "doneTitle": "Zkontroluje, zda jsou obrysy uzavřené, nakreslí šrafování a opustí režim (Enter)",
+    "cancelTitle": "Zrušit (Esc)",
+    "outerClosed": "Vnější obrys uzavřen ✓ · otvory: {{count}}",
+    "drawingHole": " · kreslení otvoru ({{count}} bod(y))",
+    "outerOpenClosable": "Vnější obrys otevřen — {{count}} bodů (lze uzavřít)",
+    "outerOpen": "Vnější obrys otevřen — {{count}} bod(y)"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/da/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/da/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linje",
+    "lineTitle": "Lige segment",
+    "arc": "Bue",
+    "arcTitle": "Buesegment (tast A, musehjul = udbulning)",
+    "closeOuter": "Luk kontur",
+    "closeOuterTitle": "Luk yderkontur (≥ 3 punkter) — derefter kan du tegne åbninger (donut)",
+    "closeHole": "Luk åbning",
+    "closeHoleTitle": "Luk åbning (≥ 3 punkter)",
+    "done": "Færdig",
+    "doneTitle": "Kontrollerer at konturerne er lukkede, tegner skraveringen og forlader tilstanden (Enter)",
+    "cancelTitle": "Annuller (Esc)",
+    "outerClosed": "Yderkontur lukket ✓ · åbninger: {{count}}",
+    "drawingHole": " · tegner åbning ({{count}} punkt(er))",
+    "outerOpenClosable": "Yderkontur åben — {{count}} punkter (kan lukkes)",
+    "outerOpen": "Yderkontur åben — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/de/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/de/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linie",
+    "lineTitle": "Gerades Segment",
+    "arc": "Bogen",
+    "arcTitle": "Bogensegment (Taste A, Mausrad = Wölbung)",
+    "closeOuter": "Kontur schließen",
+    "closeOuterTitle": "Außenkontur schließen (≥ 3 Punkte) — danach können Öffnungen (Donut) gezeichnet werden",
+    "closeHole": "Öffnung schließen",
+    "closeHoleTitle": "Öffnung schließen (≥ 3 Punkte)",
+    "done": "Fertig",
+    "doneTitle": "Prüft, ob die Konturen geschlossen sind, zeichnet die Schraffur und verlässt den Modus (Eingabe)",
+    "cancelTitle": "Abbrechen (Esc)",
+    "outerClosed": "Außenkontur geschlossen ✓ · Öffnungen: {{count}}",
+    "drawingHole": " · Öffnung wird gezeichnet ({{count}} Punkt(e))",
+    "outerOpenClosable": "Außenkontur offen — {{count}} Punkte (schließbar)",
+    "outerOpen": "Außenkontur offen — {{count}} Punkt(e)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/el/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/el/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Γραμμή",
+    "lineTitle": "Ευθύγραμμο τμήμα",
+    "arc": "Τόξο",
+    "arcTitle": "Τμήμα τόξου (πλήκτρο A, τροχός ποντικιού = κύρτωση)",
+    "closeOuter": "Κλείσιμο περιγράμματος",
+    "closeOuterTitle": "Κλείστε το εξωτερικό περίγραμμα (≥ 3 σημεία) — έπειτα μπορείτε να σχεδιάσετε ανοίγματα",
+    "closeHole": "Κλείσιμο ανοίγματος",
+    "closeHoleTitle": "Κλείσιμο ανοίγματος (≥ 3 σημεία)",
+    "done": "Τέλος",
+    "doneTitle": "Ελέγχει αν τα περιγράμματα είναι κλειστά, σχεδιάζει τη διαγράμμιση και βγαίνει από τη λειτουργία (Enter)",
+    "cancelTitle": "Ακύρωση (Esc)",
+    "outerClosed": "Εξωτερικό περίγραμμα κλειστό ✓ · ανοίγματα: {{count}}",
+    "drawingHole": " · σχεδίαση ανοίγματος ({{count}} σημείο/α)",
+    "outerOpenClosable": "Εξωτερικό περίγραμμα ανοιχτό — {{count}} σημεία (κλείνει)",
+    "outerOpen": "Εξωτερικό περίγραμμα ανοιχτό — {{count}} σημείο/α"
+  },
+  "boxWidthAbbr": "Π",
+  "boxHeightAbbr": "Υ"
 }

--- a/open-pdf-studio/js/i18n/locales/en/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/en/statusbar.json
@@ -66,5 +66,24 @@
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
   "viewFacing": "Two Pages Side by Side",
-  "compareTabTitle": "Compare"
+  "compareTabTitle": "Compare",
+  "filledAreaSketch": {
+    "line": "Line",
+    "lineTitle": "Straight segment",
+    "arc": "Arc",
+    "arcTitle": "Arc segment (key A, mouse wheel = bulge)",
+    "closeOuter": "Close contour",
+    "closeOuterTitle": "Close outer contour (≥ 3 points) — then you can draw openings (donut)",
+    "closeHole": "Close opening",
+    "closeHoleTitle": "Close opening (≥ 3 points)",
+    "done": "Done",
+    "doneTitle": "Checks the contours are closed, draws the hatch, and exits the mode (Enter)",
+    "cancelTitle": "Cancel (Esc)",
+    "outerClosed": "Outer contour closed ✓ · openings: {{count}}",
+    "drawingHole": " · drawing opening ({{count}} point(s))",
+    "outerOpenClosable": "Outer contour open — {{count}} points (closable)",
+    "outerOpen": "Outer contour open — {{count}} point(s)"
+  },
+  "boxWidthAbbr": "W",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/es/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/es/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Línea",
+    "lineTitle": "Segmento recto",
+    "arc": "Arco",
+    "arcTitle": "Segmento de arco (tecla A, rueda del ratón = curvatura)",
+    "closeOuter": "Cerrar contorno",
+    "closeOuterTitle": "Cerrar contorno exterior (≥ 3 puntos) — después podrás dibujar aberturas (donut)",
+    "closeHole": "Cerrar abertura",
+    "closeHoleTitle": "Cerrar abertura (≥ 3 puntos)",
+    "done": "Hecho",
+    "doneTitle": "Comprueba que los contornos estén cerrados, dibuja la trama y sale del modo (Intro)",
+    "cancelTitle": "Cancelar (Esc)",
+    "outerClosed": "Contorno exterior cerrado ✓ · aberturas: {{count}}",
+    "drawingHole": " · dibujando abertura ({{count}} punto(s))",
+    "outerOpenClosable": "Contorno exterior abierto — {{count}} puntos (se puede cerrar)",
+    "outerOpen": "Contorno exterior abierto — {{count}} punto(s)"
+  },
+  "boxWidthAbbr": "A",
+  "boxHeightAbbr": "Al"
 }

--- a/open-pdf-studio/js/i18n/locales/fa/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fa/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "خط",
+    "lineTitle": "پاره‌خط مستقیم",
+    "arc": "کمان",
+    "arcTitle": "پاره کمان (کلید A، چرخ ماوس = برآمدگی)",
+    "closeOuter": "بستن پیرامون",
+    "closeOuterTitle": "پیرامون بیرونی را ببندید (≥ ۳ نقطه) — سپس می‌توانید بازشوها را بکشید",
+    "closeHole": "بستن بازشو",
+    "closeHoleTitle": "بستن بازشو (≥ ۳ نقطه)",
+    "done": "پایان",
+    "doneTitle": "بررسی می‌کند که پیرامون‌ها بسته باشند، هاشور را می‌کشد و از حالت خارج می‌شود (Enter)",
+    "cancelTitle": "لغو (Esc)",
+    "outerClosed": "پیرامون بیرونی بسته شد ✓ · بازشوها: {{count}}",
+    "drawingHole": " · در حال کشیدن بازشو ({{count}} نقطه)",
+    "outerOpenClosable": "پیرامون بیرونی باز است — {{count}} نقطه (قابل بستن)",
+    "outerOpen": "پیرامون بیرونی باز است — {{count}} نقطه"
+  },
+  "boxWidthAbbr": "ع",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/fi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fi/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Viiva",
+    "lineTitle": "Suora segmentti",
+    "arc": "Kaari",
+    "arcTitle": "Kaarisegmentti (näppäin A, hiiren rulla = pullistuma)",
+    "closeOuter": "Sulje ääriviiva",
+    "closeOuterTitle": "Sulje ulkoääriviiva (≥ 3 pistettä) — sen jälkeen voit piirtää aukkoja",
+    "closeHole": "Sulje aukko",
+    "closeHoleTitle": "Sulje aukko (≥ 3 pistettä)",
+    "done": "Valmis",
+    "doneTitle": "Tarkistaa, että ääriviivat on suljettu, piirtää viivoituksen ja poistuu tilasta (Enter)",
+    "cancelTitle": "Peruuta (Esc)",
+    "outerClosed": "Ulkoääriviiva suljettu ✓ · aukkoja: {{count}}",
+    "drawingHole": " · piirretään aukkoa ({{count}} piste(ttä))",
+    "outerOpenClosable": "Ulkoääriviiva auki — {{count}} pistettä (suljettavissa)",
+    "outerOpen": "Ulkoääriviiva auki — {{count}} piste(ttä)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "K"
 }

--- a/open-pdf-studio/js/i18n/locales/fr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fr/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Ligne",
+    "lineTitle": "Segment droit",
+    "arc": "Arc",
+    "arcTitle": "Segment d'arc (touche A, molette = bombement)",
+    "closeOuter": "Fermer le contour",
+    "closeOuterTitle": "Fermer le contour extérieur (≥ 3 points) — vous pourrez ensuite tracer des ouvertures (donut)",
+    "closeHole": "Fermer l'ouverture",
+    "closeHoleTitle": "Fermer l'ouverture (≥ 3 points)",
+    "done": "Terminé",
+    "doneTitle": "Vérifie que les contours sont fermés, trace la hachure et quitte le mode (Entrée)",
+    "cancelTitle": "Annuler (Échap)",
+    "outerClosed": "Contour extérieur fermé ✓ · ouvertures : {{count}}",
+    "drawingHole": " · ouverture en cours ({{count}} point(s))",
+    "outerOpenClosable": "Contour extérieur ouvert — {{count}} points (fermable)",
+    "outerOpen": "Contour extérieur ouvert — {{count}} point(s)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/he/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/he/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "קו",
+    "lineTitle": "קטע ישר",
+    "arc": "קשת",
+    "arcTitle": "קטע קשת (מקש A, גלגלת עכבר = בליטה)",
+    "closeOuter": "סגור מתאר",
+    "closeOuterTitle": "סגור את המתאר החיצוני (≥ 3 נקודות) — לאחר מכן ניתן לצייר פתחים",
+    "closeHole": "סגור פתח",
+    "closeHoleTitle": "סגור פתח (≥ 3 נקודות)",
+    "done": "סיום",
+    "doneTitle": "בודק שהמתארים סגורים, מצייר את המילוי ויוצא מהמצב (Enter)",
+    "cancelTitle": "ביטול (Esc)",
+    "outerClosed": "מתאר חיצוני סגור ✓ · פתחים: {{count}}",
+    "drawingHole": " · מצייר פתח ({{count}} נקודות)",
+    "outerOpenClosable": "מתאר חיצוני פתוח — {{count}} נקודות (ניתן לסגור)",
+    "outerOpen": "מתאר חיצוני פתוח — {{count}} נקודות"
+  },
+  "boxWidthAbbr": "ר",
+  "boxHeightAbbr": "ג"
 }

--- a/open-pdf-studio/js/i18n/locales/hi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hi/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "रेखा",
+    "lineTitle": "सीधा खंड",
+    "arc": "चाप",
+    "arcTitle": "चाप खंड (कुंजी A, माउस व्हील = उभार)",
+    "closeOuter": "रूपरेखा बंद करें",
+    "closeOuterTitle": "बाहरी रूपरेखा बंद करें (≥ 3 बिंदु) — फिर आप खुलाव बना सकते हैं",
+    "closeHole": "खुलाव बंद करें",
+    "closeHoleTitle": "खुलाव बंद करें (≥ 3 बिंदु)",
+    "done": "पूर्ण",
+    "doneTitle": "जाँचता है कि रूपरेखाएँ बंद हैं, हैचिंग बनाता है और मोड से बाहर निकलता है (Enter)",
+    "cancelTitle": "रद्द करें (Esc)",
+    "outerClosed": "बाहरी रूपरेखा बंद ✓ · खुलाव: {{count}}",
+    "drawingHole": " · खुलाव बनाया जा रहा है ({{count}} बिंदु)",
+    "outerOpenClosable": "बाहरी रूपरेखा खुली है — {{count}} बिंदु (बंद की जा सकती है)",
+    "outerOpen": "बाहरी रूपरेखा खुली है — {{count}} बिंदु"
+  },
+  "boxWidthAbbr": "च",
+  "boxHeightAbbr": "ऊ"
 }

--- a/open-pdf-studio/js/i18n/locales/hr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hr/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linija",
+    "lineTitle": "Ravni segment",
+    "arc": "Luk",
+    "arcTitle": "Segment luka (tipka A, kotačić miša = ispupčenje)",
+    "closeOuter": "Zatvori konturu",
+    "closeOuterTitle": "Zatvori vanjsku konturu (≥ 3 točke) — zatim možete crtati otvore (donut)",
+    "closeHole": "Zatvori otvor",
+    "closeHoleTitle": "Zatvori otvor (≥ 3 točke)",
+    "done": "Gotovo",
+    "doneTitle": "Provjerava jesu li konture zatvorene, iscrtava šrafuru i izlazi iz načina rada (Enter)",
+    "cancelTitle": "Otkaži (Esc)",
+    "outerClosed": "Vanjska kontura zatvorena ✓ · otvori: {{count}}",
+    "drawingHole": " · crtanje otvora ({{count}} točka/e)",
+    "outerOpenClosable": "Vanjska kontura otvorena — {{count}} točaka (može se zatvoriti)",
+    "outerOpen": "Vanjska kontura otvorena — {{count}} točka/e"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/hu/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hu/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Vonal",
+    "lineTitle": "Egyenes szakasz",
+    "arc": "Ív",
+    "arcTitle": "Ívszakasz (A billentyű, egérgörgő = domborulat)",
+    "closeOuter": "Kontúr lezárása",
+    "closeOuterTitle": "Külső kontúr lezárása (≥ 3 pont) — utána nyílásokat (donut) rajzolhat",
+    "closeHole": "Nyílás lezárása",
+    "closeHoleTitle": "Nyílás lezárása (≥ 3 pont)",
+    "done": "Kész",
+    "doneTitle": "Ellenőrzi, hogy a kontúrok zártak-e, kirajzolja a sraffozást és kilép a módból (Enter)",
+    "cancelTitle": "Mégse (Esc)",
+    "outerClosed": "Külső kontúr lezárva ✓ · nyílások: {{count}}",
+    "drawingHole": " · nyílás rajzolása ({{count}} pont)",
+    "outerOpenClosable": "Külső kontúr nyitva — {{count}} pont (lezárható)",
+    "outerOpen": "Külső kontúr nyitva — {{count}} pont"
+  },
+  "boxWidthAbbr": "Sz",
+  "boxHeightAbbr": "M"
 }

--- a/open-pdf-studio/js/i18n/locales/id/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/id/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Garis",
+    "lineTitle": "Segmen lurus",
+    "arc": "Busur",
+    "arcTitle": "Segmen busur (tombol A, roda mouse = kelengkungan)",
+    "closeOuter": "Tutup kontur",
+    "closeOuterTitle": "Tutup kontur luar (≥ 3 titik) — lalu Anda bisa menggambar bukaan (donat)",
+    "closeHole": "Tutup bukaan",
+    "closeHoleTitle": "Tutup bukaan (≥ 3 titik)",
+    "done": "Selesai",
+    "doneTitle": "Memeriksa apakah kontur sudah tertutup, menggambar arsiran, dan keluar dari mode (Enter)",
+    "cancelTitle": "Batal (Esc)",
+    "outerClosed": "Kontur luar tertutup ✓ · bukaan: {{count}}",
+    "drawingHole": " · menggambar bukaan ({{count}} titik)",
+    "outerOpenClosable": "Kontur luar terbuka — {{count}} titik (bisa ditutup)",
+    "outerOpen": "Kontur luar terbuka — {{count}} titik"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "T"
 }

--- a/open-pdf-studio/js/i18n/locales/it/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/it/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linea",
+    "lineTitle": "Segmento retto",
+    "arc": "Arco",
+    "arcTitle": "Segmento ad arco (tasto A, rotella = bombatura)",
+    "closeOuter": "Chiudi contorno",
+    "closeOuterTitle": "Chiudi il contorno esterno (≥ 3 punti) — poi potrai disegnare aperture (donut)",
+    "closeHole": "Chiudi apertura",
+    "closeHoleTitle": "Chiudi apertura (≥ 3 punti)",
+    "done": "Fatto",
+    "doneTitle": "Verifica che i contorni siano chiusi, disegna il retino ed esce dalla modalità (Invio)",
+    "cancelTitle": "Annulla (Esc)",
+    "outerClosed": "Contorno esterno chiuso ✓ · aperture: {{count}}",
+    "drawingHole": " · apertura in corso ({{count}} punto/i)",
+    "outerOpenClosable": "Contorno esterno aperto — {{count}} punti (chiudibile)",
+    "outerOpen": "Contorno esterno aperto — {{count}} punto/i"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "A"
 }

--- a/open-pdf-studio/js/i18n/locales/ja/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ja/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "直線",
+    "lineTitle": "直線セグメント",
+    "arc": "円弧",
+    "arcTitle": "円弧セグメント（キー A、マウスホイール＝膨らみ）",
+    "closeOuter": "輪郭を閉じる",
+    "closeOuterTitle": "外側の輪郭を閉じる（3点以上）— その後、開口部（ドーナツ）を描けます",
+    "closeHole": "開口部を閉じる",
+    "closeHoleTitle": "開口部を閉じる（3点以上）",
+    "done": "完了",
+    "doneTitle": "輪郭が閉じているか確認し、ハッチングを描画してモードを終了します（Enter）",
+    "cancelTitle": "キャンセル（Esc）",
+    "outerClosed": "外側輪郭閉鎖済み ✓ · 開口部：{{count}}",
+    "drawingHole": " · 開口部を描画中（{{count}}点）",
+    "outerOpenClosable": "外側輪郭が開いています — {{count}}点（閉じられます）",
+    "outerOpen": "外側輪郭が開いています — {{count}}点"
+  },
+  "boxWidthAbbr": "幅",
+  "boxHeightAbbr": "高"
 }

--- a/open-pdf-studio/js/i18n/locales/ko/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ko/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "선",
+    "lineTitle": "직선 세그먼트",
+    "arc": "호",
+    "arcTitle": "호 세그먼트(키 A, 마우스 휠 = 볼록도)",
+    "closeOuter": "윤곽 닫기",
+    "closeOuterTitle": "외곽 윤곽을 닫습니다(3점 이상) — 이후 개구부(도넛)를 그릴 수 있습니다",
+    "closeHole": "개구부 닫기",
+    "closeHoleTitle": "개구부 닫기(3점 이상)",
+    "done": "완료",
+    "doneTitle": "윤곽이 닫혔는지 확인하고 해칭을 그린 후 모드를 종료합니다(Enter)",
+    "cancelTitle": "취소(Esc)",
+    "outerClosed": "외곽 윤곽 닫힘 ✓ · 개구부: {{count}}",
+    "drawingHole": " · 개구부 그리는 중 ({{count}}점)",
+    "outerOpenClosable": "외곽 윤곽 열림 — {{count}}점 (닫을 수 있음)",
+    "outerOpen": "외곽 윤곽 열림 — {{count}}점"
+  },
+  "boxWidthAbbr": "너",
+  "boxHeightAbbr": "높"
 }

--- a/open-pdf-studio/js/i18n/locales/ms/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ms/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Garisan",
+    "lineTitle": "Segmen lurus",
+    "arc": "Lengkok",
+    "arcTitle": "Segmen lengkok (kekunci A, roda tetikus = lengkungan)",
+    "closeOuter": "Tutup kontur",
+    "closeOuterTitle": "Tutup kontur luar (≥ 3 titik) — kemudian anda boleh melukis bukaan",
+    "closeHole": "Tutup bukaan",
+    "closeHoleTitle": "Tutup bukaan (≥ 3 titik)",
+    "done": "Selesai",
+    "doneTitle": "Menyemak sama ada kontur tertutup, melukis lorekan dan keluar dari mod (Enter)",
+    "cancelTitle": "Batal (Esc)",
+    "outerClosed": "Kontur luar tertutup ✓ · bukaan: {{count}}",
+    "drawingHole": " · melukis bukaan ({{count}} titik)",
+    "outerOpenClosable": "Kontur luar terbuka — {{count}} titik (boleh ditutup)",
+    "outerOpen": "Kontur luar terbuka — {{count}} titik"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "T"
 }

--- a/open-pdf-studio/js/i18n/locales/nb/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/nb/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linje",
+    "lineTitle": "Rett segment",
+    "arc": "Bue",
+    "arcTitle": "Buesegment (tast A, musehjul = utbuling)",
+    "closeOuter": "Lukk kontur",
+    "closeOuterTitle": "Lukk ytterkontur (≥ 3 punkter) — deretter kan du tegne åpninger (smultring)",
+    "closeHole": "Lukk åpning",
+    "closeHoleTitle": "Lukk åpning (≥ 3 punkter)",
+    "done": "Ferdig",
+    "doneTitle": "Sjekker at konturene er lukket, tegner skraveringen og forlater modusen (Enter)",
+    "cancelTitle": "Avbryt (Esc)",
+    "outerClosed": "Ytterkontur lukket ✓ · åpninger: {{count}}",
+    "drawingHole": " · tegner åpning ({{count}} punkt(er))",
+    "outerOpenClosable": "Ytterkontur åpen — {{count}} punkter (kan lukkes)",
+    "outerOpen": "Ytterkontur åpen — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/nl/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/nl/statusbar.json
@@ -66,5 +66,24 @@
   "viewContinuous": "Doorlopend",
   "viewBook": "Twee pagina’s",
   "viewFacing": "Twee pagina’s naast elkaar",
-  "compareTabTitle": "Vergelijken"
+  "compareTabTitle": "Vergelijken",
+  "filledAreaSketch": {
+    "line": "Lijn",
+    "lineTitle": "Recht segment",
+    "arc": "Boog",
+    "arcTitle": "Boogsegment (sneltoets A, muiswiel = bolling)",
+    "closeOuter": "Sluit contour",
+    "closeOuterTitle": "Buitenrand sluiten (≥ 3 punten) — daarna kun je openingen (donut) tekenen",
+    "closeHole": "Opening sluiten",
+    "closeHoleTitle": "Opening sluiten (≥ 3 punten)",
+    "done": "Gereed",
+    "doneTitle": "Controleert of de contouren gesloten zijn, tekent de arcering en verlaat de modus (Enter)",
+    "cancelTitle": "Annuleren (Esc)",
+    "outerClosed": "Buitenrand gesloten ✓ · openingen: {{count}}",
+    "drawingHole": " · bezig met opening ({{count}} punt(en))",
+    "outerOpenClosable": "Buitenrand open — {{count}} punten (sluitbaar)",
+    "outerOpen": "Buitenrand open — {{count}} punt(en)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/pl/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/pl/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linia",
+    "lineTitle": "Odcinek prosty",
+    "arc": "Łuk",
+    "arcTitle": "Segment łuku (klawisz A, kółko myszy = wybrzuszenie)",
+    "closeOuter": "Zamknij kontur",
+    "closeOuterTitle": "Zamknij kontur zewnętrzny (≥ 3 punkty) — potem można rysować otwory (donut)",
+    "closeHole": "Zamknij otwór",
+    "closeHoleTitle": "Zamknij otwór (≥ 3 punkty)",
+    "done": "Gotowe",
+    "doneTitle": "Sprawdza, czy kontury są zamknięte, rysuje kreskowanie i wychodzi z trybu (Enter)",
+    "cancelTitle": "Anuluj (Esc)",
+    "outerClosed": "Kontur zewnętrzny zamknięty ✓ · otwory: {{count}}",
+    "drawingHole": " · rysowanie otworu ({{count}} punkt(y))",
+    "outerOpenClosable": "Kontur zewnętrzny otwarty — {{count}} punktów (można zamknąć)",
+    "outerOpen": "Kontur zewnętrzny otwarty — {{count}} punkt(y)"
+  },
+  "boxWidthAbbr": "S",
+  "boxHeightAbbr": "W"
 }

--- a/open-pdf-studio/js/i18n/locales/pt/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/pt/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linha",
+    "lineTitle": "Segmento reto",
+    "arc": "Arco",
+    "arcTitle": "Segmento de arco (tecla A, roda do rato = abaulamento)",
+    "closeOuter": "Fechar contorno",
+    "closeOuterTitle": "Fechar contorno exterior (≥ 3 pontos) — depois pode desenhar aberturas (donut)",
+    "closeHole": "Fechar abertura",
+    "closeHoleTitle": "Fechar abertura (≥ 3 pontos)",
+    "done": "Concluído",
+    "doneTitle": "Verifica se os contornos estão fechados, desenha a trama e sai do modo (Enter)",
+    "cancelTitle": "Cancelar (Esc)",
+    "outerClosed": "Contorno exterior fechado ✓ · aberturas: {{count}}",
+    "drawingHole": " · a desenhar abertura ({{count}} ponto(s))",
+    "outerOpenClosable": "Contorno exterior aberto — {{count}} pontos (fechável)",
+    "outerOpen": "Contorno exterior aberto — {{count}} ponto(s)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "A"
 }

--- a/open-pdf-studio/js/i18n/locales/ro/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ro/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linie",
+    "lineTitle": "Segment drept",
+    "arc": "Arc",
+    "arcTitle": "Segment de arc (tasta A, rotița mouse-ului = bombare)",
+    "closeOuter": "Închide conturul",
+    "closeOuterTitle": "Închide conturul exterior (≥ 3 puncte) — apoi poți desena deschideri (donut)",
+    "closeHole": "Închide deschiderea",
+    "closeHoleTitle": "Închide deschiderea (≥ 3 puncte)",
+    "done": "Terminat",
+    "doneTitle": "Verifică dacă conturile sunt închise, desenează haşura și iese din mod (Enter)",
+    "cancelTitle": "Anulează (Esc)",
+    "outerClosed": "Contur exterior închis ✓ · deschideri: {{count}}",
+    "drawingHole": " · se desenează deschiderea ({{count}} punct(e))",
+    "outerOpenClosable": "Contur exterior deschis — {{count}} puncte (se poate închide)",
+    "outerOpen": "Contur exterior deschis — {{count}} punct(e)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/ru/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ru/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Линия",
+    "lineTitle": "Прямой сегмент",
+    "arc": "Дуга",
+    "arcTitle": "Сегмент дуги (клавиша A, колесо мыши = выпуклость)",
+    "closeOuter": "Замкнуть контур",
+    "closeOuterTitle": "Замкнуть внешний контур (≥ 3 точек) — затем можно рисовать отверстия (бублик)",
+    "closeHole": "Замкнуть отверстие",
+    "closeHoleTitle": "Замкнуть отверстие (≥ 3 точек)",
+    "done": "Готово",
+    "doneTitle": "Проверяет, что контуры замкнуты, рисует штриховку и выходит из режима (Enter)",
+    "cancelTitle": "Отмена (Esc)",
+    "outerClosed": "Внешний контур замкнут ✓ · отверстия: {{count}}",
+    "drawingHole": " · рисование отверстия ({{count}} точ.)",
+    "outerOpenClosable": "Внешний контур открыт — {{count}} точек (можно замкнуть)",
+    "outerOpen": "Внешний контур открыт — {{count}} точ."
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/sk/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sk/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Čiara",
+    "lineTitle": "Priamy segment",
+    "arc": "Oblúk",
+    "arcTitle": "Oblúkový segment (klávesa A, koliesko myši = vypuklosť)",
+    "closeOuter": "Zavrieť obrys",
+    "closeOuterTitle": "Zavrieť vonkajší obrys (≥ 3 body) — potom môžete kresliť otvory (donut)",
+    "closeHole": "Zavrieť otvor",
+    "closeHoleTitle": "Zavrieť otvor (≥ 3 body)",
+    "done": "Hotovo",
+    "doneTitle": "Skontroluje, či sú obrysy uzavreté, nakreslí šrafovanie a opustí režim (Enter)",
+    "cancelTitle": "Zrušiť (Esc)",
+    "outerClosed": "Vonkajší obrys uzavretý ✓ · otvory: {{count}}",
+    "drawingHole": " · kreslenie otvoru ({{count}} bod(y))",
+    "outerOpenClosable": "Vonkajší obrys otvorený — {{count}} bodov (možno zavrieť)",
+    "outerOpen": "Vonkajší obrys otvorený — {{count}} bod(y)"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/sr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sr/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Линија",
+    "lineTitle": "Прав сегмент",
+    "arc": "Лук",
+    "arcTitle": "Сегмент лука (тастер A, точкић миша = испупчење)",
+    "closeOuter": "Затвори контуру",
+    "closeOuterTitle": "Затвори спољну контуру (≥ 3 тачке) — затим можете цртати отворе (донат)",
+    "closeHole": "Затвори отвор",
+    "closeHoleTitle": "Затвори отвор (≥ 3 тачке)",
+    "done": "Готово",
+    "doneTitle": "Проверава да ли су контуре затворене, исцртава шрафуру и излази из режима (Enter)",
+    "cancelTitle": "Откажи (Esc)",
+    "outerClosed": "Спољна контура затворена ✓ · отвори: {{count}}",
+    "drawingHole": " · цртање отвора ({{count}} тачка/е)",
+    "outerOpenClosable": "Спољна контура отворена — {{count}} тачака (може се затворити)",
+    "outerOpen": "Спољна контура отворена — {{count}} тачка/е"
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/sv/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sv/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Linje",
+    "lineTitle": "Rakt segment",
+    "arc": "Båge",
+    "arcTitle": "Bågsegment (tangent A, mushjul = bukt)",
+    "closeOuter": "Stäng konturen",
+    "closeOuterTitle": "Stäng ytterkonturen (≥ 3 punkter) — sedan kan du rita öppningar (munk)",
+    "closeHole": "Stäng öppning",
+    "closeHoleTitle": "Stäng öppning (≥ 3 punkter)",
+    "done": "Klar",
+    "doneTitle": "Kontrollerar att konturerna är stängda, ritar skrafferingen och lämnar läget (Retur)",
+    "cancelTitle": "Avbryt (Esc)",
+    "outerClosed": "Ytterkontur stängd ✓ · öppningar: {{count}}",
+    "drawingHole": " · ritar öppning ({{count}} punkt(er))",
+    "outerOpenClosable": "Ytterkontur öppen — {{count}} punkter (kan stängas)",
+    "outerOpen": "Ytterkontur öppen — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/sw/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sw/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Mstari",
+    "lineTitle": "Sehemu iliyonyooka",
+    "arc": "Upinde",
+    "arcTitle": "Sehemu ya upinde (kitufe A, gurudumu la panya = uvimbe)",
+    "closeOuter": "Funga ukingo",
+    "closeOuterTitle": "Funga ukingo wa nje (≥ pointi 3) — kisha unaweza kuchora fursa",
+    "closeHole": "Funga fursa",
+    "closeHoleTitle": "Funga fursa (≥ pointi 3)",
+    "done": "Imekamilika",
+    "doneTitle": "Inakagua kama kingo zimefungwa, inachora mistari na kutoka katika hali hii (Enter)",
+    "cancelTitle": "Ghairi (Esc)",
+    "outerClosed": "Ukingo wa nje umefungwa ✓ · fursa: {{count}}",
+    "drawingHole": " · inachora fursa (pointi {{count}})",
+    "outerOpenClosable": "Ukingo wa nje umefunguliwa — pointi {{count}} (unaweza kufungwa)",
+    "outerOpen": "Ukingo wa nje umefunguliwa — pointi {{count}}"
+  },
+  "boxWidthAbbr": "U",
+  "boxHeightAbbr": "K"
 }

--- a/open-pdf-studio/js/i18n/locales/ta/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ta/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "கோடு",
+    "lineTitle": "நேர்கோட்டுப் பகுதி",
+    "arc": "வளைவு",
+    "arcTitle": "வளைவுப் பகுதி (விசை A, மவுஸ் வீல் = குமிழ்)",
+    "closeOuter": "சுற்றுவரையை மூடு",
+    "closeOuterTitle": "வெளிப்புற சுற்றுவரையை மூடவும் (≥ 3 புள்ளிகள்) — பின்னர் திறப்புகளை வரையலாம்",
+    "closeHole": "திறப்பை மூடு",
+    "closeHoleTitle": "திறப்பை மூடு (≥ 3 புள்ளிகள்)",
+    "done": "முடிந்தது",
+    "doneTitle": "சுற்றுவரைகள் மூடப்பட்டுள்ளதா எனச் சரிபார்த்து, சரடு வரைந்து பயன்முறையிலிருந்து வெளியேறும் (Enter)",
+    "cancelTitle": "ரத்து (Esc)",
+    "outerClosed": "வெளிப்புற சுற்றுவரை மூடப்பட்டது ✓ · திறப்புகள்: {{count}}",
+    "drawingHole": " · திறப்பு வரையப்படுகிறது ({{count}} புள்ளிகள்)",
+    "outerOpenClosable": "வெளிப்புற சுற்றுவரை திறந்துள்ளது — {{count}} புள்ளிகள் (மூடலாம்)",
+    "outerOpen": "வெளிப்புற சுற்றுவரை திறந்துள்ளது — {{count}} புள்ளிகள்"
+  },
+  "boxWidthAbbr": "அ",
+  "boxHeightAbbr": "உ"
 }

--- a/open-pdf-studio/js/i18n/locales/th/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/th/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "เส้นตรง",
+    "lineTitle": "ส่วนเส้นตรง",
+    "arc": "ส่วนโค้ง",
+    "arcTitle": "ส่วนโค้ง (ปุ่ม A, ล้อเมาส์ = ความโค้งนูน)",
+    "closeOuter": "ปิดเส้นขอบ",
+    "closeOuterTitle": "ปิดเส้นขอบด้านนอก (≥ 3 จุด) — จากนั้นสามารถวาดช่องเปิดได้",
+    "closeHole": "ปิดช่องเปิด",
+    "closeHoleTitle": "ปิดช่องเปิด (≥ 3 จุด)",
+    "done": "เสร็จสิ้น",
+    "doneTitle": "ตรวจสอบว่าเส้นขอบปิดแล้ว วาดลายเส้น และออกจากโหมด (Enter)",
+    "cancelTitle": "ยกเลิก (Esc)",
+    "outerClosed": "เส้นขอบด้านนอกปิดแล้ว ✓ · ช่องเปิด: {{count}}",
+    "drawingHole": " · กำลังวาดช่องเปิด ({{count}} จุด)",
+    "outerOpenClosable": "เส้นขอบด้านนอกเปิดอยู่ — {{count}} จุด (ปิดได้)",
+    "outerOpen": "เส้นขอบด้านนอกเปิดอยู่ — {{count}} จุด"
+  },
+  "boxWidthAbbr": "ก",
+  "boxHeightAbbr": "ส"
 }

--- a/open-pdf-studio/js/i18n/locales/tr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/tr/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Çizgi",
+    "lineTitle": "Düz segment",
+    "arc": "Yay",
+    "arcTitle": "Yay segmenti (A tuşu, fare tekerleği = bombe)",
+    "closeOuter": "Konturu kapat",
+    "closeOuterTitle": "Dış konturu kapat (≥ 3 nokta) — ardından açıklık (donut) çizebilirsiniz",
+    "closeHole": "Açıklığı kapat",
+    "closeHoleTitle": "Açıklığı kapat (≥ 3 nokta)",
+    "done": "Bitti",
+    "doneTitle": "Konturların kapalı olup olmadığını kontrol eder, taramayı çizer ve moddan çıkar (Enter)",
+    "cancelTitle": "İptal (Esc)",
+    "outerClosed": "Dış kontur kapalı ✓ · açıklıklar: {{count}}",
+    "drawingHole": " · açıklık çiziliyor ({{count}} nokta)",
+    "outerOpenClosable": "Dış kontur açık — {{count}} nokta (kapatılabilir)",
+    "outerOpen": "Dış kontur açık — {{count}} nokta"
+  },
+  "boxWidthAbbr": "G",
+  "boxHeightAbbr": "Y"
 }

--- a/open-pdf-studio/js/i18n/locales/uk/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/uk/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Лінія",
+    "lineTitle": "Прямий сегмент",
+    "arc": "Дуга",
+    "arcTitle": "Сегмент дуги (клавіша A, коліщатко миші = випуклість)",
+    "closeOuter": "Замкнути контур",
+    "closeOuterTitle": "Замкнути зовнішній контур (≥ 3 точки) — потім можна малювати отвори (бублик)",
+    "closeHole": "Замкнути отвір",
+    "closeHoleTitle": "Замкнути отвір (≥ 3 точки)",
+    "done": "Готово",
+    "doneTitle": "Перевіряє, чи контури замкнені, малює штрихування і виходить із режиму (Enter)",
+    "cancelTitle": "Скасувати (Esc)",
+    "outerClosed": "Зовнішній контур замкнено ✓ · отвори: {{count}}",
+    "drawingHole": " · малювання отвору ({{count}} точ.)",
+    "outerOpenClosable": "Зовнішній контур відкрито — {{count}} точок (можна замкнути)",
+    "outerOpen": "Зовнішній контур відкрито — {{count}} точ."
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/ur/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ur/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "لائن",
+    "lineTitle": "سیدھا حصہ",
+    "arc": "آرک",
+    "arcTitle": "آرک حصہ (کلید A، ماؤس وہیل = ابھار)",
+    "closeOuter": "خاکہ بند کریں",
+    "closeOuterTitle": "بیرونی خاکہ بند کریں (≥ 3 پوائنٹس) — پھر آپ سوراخ بنا سکتے ہیں",
+    "closeHole": "سوراخ بند کریں",
+    "closeHoleTitle": "سوراخ بند کریں (≥ 3 پوائنٹس)",
+    "done": "مکمل",
+    "doneTitle": "جانچتا ہے کہ خاکے بند ہیں، ہیچنگ بناتا ہے اور موڈ سے نکل جاتا ہے (Enter)",
+    "cancelTitle": "منسوخ کریں (Esc)",
+    "outerClosed": "بیرونی خاکہ بند ✓ · سوراخ: {{count}}",
+    "drawingHole": " · سوراخ بن رہا ہے ({{count}} پوائنٹس)",
+    "outerOpenClosable": "بیرونی خاکہ کھلا ہے — {{count}} پوائنٹس (بند کیا جا سکتا ہے)",
+    "outerOpen": "بیرونی خاکہ کھلا ہے — {{count}} پوائنٹس"
+  },
+  "boxWidthAbbr": "چ",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/vi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/vi/statusbar.json
@@ -58,5 +58,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "Đường thẳng",
+    "lineTitle": "Đoạn thẳng",
+    "arc": "Cung",
+    "arcTitle": "Đoạn cung (phím A, con lăn chuột = độ phồng)",
+    "closeOuter": "Đóng đường viền",
+    "closeOuterTitle": "Đóng đường viền ngoài (≥ 3 điểm) — sau đó bạn có thể vẽ lỗ mở",
+    "closeHole": "Đóng lỗ mở",
+    "closeHoleTitle": "Đóng lỗ mở (≥ 3 điểm)",
+    "done": "Xong",
+    "doneTitle": "Kiểm tra các đường viền đã đóng, vẽ nét gạch và thoát chế độ (Enter)",
+    "cancelTitle": "Hủy (Esc)",
+    "outerClosed": "Đường viền ngoài đã đóng ✓ · lỗ mở: {{count}}",
+    "drawingHole": " · đang vẽ lỗ mở ({{count}} điểm)",
+    "outerOpenClosable": "Đường viền ngoài đang mở — {{count}} điểm (có thể đóng)",
+    "outerOpen": "Đường viền ngoài đang mở — {{count}} điểm"
+  },
+  "boxWidthAbbr": "R",
+  "boxHeightAbbr": "C"
 }

--- a/open-pdf-studio/js/i18n/locales/zh/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/zh/statusbar.json
@@ -57,5 +57,24 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "line": "直线",
+    "lineTitle": "直线段",
+    "arc": "圆弧",
+    "arcTitle": "圆弧段（按键 A，鼠标滚轮 = 弧度）",
+    "closeOuter": "闭合轮廓",
+    "closeOuterTitle": "闭合外轮廓（≥ 3 个点）— 之后可以绘制开孔（环形）",
+    "closeHole": "闭合开孔",
+    "closeHoleTitle": "闭合开孔（≥ 3 个点）",
+    "done": "完成",
+    "doneTitle": "检查轮廓是否闭合，绘制填充线并退出该模式（回车）",
+    "cancelTitle": "取消（Esc）",
+    "outerClosed": "外轮廓已闭合 ✓ · 开孔：{{count}}",
+    "drawingHole": " · 正在绘制开孔（{{count}} 个点）",
+    "outerOpenClosable": "外轮廓未闭合 — {{count}} 个点（可闭合）",
+    "outerOpen": "外轮廓未闭合 — {{count}} 个点"
+  },
+  "boxWidthAbbr": "宽",
+  "boxHeightAbbr": "高"
 }

--- a/open-pdf-studio/js/solid/components/BoxSizeOverlay.jsx
+++ b/open-pdf-studio/js/solid/components/BoxSizeOverlay.jsx
@@ -2,6 +2,7 @@ import { Show, createSignal, createEffect, onCleanup } from 'solid-js';
 import { annotProps, updateAnnotProp } from '../stores/propertiesStore.js';
 import { state, getActiveDocument } from '../../core/state.js';
 import { getMeasureScale } from '../../annotations/measurement.js';
+import { useTranslation } from '../../i18n/useTranslation.js';
 
 // Temporary width/height "dimensions" for a selected rectangle — two small
 // editable fields floating next to the selection. Values are in measured
@@ -9,6 +10,7 @@ import { getMeasureScale } from '../../annotations/measurement.js';
 // the rectangle (top-left anchored) through the normal property pipeline
 // (undo + redraw included).
 export default function BoxSizeOverlay() {
+  const { t } = useTranslation('statusbar');
   const [pos, setPos] = createSignal(null); // { x, y } screen px
   const [wVal, setWVal] = createSignal('');
   const [hVal, setHVal] = createSignal('');
@@ -113,7 +115,7 @@ export default function BoxSizeOverlay() {
         'font-size': '12px',
       }}>
         <div style={{ display: 'flex', 'align-items': 'center', gap: '4px' }}>
-          <span style={{ width: '14px', 'font-weight': 600 }}>B</span>
+          <span style={{ width: '14px', 'font-weight': 600 }}>{t('boxWidthAbbr')}</span>
           <input style={inputStyle} value={wVal()}
             onFocus={onDimFocus} onMouseUp={onDimMouseUp}
             onInput={(e) => setWVal(e.target.value)}
@@ -122,7 +124,7 @@ export default function BoxSizeOverlay() {
           <span>{unit()}</span>
         </div>
         <div style={{ display: 'flex', 'align-items': 'center', gap: '4px' }}>
-          <span style={{ width: '14px', 'font-weight': 600 }}>H</span>
+          <span style={{ width: '14px', 'font-weight': 600 }}>{t('boxHeightAbbr')}</span>
           <input style={inputStyle} value={hVal()}
             onFocus={onDimFocus} onMouseUp={onDimMouseUp}
             onInput={(e) => setHVal(e.target.value)}

--- a/open-pdf-studio/js/solid/components/SketchModeBar.jsx
+++ b/open-pdf-studio/js/solid/components/SketchModeBar.jsx
@@ -1,6 +1,7 @@
 import { Show, createSignal, onMount, onCleanup } from 'solid-js';
 import { state } from '../../core/state.js';
 import { filledAreaSketch } from '../../tools/tools/filled-area-tool.js';
+import { useTranslation } from '../../i18n/useTranslation.js';
 
 // Floating sketch toolbar for the filled-area (arcering) tool — makes the
 // existing sketch machinery VISIBLE: line/arc segments, close-contour with
@@ -12,6 +13,7 @@ const BTN = 'padding:3px 10px;font-size:11px;font-family:inherit;border:1px soli
 const BTN_ACTIVE = BTN + ';background:var(--theme-accent-soft,#cce4f7);box-shadow:inset 0 0 0 1px var(--theme-active,#0078d7)';
 
 export default function SketchModeBar() {
+  const { t } = useTranslation('statusbar');
   const [snap, setSnap] = createSignal({ visible: false });
 
   // Poll tool state (same pattern as BoxSizeOverlay) — the drawing state
@@ -31,12 +33,12 @@ export default function SketchModeBar() {
   const statusText = () => {
     const st = s();
     if (st.phase === 'holes') {
-      const cur = st.points > 0 ? ` · bezig met opening (${st.points} ${st.points === 1 ? 'punt' : 'punten'})` : '';
-      return `Buitenrand gesloten ✓ · openingen: ${st.holes}${cur}`;
+      const cur = st.points > 0 ? t('filledAreaSketch.drawingHole', { count: st.points }) : '';
+      return t('filledAreaSketch.outerClosed', { count: st.holes }) + cur;
     }
     return st.points >= 3
-      ? `Buitenrand open — ${st.points} punten (sluitbaar)`
-      : `Buitenrand open — ${st.points} ${st.points === 1 ? 'punt' : 'punten'}`;
+      ? t('filledAreaSketch.outerOpenClosable', { count: st.points })
+      : t('filledAreaSketch.outerOpen', { count: st.points });
   };
 
   return (
@@ -59,23 +61,23 @@ export default function SketchModeBar() {
         'user-select': 'none',
       }}>
         <span style={{ opacity: 0.8, 'margin-right': '4px', 'white-space': 'nowrap' }}>{statusText()}</span>
-        <button style={!s().arcMode ? BTN_ACTIVE : BTN} title="Recht segment"
+        <button style={!s().arcMode ? BTN_ACTIVE : BTN} title={t('filledAreaSketch.lineTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => filledAreaSketch.setArcMode(false)}>Lijn</button>
-        <button style={s().arcMode ? BTN_ACTIVE : BTN} title="Boogsegment (sneltoets A, muiswiel = bolling)"
+          onClick={() => filledAreaSketch.setArcMode(false)}>{t('filledAreaSketch.line')}</button>
+        <button style={s().arcMode ? BTN_ACTIVE : BTN} title={t('filledAreaSketch.arcTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => filledAreaSketch.setArcMode(true)}>Boog</button>
+          onClick={() => filledAreaSketch.setArcMode(true)}>{t('filledAreaSketch.arc')}</button>
         <button style={BTN + (closeEnabled() ? '' : ';opacity:0.45;cursor:default')}
-          title={s().phase === 'holes' ? 'Opening sluiten (≥ 3 punten)' : 'Buitenrand sluiten (≥ 3 punten) — daarna kun je openingen (donut) tekenen'}
+          title={s().phase === 'holes' ? t('filledAreaSketch.closeHoleTitle') : t('filledAreaSketch.closeOuterTitle')}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => closeEnabled() && filledAreaSketch.closeLoop()}>
-          {s().phase === 'holes' ? 'Opening sluiten' : 'Sluit contour'}
+          {s().phase === 'holes' ? t('filledAreaSketch.closeHole') : t('filledAreaSketch.closeOuter')}
         </button>
         <button style={BTN + (finishEnabled() ? ';font-weight:600' : ';opacity:0.45;cursor:default')}
-          title="Controleert of de contouren gesloten zijn, tekent de arcering en verlaat de modus (Enter)"
+          title={t('filledAreaSketch.doneTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => finishEnabled() && filledAreaSketch.finish()}>✓ Gereed</button>
-        <button style={BTN} title="Annuleren (Esc)"
+          onClick={() => finishEnabled() && filledAreaSketch.finish()}>✓ {t('filledAreaSketch.done')}</button>
+        <button style={BTN} title={t('filledAreaSketch.cancelTitle')}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => filledAreaSketch.cancel()}>✕</button>
       </div>


### PR DESCRIPTION
Fixes #364.

The floating toolbar shown while sketching a Filled Area annotation was entirely hardcoded in Dutch, and the box-size dimension overlay used Dutch abbreviations for its labels.

## Changes
- `SketchModeBar.jsx`: all button labels, tooltips, and the dynamic status text now go through `t('filledAreaSketch.*')`, with `{{count}}` interpolation for the point/opening counts
- `BoxSizeOverlay.jsx`: the "B"/"H" field labels now use `t('boxWidthAbbr')` / `t('boxHeightAbbr')`
- Added `filledAreaSketch.*` (15 keys) and `boxWidthAbbr`/`boxHeightAbbr` to all 39 locale `statusbar.json` files

## Testing
- `npm run typecheck` passes
- Verified live in `npm run tauri:dev` (Vite dev server view): drew a Filled Area shape and confirmed the toolbar now reads "Outer contour open — 3 points (closable)" / "Line" / "Arc" / "Close contour" / "✓ Done", and after closing "Outer contour closed ✓ · openings: 0" / "Close opening"
- `BoxSizeOverlay.jsx` wiring is code-reviewed and uses the same validated i18next keys/namespace as the rest of the fix, but I could not get a synthetic mouse drag to draw a rectangle in the automated test harness to visually confirm the "W"/"H" labels live — worth a quick manual check