### PR TITLE
feat: undo the last point while sketching a Filled Area

### DIFF
--- a/open-pdf-studio/js/i18n/locales/ar/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ar/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "تراجع عن النقطة",
+    "undoPointTitle": "إزالة النقطة الأخيرة (Backspace)",
+    "holesPhaseHint": "انقر لإضافة فتحة · Enter أو النقر بزر الفأرة الأيمن = تم",
+    "line": "خط",
+    "lineTitle": "مقطع مستقيم",
+    "arc": "قوس",
+    "arcTitle": "مقطع قوس (مفتاح A، عجلة الفأرة = التحدّب)",
+    "closeOuter": "إغلاق المحيط",
+    "closeOuterTitle": "أغلق المحيط الخارجي (≥ 3 نقاط) — يمكنك بعدها رسم فتحات",
+    "closeHole": "إغلاق الفتحة",
+    "closeHoleTitle": "إغلاق الفتحة (≥ 3 نقاط)",
+    "done": "تم",
+    "doneTitle": "يتحقق من إغلاق المحيطات، يرسم التظليل، ويخرج من الوضع (Enter)",
+    "cancelTitle": "إلغاء (Esc)",
+    "outerClosed": "المحيط الخارجي مغلق ✓ · الفتحات: {{count}}",
+    "drawingHole": " · جارٍ رسم الفتحة ({{count}} نقطة)",
+    "outerOpenClosable": "المحيط الخارجي مفتوح — {{count}} نقاط (قابل للإغلاق)",
+    "outerOpen": "المحيط الخارجي مفتوح — {{count}} نقطة"
+  },
+  "boxWidthAbbr": "ع",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/bg/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/bg/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Отмяна на точка",
+    "undoPointTitle": "Премахни последната точка (Backspace)",
+    "holesPhaseHint": "Кликнете за отвор · Enter или десен бутон = готово",
+    "line": "Линия",
+    "lineTitle": "Прав сегмент",
+    "arc": "Дъга",
+    "arcTitle": "Сегмент от дъга (клавиш A, колелце на мишката = изпъкналост)",
+    "closeOuter": "Затвори контура",
+    "closeOuterTitle": "Затвори външния контур (≥ 3 точки) — после можете да чертаете отвори (донът)",
+    "closeHole": "Затвори отвора",
+    "closeHoleTitle": "Затвори отвора (≥ 3 точки)",
+    "done": "Готово",
+    "doneTitle": "Проверява дали контурите са затворени, чертае щриховката и излиза от режима (Enter)",
+    "cancelTitle": "Отказ (Esc)",
+    "outerClosed": "Външен контур затворен ✓ · отвори: {{count}}",
+    "drawingHole": " · чертане на отвор ({{count}} точка/и)",
+    "outerOpenClosable": "Външен контур отворен — {{count}} точки (може да се затвори)",
+    "outerOpen": "Външен контур отворен — {{count}} точка/и"
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/bn/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/bn/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "পয়েন্ট পূর্বাবস্থায় ফেরান",
+    "undoPointTitle": "শেষ পয়েন্ট সরান (Backspace)",
+    "holesPhaseHint": "খোলা অংশের জন্য ক্লিক করুন · Enter বা ডান-ক্লিক = সম্পন্ন",
+    "line": "রেখা",
+    "lineTitle": "সরল অংশ",
+    "arc": "চাপ",
+    "arcTitle": "চাপ অংশ (কী A, মাউস হুইল = স্ফীতি)",
+    "closeOuter": "রূপরেখা বন্ধ করুন",
+    "closeOuterTitle": "বাইরের রূপরেখা বন্ধ করুন (≥ 3 পয়েন্ট) — তারপর আপনি খোলা অংশ আঁকতে পারবেন",
+    "closeHole": "খোলা অংশ বন্ধ করুন",
+    "closeHoleTitle": "খোলা অংশ বন্ধ করুন (≥ 3 পয়েন্ট)",
+    "done": "সম্পন্ন",
+    "doneTitle": "রূপরেখা বন্ধ কিনা যাচাই করে, হ্যাচিং আঁকে এবং মোড থেকে বেরিয়ে যায় (Enter)",
+    "cancelTitle": "বাতিল (Esc)",
+    "outerClosed": "বাইরের রূপরেখা বন্ধ ✓ · খোলা অংশ: {{count}}",
+    "drawingHole": " · খোলা অংশ আঁকা হচ্ছে ({{count}} পয়েন্ট)",
+    "outerOpenClosable": "বাইরের রূপরেখা খোলা — {{count}} পয়েন্ট (বন্ধ করা যাবে)",
+    "outerOpen": "বাইরের রূপরেখা খোলা — {{count}} পয়েন্ট"
+  },
+  "boxWidthAbbr": "প",
+  "boxHeightAbbr": "উ"
 }

--- a/open-pdf-studio/js/i18n/locales/ca/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ca/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Desfés punt",
+    "undoPointTitle": "Elimina l'últim punt (Retrocés)",
+    "holesPhaseHint": "Fes clic per a una obertura · Retorn o clic dret = fet",
+    "line": "Línia",
+    "lineTitle": "Segment recte",
+    "arc": "Arc",
+    "arcTitle": "Segment d'arc (tecla A, roda del ratolí = bombament)",
+    "closeOuter": "Tanca el contorn",
+    "closeOuterTitle": "Tanca el contorn exterior (≥ 3 punts) — després pots dibuixar obertures (donut)",
+    "closeHole": "Tanca l'obertura",
+    "closeHoleTitle": "Tanca l'obertura (≥ 3 punts)",
+    "done": "Fet",
+    "doneTitle": "Comprova que els contorns estiguin tancats, dibuixa el ratllat i surt del mode (Retorn)",
+    "cancelTitle": "Cancel·la (Esc)",
+    "outerClosed": "Contorn exterior tancat ✓ · obertures: {{count}}",
+    "drawingHole": " · dibuixant obertura ({{count}} punt(s))",
+    "outerOpenClosable": "Contorn exterior obert — {{count}} punts (tancable)",
+    "outerOpen": "Contorn exterior obert — {{count}} punt(s)"
+  },
+  "boxWidthAbbr": "A",
+  "boxHeightAbbr": "Al"
 }

--- a/open-pdf-studio/js/i18n/locales/cs/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/cs/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Zpět bod",
+    "undoPointTitle": "Odebrat poslední bod (Backspace)",
+    "holesPhaseHint": "Klikněte pro otvor · Enter nebo pravé tlačítko = hotovo",
+    "line": "Čára",
+    "lineTitle": "Přímý segment",
+    "arc": "Oblouk",
+    "arcTitle": "Obloukový segment (klávesa A, kolečko myši = vypuklost)",
+    "closeOuter": "Zavřít obrys",
+    "closeOuterTitle": "Zavřít vnější obrys (≥ 3 body) — poté můžete kreslit otvory (donut)",
+    "closeHole": "Zavřít otvor",
+    "closeHoleTitle": "Zavřít otvor (≥ 3 body)",
+    "done": "Hotovo",
+    "doneTitle": "Zkontroluje, zda jsou obrysy uzavřené, nakreslí šrafování a opustí režim (Enter)",
+    "cancelTitle": "Zrušit (Esc)",
+    "outerClosed": "Vnější obrys uzavřen ✓ · otvory: {{count}}",
+    "drawingHole": " · kreslení otvoru ({{count}} bod(y))",
+    "outerOpenClosable": "Vnější obrys otevřen — {{count}} bodů (lze uzavřít)",
+    "outerOpen": "Vnější obrys otevřen — {{count}} bod(y)"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/da/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/da/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Fortryd punkt",
+    "undoPointTitle": "Fjern seneste punkt (Backspace)",
+    "holesPhaseHint": "Klik for en åbning · Enter eller højreklik = færdig",
+    "line": "Linje",
+    "lineTitle": "Lige segment",
+    "arc": "Bue",
+    "arcTitle": "Buesegment (tast A, musehjul = udbulning)",
+    "closeOuter": "Luk kontur",
+    "closeOuterTitle": "Luk yderkontur (≥ 3 punkter) — derefter kan du tegne åbninger (donut)",
+    "closeHole": "Luk åbning",
+    "closeHoleTitle": "Luk åbning (≥ 3 punkter)",
+    "done": "Færdig",
+    "doneTitle": "Kontrollerer at konturerne er lukkede, tegner skraveringen og forlader tilstanden (Enter)",
+    "cancelTitle": "Annuller (Esc)",
+    "outerClosed": "Yderkontur lukket ✓ · åbninger: {{count}}",
+    "drawingHole": " · tegner åbning ({{count}} punkt(er))",
+    "outerOpenClosable": "Yderkontur åben — {{count}} punkter (kan lukkes)",
+    "outerOpen": "Yderkontur åben — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/de/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/de/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Punkt zurücknehmen",
+    "undoPointTitle": "Letzten Punkt entfernen (Rücktaste)",
+    "holesPhaseHint": "Klicken für eine Öffnung · Eingabe oder Rechtsklick = fertig",
+    "line": "Linie",
+    "lineTitle": "Gerades Segment",
+    "arc": "Bogen",
+    "arcTitle": "Bogensegment (Taste A, Mausrad = Wölbung)",
+    "closeOuter": "Kontur schließen",
+    "closeOuterTitle": "Außenkontur schließen (≥ 3 Punkte) — danach können Öffnungen (Donut) gezeichnet werden",
+    "closeHole": "Öffnung schließen",
+    "closeHoleTitle": "Öffnung schließen (≥ 3 Punkte)",
+    "done": "Fertig",
+    "doneTitle": "Prüft, ob die Konturen geschlossen sind, zeichnet die Schraffur und verlässt den Modus (Eingabe)",
+    "cancelTitle": "Abbrechen (Esc)",
+    "outerClosed": "Außenkontur geschlossen ✓ · Öffnungen: {{count}}",
+    "drawingHole": " · Öffnung wird gezeichnet ({{count}} Punkt(e))",
+    "outerOpenClosable": "Außenkontur offen — {{count}} Punkte (schließbar)",
+    "outerOpen": "Außenkontur offen — {{count}} Punkt(e)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/el/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/el/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Αναίρεση σημείου",
+    "undoPointTitle": "Αφαίρεση τελευταίου σημείου (Backspace)",
+    "holesPhaseHint": "Κλικ για άνοιγμα · Enter ή δεξί κλικ = τέλος",
+    "line": "Γραμμή",
+    "lineTitle": "Ευθύγραμμο τμήμα",
+    "arc": "Τόξο",
+    "arcTitle": "Τμήμα τόξου (πλήκτρο A, τροχός ποντικιού = κύρτωση)",
+    "closeOuter": "Κλείσιμο περιγράμματος",
+    "closeOuterTitle": "Κλείστε το εξωτερικό περίγραμμα (≥ 3 σημεία) — έπειτα μπορείτε να σχεδιάσετε ανοίγματα",
+    "closeHole": "Κλείσιμο ανοίγματος",
+    "closeHoleTitle": "Κλείσιμο ανοίγματος (≥ 3 σημεία)",
+    "done": "Τέλος",
+    "doneTitle": "Ελέγχει αν τα περιγράμματα είναι κλειστά, σχεδιάζει τη διαγράμμιση και βγαίνει από τη λειτουργία (Enter)",
+    "cancelTitle": "Ακύρωση (Esc)",
+    "outerClosed": "Εξωτερικό περίγραμμα κλειστό ✓ · ανοίγματα: {{count}}",
+    "drawingHole": " · σχεδίαση ανοίγματος ({{count}} σημείο/α)",
+    "outerOpenClosable": "Εξωτερικό περίγραμμα ανοιχτό — {{count}} σημεία (κλείνει)",
+    "outerOpen": "Εξωτερικό περίγραμμα ανοιχτό — {{count}} σημείο/α"
+  },
+  "boxWidthAbbr": "Π",
+  "boxHeightAbbr": "Υ"
 }

--- a/open-pdf-studio/js/i18n/locales/en/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/en/statusbar.json
@@ -66,5 +66,27 @@
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
   "viewFacing": "Two Pages Side by Side",
-  "compareTabTitle": "Compare"
+  "compareTabTitle": "Compare",
+  "filledAreaSketch": {
+    "undoPoint": "Undo point",
+    "undoPointTitle": "Remove last point (Backspace)",
+    "holesPhaseHint": "Click for an opening · Enter or right-click = done",
+    "line": "Line",
+    "lineTitle": "Straight segment",
+    "arc": "Arc",
+    "arcTitle": "Arc segment (key A, mouse wheel = bulge)",
+    "closeOuter": "Close contour",
+    "closeOuterTitle": "Close outer contour (≥ 3 points) — then you can draw openings (donut)",
+    "closeHole": "Close opening",
+    "closeHoleTitle": "Close opening (≥ 3 points)",
+    "done": "Done",
+    "doneTitle": "Checks the contours are closed, draws the hatch, and exits the mode (Enter)",
+    "cancelTitle": "Cancel (Esc)",
+    "outerClosed": "Outer contour closed ✓ · openings: {{count}}",
+    "drawingHole": " · drawing opening ({{count}} point(s))",
+    "outerOpenClosable": "Outer contour open — {{count}} points (closable)",
+    "outerOpen": "Outer contour open — {{count}} point(s)"
+  },
+  "boxWidthAbbr": "W",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/es/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/es/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Deshacer punto",
+    "undoPointTitle": "Eliminar el último punto (Retroceso)",
+    "holesPhaseHint": "Haga clic para una abertura · Intro o clic derecho = hecho",
+    "line": "Línea",
+    "lineTitle": "Segmento recto",
+    "arc": "Arco",
+    "arcTitle": "Segmento de arco (tecla A, rueda del ratón = curvatura)",
+    "closeOuter": "Cerrar contorno",
+    "closeOuterTitle": "Cerrar contorno exterior (≥ 3 puntos) — después podrás dibujar aberturas (donut)",
+    "closeHole": "Cerrar abertura",
+    "closeHoleTitle": "Cerrar abertura (≥ 3 puntos)",
+    "done": "Hecho",
+    "doneTitle": "Comprueba que los contornos estén cerrados, dibuja la trama y sale del modo (Intro)",
+    "cancelTitle": "Cancelar (Esc)",
+    "outerClosed": "Contorno exterior cerrado ✓ · aberturas: {{count}}",
+    "drawingHole": " · dibujando abertura ({{count}} punto(s))",
+    "outerOpenClosable": "Contorno exterior abierto — {{count}} puntos (se puede cerrar)",
+    "outerOpen": "Contorno exterior abierto — {{count}} punto(s)"
+  },
+  "boxWidthAbbr": "A",
+  "boxHeightAbbr": "Al"
 }

--- a/open-pdf-studio/js/i18n/locales/fa/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fa/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "واگرد نقطه",
+    "undoPointTitle": "حذف آخرین نقطه (Backspace)",
+    "holesPhaseHint": "برای بازشو کلیک کنید · Enter یا کلیک راست = پایان",
+    "line": "خط",
+    "lineTitle": "پاره‌خط مستقیم",
+    "arc": "کمان",
+    "arcTitle": "پاره کمان (کلید A، چرخ ماوس = برآمدگی)",
+    "closeOuter": "بستن پیرامون",
+    "closeOuterTitle": "پیرامون بیرونی را ببندید (≥ ۳ نقطه) — سپس می‌توانید بازشوها را بکشید",
+    "closeHole": "بستن بازشو",
+    "closeHoleTitle": "بستن بازشو (≥ ۳ نقطه)",
+    "done": "پایان",
+    "doneTitle": "بررسی می‌کند که پیرامون‌ها بسته باشند، هاشور را می‌کشد و از حالت خارج می‌شود (Enter)",
+    "cancelTitle": "لغو (Esc)",
+    "outerClosed": "پیرامون بیرونی بسته شد ✓ · بازشوها: {{count}}",
+    "drawingHole": " · در حال کشیدن بازشو ({{count}} نقطه)",
+    "outerOpenClosable": "پیرامون بیرونی باز است — {{count}} نقطه (قابل بستن)",
+    "outerOpen": "پیرامون بیرونی باز است — {{count}} نقطه"
+  },
+  "boxWidthAbbr": "ع",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/fi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fi/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Kumoa piste",
+    "undoPointTitle": "Poista viimeisin piste (Askelpalautin)",
+    "holesPhaseHint": "Napsauta aukkoa varten · Enter tai oikea napsautus = valmis",
+    "line": "Viiva",
+    "lineTitle": "Suora segmentti",
+    "arc": "Kaari",
+    "arcTitle": "Kaarisegmentti (näppäin A, hiiren rulla = pullistuma)",
+    "closeOuter": "Sulje ääriviiva",
+    "closeOuterTitle": "Sulje ulkoääriviiva (≥ 3 pistettä) — sen jälkeen voit piirtää aukkoja",
+    "closeHole": "Sulje aukko",
+    "closeHoleTitle": "Sulje aukko (≥ 3 pistettä)",
+    "done": "Valmis",
+    "doneTitle": "Tarkistaa, että ääriviivat on suljettu, piirtää viivoituksen ja poistuu tilasta (Enter)",
+    "cancelTitle": "Peruuta (Esc)",
+    "outerClosed": "Ulkoääriviiva suljettu ✓ · aukkoja: {{count}}",
+    "drawingHole": " · piirretään aukkoa ({{count}} piste(ttä))",
+    "outerOpenClosable": "Ulkoääriviiva auki — {{count}} pistettä (suljettavissa)",
+    "outerOpen": "Ulkoääriviiva auki — {{count}} piste(ttä)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "K"
 }

--- a/open-pdf-studio/js/i18n/locales/fr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/fr/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Annuler le point",
+    "undoPointTitle": "Supprimer le dernier point (Retour arrière)",
+    "holesPhaseHint": "Cliquez pour une ouverture · Entrée ou clic droit = terminé",
+    "line": "Ligne",
+    "lineTitle": "Segment droit",
+    "arc": "Arc",
+    "arcTitle": "Segment d'arc (touche A, molette = bombement)",
+    "closeOuter": "Fermer le contour",
+    "closeOuterTitle": "Fermer le contour extérieur (≥ 3 points) — vous pourrez ensuite tracer des ouvertures (donut)",
+    "closeHole": "Fermer l'ouverture",
+    "closeHoleTitle": "Fermer l'ouverture (≥ 3 points)",
+    "done": "Terminé",
+    "doneTitle": "Vérifie que les contours sont fermés, trace la hachure et quitte le mode (Entrée)",
+    "cancelTitle": "Annuler (Échap)",
+    "outerClosed": "Contour extérieur fermé ✓ · ouvertures : {{count}}",
+    "drawingHole": " · ouverture en cours ({{count}} point(s))",
+    "outerOpenClosable": "Contour extérieur ouvert — {{count}} points (fermable)",
+    "outerOpen": "Contour extérieur ouvert — {{count}} point(s)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/he/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/he/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "בטל נקודה",
+    "undoPointTitle": "הסר את הנקודה האחרונה (Backspace)",
+    "holesPhaseHint": "לחץ לפתח · Enter או קליק ימני = סיום",
+    "line": "קו",
+    "lineTitle": "קטע ישר",
+    "arc": "קשת",
+    "arcTitle": "קטע קשת (מקש A, גלגלת עכבר = בליטה)",
+    "closeOuter": "סגור מתאר",
+    "closeOuterTitle": "סגור את המתאר החיצוני (≥ 3 נקודות) — לאחר מכן ניתן לצייר פתחים",
+    "closeHole": "סגור פתח",
+    "closeHoleTitle": "סגור פתח (≥ 3 נקודות)",
+    "done": "סיום",
+    "doneTitle": "בודק שהמתארים סגורים, מצייר את המילוי ויוצא מהמצב (Enter)",
+    "cancelTitle": "ביטול (Esc)",
+    "outerClosed": "מתאר חיצוני סגור ✓ · פתחים: {{count}}",
+    "drawingHole": " · מצייר פתח ({{count}} נקודות)",
+    "outerOpenClosable": "מתאר חיצוני פתוח — {{count}} נקודות (ניתן לסגור)",
+    "outerOpen": "מתאר חיצוני פתוח — {{count}} נקודות"
+  },
+  "boxWidthAbbr": "ר",
+  "boxHeightAbbr": "ג"
 }

--- a/open-pdf-studio/js/i18n/locales/hi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hi/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "बिंदु पूर्ववत करें",
+    "undoPointTitle": "अंतिम बिंदु हटाएं (Backspace)",
+    "holesPhaseHint": "खुलाव के लिए क्लिक करें · Enter या राइट-क्लिक = पूर्ण",
+    "line": "रेखा",
+    "lineTitle": "सीधा खंड",
+    "arc": "चाप",
+    "arcTitle": "चाप खंड (कुंजी A, माउस व्हील = उभार)",
+    "closeOuter": "रूपरेखा बंद करें",
+    "closeOuterTitle": "बाहरी रूपरेखा बंद करें (≥ 3 बिंदु) — फिर आप खुलाव बना सकते हैं",
+    "closeHole": "खुलाव बंद करें",
+    "closeHoleTitle": "खुलाव बंद करें (≥ 3 बिंदु)",
+    "done": "पूर्ण",
+    "doneTitle": "जाँचता है कि रूपरेखाएँ बंद हैं, हैचिंग बनाता है और मोड से बाहर निकलता है (Enter)",
+    "cancelTitle": "रद्द करें (Esc)",
+    "outerClosed": "बाहरी रूपरेखा बंद ✓ · खुलाव: {{count}}",
+    "drawingHole": " · खुलाव बनाया जा रहा है ({{count}} बिंदु)",
+    "outerOpenClosable": "बाहरी रूपरेखा खुली है — {{count}} बिंदु (बंद की जा सकती है)",
+    "outerOpen": "बाहरी रूपरेखा खुली है — {{count}} बिंदु"
+  },
+  "boxWidthAbbr": "च",
+  "boxHeightAbbr": "ऊ"
 }

--- a/open-pdf-studio/js/i18n/locales/hr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hr/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Poništi točku",
+    "undoPointTitle": "Ukloni zadnju točku (Backspace)",
+    "holesPhaseHint": "Kliknite za otvor · Enter ili desni klik = gotovo",
+    "line": "Linija",
+    "lineTitle": "Ravni segment",
+    "arc": "Luk",
+    "arcTitle": "Segment luka (tipka A, kotačić miša = ispupčenje)",
+    "closeOuter": "Zatvori konturu",
+    "closeOuterTitle": "Zatvori vanjsku konturu (≥ 3 točke) — zatim možete crtati otvore (donut)",
+    "closeHole": "Zatvori otvor",
+    "closeHoleTitle": "Zatvori otvor (≥ 3 točke)",
+    "done": "Gotovo",
+    "doneTitle": "Provjerava jesu li konture zatvorene, iscrtava šrafuru i izlazi iz načina rada (Enter)",
+    "cancelTitle": "Otkaži (Esc)",
+    "outerClosed": "Vanjska kontura zatvorena ✓ · otvori: {{count}}",
+    "drawingHole": " · crtanje otvora ({{count}} točka/e)",
+    "outerOpenClosable": "Vanjska kontura otvorena — {{count}} točaka (može se zatvoriti)",
+    "outerOpen": "Vanjska kontura otvorena — {{count}} točka/e"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/hu/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/hu/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Pont visszavonása",
+    "undoPointTitle": "Utolsó pont eltávolítása (Backspace)",
+    "holesPhaseHint": "Kattintson nyíláshoz · Enter vagy jobb katt = kész",
+    "line": "Vonal",
+    "lineTitle": "Egyenes szakasz",
+    "arc": "Ív",
+    "arcTitle": "Ívszakasz (A billentyű, egérgörgő = domborulat)",
+    "closeOuter": "Kontúr lezárása",
+    "closeOuterTitle": "Külső kontúr lezárása (≥ 3 pont) — utána nyílásokat (donut) rajzolhat",
+    "closeHole": "Nyílás lezárása",
+    "closeHoleTitle": "Nyílás lezárása (≥ 3 pont)",
+    "done": "Kész",
+    "doneTitle": "Ellenőrzi, hogy a kontúrok zártak-e, kirajzolja a sraffozást és kilép a módból (Enter)",
+    "cancelTitle": "Mégse (Esc)",
+    "outerClosed": "Külső kontúr lezárva ✓ · nyílások: {{count}}",
+    "drawingHole": " · nyílás rajzolása ({{count}} pont)",
+    "outerOpenClosable": "Külső kontúr nyitva — {{count}} pont (lezárható)",
+    "outerOpen": "Külső kontúr nyitva — {{count}} pont"
+  },
+  "boxWidthAbbr": "Sz",
+  "boxHeightAbbr": "M"
 }

--- a/open-pdf-studio/js/i18n/locales/id/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/id/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Batalkan titik",
+    "undoPointTitle": "Hapus titik terakhir (Backspace)",
+    "holesPhaseHint": "Klik untuk bukaan · Enter atau klik kanan = selesai",
+    "line": "Garis",
+    "lineTitle": "Segmen lurus",
+    "arc": "Busur",
+    "arcTitle": "Segmen busur (tombol A, roda mouse = kelengkungan)",
+    "closeOuter": "Tutup kontur",
+    "closeOuterTitle": "Tutup kontur luar (≥ 3 titik) — lalu Anda bisa menggambar bukaan (donat)",
+    "closeHole": "Tutup bukaan",
+    "closeHoleTitle": "Tutup bukaan (≥ 3 titik)",
+    "done": "Selesai",
+    "doneTitle": "Memeriksa apakah kontur sudah tertutup, menggambar arsiran, dan keluar dari mode (Enter)",
+    "cancelTitle": "Batal (Esc)",
+    "outerClosed": "Kontur luar tertutup ✓ · bukaan: {{count}}",
+    "drawingHole": " · menggambar bukaan ({{count}} titik)",
+    "outerOpenClosable": "Kontur luar terbuka — {{count}} titik (bisa ditutup)",
+    "outerOpen": "Kontur luar terbuka — {{count}} titik"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "T"
 }

--- a/open-pdf-studio/js/i18n/locales/it/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/it/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Annulla punto",
+    "undoPointTitle": "Rimuovi ultimo punto (Backspace)",
+    "holesPhaseHint": "Clicca per un'apertura · Invio o clic destro = fatto",
+    "line": "Linea",
+    "lineTitle": "Segmento retto",
+    "arc": "Arco",
+    "arcTitle": "Segmento ad arco (tasto A, rotella = bombatura)",
+    "closeOuter": "Chiudi contorno",
+    "closeOuterTitle": "Chiudi il contorno esterno (≥ 3 punti) — poi potrai disegnare aperture (donut)",
+    "closeHole": "Chiudi apertura",
+    "closeHoleTitle": "Chiudi apertura (≥ 3 punti)",
+    "done": "Fatto",
+    "doneTitle": "Verifica che i contorni siano chiusi, disegna il retino ed esce dalla modalità (Invio)",
+    "cancelTitle": "Annulla (Esc)",
+    "outerClosed": "Contorno esterno chiuso ✓ · aperture: {{count}}",
+    "drawingHole": " · apertura in corso ({{count}} punto/i)",
+    "outerOpenClosable": "Contorno esterno aperto — {{count}} punti (chiudibile)",
+    "outerOpen": "Contorno esterno aperto — {{count}} punto/i"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "A"
 }

--- a/open-pdf-studio/js/i18n/locales/ja/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ja/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "点を元に戻す",
+    "undoPointTitle": "最後の点を削除（Backspace）",
+    "holesPhaseHint": "クリックで開口部を追加 · Enterまたは右クリック＝完了",
+    "line": "直線",
+    "lineTitle": "直線セグメント",
+    "arc": "円弧",
+    "arcTitle": "円弧セグメント（キー A、マウスホイール＝膨らみ）",
+    "closeOuter": "輪郭を閉じる",
+    "closeOuterTitle": "外側の輪郭を閉じる（3点以上）— その後、開口部（ドーナツ）を描けます",
+    "closeHole": "開口部を閉じる",
+    "closeHoleTitle": "開口部を閉じる（3点以上）",
+    "done": "完了",
+    "doneTitle": "輪郭が閉じているか確認し、ハッチングを描画してモードを終了します（Enter）",
+    "cancelTitle": "キャンセル（Esc）",
+    "outerClosed": "外側輪郭閉鎖済み ✓ · 開口部：{{count}}",
+    "drawingHole": " · 開口部を描画中（{{count}}点）",
+    "outerOpenClosable": "外側輪郭が開いています — {{count}}点（閉じられます）",
+    "outerOpen": "外側輪郭が開いています — {{count}}点"
+  },
+  "boxWidthAbbr": "幅",
+  "boxHeightAbbr": "高"
 }

--- a/open-pdf-studio/js/i18n/locales/ko/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ko/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "점 실행 취소",
+    "undoPointTitle": "마지막 점 제거(Backspace)",
+    "holesPhaseHint": "클릭하여 개구부 추가 · Enter 또는 우클릭 = 완료",
+    "line": "선",
+    "lineTitle": "직선 세그먼트",
+    "arc": "호",
+    "arcTitle": "호 세그먼트(키 A, 마우스 휠 = 볼록도)",
+    "closeOuter": "윤곽 닫기",
+    "closeOuterTitle": "외곽 윤곽을 닫습니다(3점 이상) — 이후 개구부(도넛)를 그릴 수 있습니다",
+    "closeHole": "개구부 닫기",
+    "closeHoleTitle": "개구부 닫기(3점 이상)",
+    "done": "완료",
+    "doneTitle": "윤곽이 닫혔는지 확인하고 해칭을 그린 후 모드를 종료합니다(Enter)",
+    "cancelTitle": "취소(Esc)",
+    "outerClosed": "외곽 윤곽 닫힘 ✓ · 개구부: {{count}}",
+    "drawingHole": " · 개구부 그리는 중 ({{count}}점)",
+    "outerOpenClosable": "외곽 윤곽 열림 — {{count}}점 (닫을 수 있음)",
+    "outerOpen": "외곽 윤곽 열림 — {{count}}점"
+  },
+  "boxWidthAbbr": "너",
+  "boxHeightAbbr": "높"
 }

--- a/open-pdf-studio/js/i18n/locales/ms/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ms/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Buat asal titik",
+    "undoPointTitle": "Buang titik terakhir (Backspace)",
+    "holesPhaseHint": "Klik untuk bukaan · Enter atau klik kanan = selesai",
+    "line": "Garisan",
+    "lineTitle": "Segmen lurus",
+    "arc": "Lengkok",
+    "arcTitle": "Segmen lengkok (kekunci A, roda tetikus = lengkungan)",
+    "closeOuter": "Tutup kontur",
+    "closeOuterTitle": "Tutup kontur luar (≥ 3 titik) — kemudian anda boleh melukis bukaan",
+    "closeHole": "Tutup bukaan",
+    "closeHoleTitle": "Tutup bukaan (≥ 3 titik)",
+    "done": "Selesai",
+    "doneTitle": "Menyemak sama ada kontur tertutup, melukis lorekan dan keluar dari mod (Enter)",
+    "cancelTitle": "Batal (Esc)",
+    "outerClosed": "Kontur luar tertutup ✓ · bukaan: {{count}}",
+    "drawingHole": " · melukis bukaan ({{count}} titik)",
+    "outerOpenClosable": "Kontur luar terbuka — {{count}} titik (boleh ditutup)",
+    "outerOpen": "Kontur luar terbuka — {{count}} titik"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "T"
 }

--- a/open-pdf-studio/js/i18n/locales/nb/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/nb/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Angre punkt",
+    "undoPointTitle": "Fjern siste punkt (Backspace)",
+    "holesPhaseHint": "Klikk for en åpning · Enter eller høyreklikk = ferdig",
+    "line": "Linje",
+    "lineTitle": "Rett segment",
+    "arc": "Bue",
+    "arcTitle": "Buesegment (tast A, musehjul = utbuling)",
+    "closeOuter": "Lukk kontur",
+    "closeOuterTitle": "Lukk ytterkontur (≥ 3 punkter) — deretter kan du tegne åpninger (smultring)",
+    "closeHole": "Lukk åpning",
+    "closeHoleTitle": "Lukk åpning (≥ 3 punkter)",
+    "done": "Ferdig",
+    "doneTitle": "Sjekker at konturene er lukket, tegner skraveringen og forlater modusen (Enter)",
+    "cancelTitle": "Avbryt (Esc)",
+    "outerClosed": "Ytterkontur lukket ✓ · åpninger: {{count}}",
+    "drawingHole": " · tegner åpning ({{count}} punkt(er))",
+    "outerOpenClosable": "Ytterkontur åpen — {{count}} punkter (kan lukkes)",
+    "outerOpen": "Ytterkontur åpen — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/nl/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/nl/statusbar.json
@@ -66,5 +66,27 @@
   "viewContinuous": "Doorlopend",
   "viewBook": "Twee pagina’s",
   "viewFacing": "Twee pagina’s naast elkaar",
-  "compareTabTitle": "Vergelijken"
+  "compareTabTitle": "Vergelijken",
+  "filledAreaSketch": {
+    "undoPoint": "Punt ongedaan maken",
+    "undoPointTitle": "Verwijder laatste punt (Backspace)",
+    "holesPhaseHint": "Klik voor een opening · Enter of rechtermuisklik = gereed",
+    "line": "Lijn",
+    "lineTitle": "Recht segment",
+    "arc": "Boog",
+    "arcTitle": "Boogsegment (sneltoets A, muiswiel = bolling)",
+    "closeOuter": "Sluit contour",
+    "closeOuterTitle": "Buitenrand sluiten (≥ 3 punten) — daarna kun je openingen (donut) tekenen",
+    "closeHole": "Opening sluiten",
+    "closeHoleTitle": "Opening sluiten (≥ 3 punten)",
+    "done": "Gereed",
+    "doneTitle": "Controleert of de contouren gesloten zijn, tekent de arcering en verlaat de modus (Enter)",
+    "cancelTitle": "Annuleren (Esc)",
+    "outerClosed": "Buitenrand gesloten ✓ · openingen: {{count}}",
+    "drawingHole": " · bezig met opening ({{count}} punt(en))",
+    "outerOpenClosable": "Buitenrand open — {{count}} punten (sluitbaar)",
+    "outerOpen": "Buitenrand open — {{count}} punt(en)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/pl/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/pl/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Cofnij punkt",
+    "undoPointTitle": "Usuń ostatni punkt (Backspace)",
+    "holesPhaseHint": "Kliknij, aby dodać otwór · Enter lub prawy przycisk = gotowe",
+    "line": "Linia",
+    "lineTitle": "Odcinek prosty",
+    "arc": "Łuk",
+    "arcTitle": "Segment łuku (klawisz A, kółko myszy = wybrzuszenie)",
+    "closeOuter": "Zamknij kontur",
+    "closeOuterTitle": "Zamknij kontur zewnętrzny (≥ 3 punkty) — potem można rysować otwory (donut)",
+    "closeHole": "Zamknij otwór",
+    "closeHoleTitle": "Zamknij otwór (≥ 3 punkty)",
+    "done": "Gotowe",
+    "doneTitle": "Sprawdza, czy kontury są zamknięte, rysuje kreskowanie i wychodzi z trybu (Enter)",
+    "cancelTitle": "Anuluj (Esc)",
+    "outerClosed": "Kontur zewnętrzny zamknięty ✓ · otwory: {{count}}",
+    "drawingHole": " · rysowanie otworu ({{count}} punkt(y))",
+    "outerOpenClosable": "Kontur zewnętrzny otwarty — {{count}} punktów (można zamknąć)",
+    "outerOpen": "Kontur zewnętrzny otwarty — {{count}} punkt(y)"
+  },
+  "boxWidthAbbr": "S",
+  "boxHeightAbbr": "W"
 }

--- a/open-pdf-studio/js/i18n/locales/pt/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/pt/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Desfazer ponto",
+    "undoPointTitle": "Remover último ponto (Backspace)",
+    "holesPhaseHint": "Clique para uma abertura · Enter ou clique direito = concluído",
+    "line": "Linha",
+    "lineTitle": "Segmento reto",
+    "arc": "Arco",
+    "arcTitle": "Segmento de arco (tecla A, roda do rato = abaulamento)",
+    "closeOuter": "Fechar contorno",
+    "closeOuterTitle": "Fechar contorno exterior (≥ 3 pontos) — depois pode desenhar aberturas (donut)",
+    "closeHole": "Fechar abertura",
+    "closeHoleTitle": "Fechar abertura (≥ 3 pontos)",
+    "done": "Concluído",
+    "doneTitle": "Verifica se os contornos estão fechados, desenha a trama e sai do modo (Enter)",
+    "cancelTitle": "Cancelar (Esc)",
+    "outerClosed": "Contorno exterior fechado ✓ · aberturas: {{count}}",
+    "drawingHole": " · a desenhar abertura ({{count}} ponto(s))",
+    "outerOpenClosable": "Contorno exterior aberto — {{count}} pontos (fechável)",
+    "outerOpen": "Contorno exterior aberto — {{count}} ponto(s)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "A"
 }

--- a/open-pdf-studio/js/i18n/locales/ro/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ro/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Anulează punctul",
+    "undoPointTitle": "Elimină ultimul punct (Backspace)",
+    "holesPhaseHint": "Clic pentru o deschidere · Enter sau clic dreapta = terminat",
+    "line": "Linie",
+    "lineTitle": "Segment drept",
+    "arc": "Arc",
+    "arcTitle": "Segment de arc (tasta A, rotița mouse-ului = bombare)",
+    "closeOuter": "Închide conturul",
+    "closeOuterTitle": "Închide conturul exterior (≥ 3 puncte) — apoi poți desena deschideri (donut)",
+    "closeHole": "Închide deschiderea",
+    "closeHoleTitle": "Închide deschiderea (≥ 3 puncte)",
+    "done": "Terminat",
+    "doneTitle": "Verifică dacă conturile sunt închise, desenează haşura și iese din mod (Enter)",
+    "cancelTitle": "Anulează (Esc)",
+    "outerClosed": "Contur exterior închis ✓ · deschideri: {{count}}",
+    "drawingHole": " · se desenează deschiderea ({{count}} punct(e))",
+    "outerOpenClosable": "Contur exterior deschis — {{count}} puncte (se poate închide)",
+    "outerOpen": "Contur exterior deschis — {{count}} punct(e)"
+  },
+  "boxWidthAbbr": "L",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/ru/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ru/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Отменить точку",
+    "undoPointTitle": "Удалить последнюю точку (Backspace)",
+    "holesPhaseHint": "Щёлкните для отверстия · Enter или ПКМ = готово",
+    "line": "Линия",
+    "lineTitle": "Прямой сегмент",
+    "arc": "Дуга",
+    "arcTitle": "Сегмент дуги (клавиша A, колесо мыши = выпуклость)",
+    "closeOuter": "Замкнуть контур",
+    "closeOuterTitle": "Замкнуть внешний контур (≥ 3 точек) — затем можно рисовать отверстия (бублик)",
+    "closeHole": "Замкнуть отверстие",
+    "closeHoleTitle": "Замкнуть отверстие (≥ 3 точек)",
+    "done": "Готово",
+    "doneTitle": "Проверяет, что контуры замкнуты, рисует штриховку и выходит из режима (Enter)",
+    "cancelTitle": "Отмена (Esc)",
+    "outerClosed": "Внешний контур замкнут ✓ · отверстия: {{count}}",
+    "drawingHole": " · рисование отверстия ({{count}} точ.)",
+    "outerOpenClosable": "Внешний контур открыт — {{count}} точек (можно замкнуть)",
+    "outerOpen": "Внешний контур открыт — {{count}} точ."
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/sk/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sk/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Spať bod",
+    "undoPointTitle": "Odobrať posledný bod (Backspace)",
+    "holesPhaseHint": "Kliknite pre otvor · Enter alebo pravé tlačidlo = hotovo",
+    "line": "Čiara",
+    "lineTitle": "Priamy segment",
+    "arc": "Oblúk",
+    "arcTitle": "Oblúkový segment (klávesa A, koliesko myši = vypuklosť)",
+    "closeOuter": "Zavrieť obrys",
+    "closeOuterTitle": "Zavrieť vonkajší obrys (≥ 3 body) — potom môžete kresliť otvory (donut)",
+    "closeHole": "Zavrieť otvor",
+    "closeHoleTitle": "Zavrieť otvor (≥ 3 body)",
+    "done": "Hotovo",
+    "doneTitle": "Skontroluje, či sú obrysy uzavreté, nakreslí šrafovanie a opustí režim (Enter)",
+    "cancelTitle": "Zrušiť (Esc)",
+    "outerClosed": "Vonkajší obrys uzavretý ✓ · otvory: {{count}}",
+    "drawingHole": " · kreslenie otvoru ({{count}} bod(y))",
+    "outerOpenClosable": "Vonkajší obrys otvorený — {{count}} bodov (možno zavrieť)",
+    "outerOpen": "Vonkajší obrys otvorený — {{count}} bod(y)"
+  },
+  "boxWidthAbbr": "Š",
+  "boxHeightAbbr": "V"
 }

--- a/open-pdf-studio/js/i18n/locales/sr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sr/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Опозови тачку",
+    "undoPointTitle": "Уклони последњу тачку (Backspace)",
+    "holesPhaseHint": "Кликните за отвор · Enter или десни клик = готово",
+    "line": "Линија",
+    "lineTitle": "Прав сегмент",
+    "arc": "Лук",
+    "arcTitle": "Сегмент лука (тастер A, точкић миша = испупчење)",
+    "closeOuter": "Затвори контуру",
+    "closeOuterTitle": "Затвори спољну контуру (≥ 3 тачке) — затим можете цртати отворе (донат)",
+    "closeHole": "Затвори отвор",
+    "closeHoleTitle": "Затвори отвор (≥ 3 тачке)",
+    "done": "Готово",
+    "doneTitle": "Проверава да ли су контуре затворене, исцртава шрафуру и излази из режима (Enter)",
+    "cancelTitle": "Откажи (Esc)",
+    "outerClosed": "Спољна контура затворена ✓ · отвори: {{count}}",
+    "drawingHole": " · цртање отвора ({{count}} тачка/е)",
+    "outerOpenClosable": "Спољна контура отворена — {{count}} тачака (може се затворити)",
+    "outerOpen": "Спољна контура отворена — {{count}} тачка/е"
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/sv/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sv/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Ångra punkt",
+    "undoPointTitle": "Ta bort senaste punkten (Backsteg)",
+    "holesPhaseHint": "Klicka för en öppning · Retur eller högerklick = klar",
+    "line": "Linje",
+    "lineTitle": "Rakt segment",
+    "arc": "Båge",
+    "arcTitle": "Bågsegment (tangent A, mushjul = bukt)",
+    "closeOuter": "Stäng konturen",
+    "closeOuterTitle": "Stäng ytterkonturen (≥ 3 punkter) — sedan kan du rita öppningar (munk)",
+    "closeHole": "Stäng öppning",
+    "closeHoleTitle": "Stäng öppning (≥ 3 punkter)",
+    "done": "Klar",
+    "doneTitle": "Kontrollerar att konturerna är stängda, ritar skrafferingen och lämnar läget (Retur)",
+    "cancelTitle": "Avbryt (Esc)",
+    "outerClosed": "Ytterkontur stängd ✓ · öppningar: {{count}}",
+    "drawingHole": " · ritar öppning ({{count}} punkt(er))",
+    "outerOpenClosable": "Ytterkontur öppen — {{count}} punkter (kan stängas)",
+    "outerOpen": "Ytterkontur öppen — {{count}} punkt(er)"
+  },
+  "boxWidthAbbr": "B",
+  "boxHeightAbbr": "H"
 }

--- a/open-pdf-studio/js/i18n/locales/sw/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/sw/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Tengua pointi",
+    "undoPointTitle": "Ondoa pointi ya mwisho (Backspace)",
+    "holesPhaseHint": "Bofya kwa fursa · Enter au kubofya kulia = imekamilika",
+    "line": "Mstari",
+    "lineTitle": "Sehemu iliyonyooka",
+    "arc": "Upinde",
+    "arcTitle": "Sehemu ya upinde (kitufe A, gurudumu la panya = uvimbe)",
+    "closeOuter": "Funga ukingo",
+    "closeOuterTitle": "Funga ukingo wa nje (≥ pointi 3) — kisha unaweza kuchora fursa",
+    "closeHole": "Funga fursa",
+    "closeHoleTitle": "Funga fursa (≥ pointi 3)",
+    "done": "Imekamilika",
+    "doneTitle": "Inakagua kama kingo zimefungwa, inachora mistari na kutoka katika hali hii (Enter)",
+    "cancelTitle": "Ghairi (Esc)",
+    "outerClosed": "Ukingo wa nje umefungwa ✓ · fursa: {{count}}",
+    "drawingHole": " · inachora fursa (pointi {{count}})",
+    "outerOpenClosable": "Ukingo wa nje umefunguliwa — pointi {{count}} (unaweza kufungwa)",
+    "outerOpen": "Ukingo wa nje umefunguliwa — pointi {{count}}"
+  },
+  "boxWidthAbbr": "U",
+  "boxHeightAbbr": "K"
 }

--- a/open-pdf-studio/js/i18n/locales/ta/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ta/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "புள்ளியை மீட்டமை",
+    "undoPointTitle": "கடைசி புள்ளியை அகற்று (Backspace)",
+    "holesPhaseHint": "திறப்புக்கு கிளிக் செய்யவும் · Enter அல்லது வலது கிளிக் = முடிந்தது",
+    "line": "கோடு",
+    "lineTitle": "நேர்கோட்டுப் பகுதி",
+    "arc": "வளைவு",
+    "arcTitle": "வளைவுப் பகுதி (விசை A, மவுஸ் வீல் = குமிழ்)",
+    "closeOuter": "சுற்றுவரையை மூடு",
+    "closeOuterTitle": "வெளிப்புற சுற்றுவரையை மூடவும் (≥ 3 புள்ளிகள்) — பின்னர் திறப்புகளை வரையலாம்",
+    "closeHole": "திறப்பை மூடு",
+    "closeHoleTitle": "திறப்பை மூடு (≥ 3 புள்ளிகள்)",
+    "done": "முடிந்தது",
+    "doneTitle": "சுற்றுவரைகள் மூடப்பட்டுள்ளதா எனச் சரிபார்த்து, சரடு வரைந்து பயன்முறையிலிருந்து வெளியேறும் (Enter)",
+    "cancelTitle": "ரத்து (Esc)",
+    "outerClosed": "வெளிப்புற சுற்றுவரை மூடப்பட்டது ✓ · திறப்புகள்: {{count}}",
+    "drawingHole": " · திறப்பு வரையப்படுகிறது ({{count}} புள்ளிகள்)",
+    "outerOpenClosable": "வெளிப்புற சுற்றுவரை திறந்துள்ளது — {{count}} புள்ளிகள் (மூடலாம்)",
+    "outerOpen": "வெளிப்புற சுற்றுவரை திறந்துள்ளது — {{count}} புள்ளிகள்"
+  },
+  "boxWidthAbbr": "அ",
+  "boxHeightAbbr": "உ"
 }

--- a/open-pdf-studio/js/i18n/locales/th/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/th/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "เลิกทำจุด",
+    "undoPointTitle": "ลบจุดล่าสุด (Backspace)",
+    "holesPhaseHint": "คลิกเพื่อเปิดช่อง · Enter หรือคลิกขวา = เสร็จสิ้น",
+    "line": "เส้นตรง",
+    "lineTitle": "ส่วนเส้นตรง",
+    "arc": "ส่วนโค้ง",
+    "arcTitle": "ส่วนโค้ง (ปุ่ม A, ล้อเมาส์ = ความโค้งนูน)",
+    "closeOuter": "ปิดเส้นขอบ",
+    "closeOuterTitle": "ปิดเส้นขอบด้านนอก (≥ 3 จุด) — จากนั้นสามารถวาดช่องเปิดได้",
+    "closeHole": "ปิดช่องเปิด",
+    "closeHoleTitle": "ปิดช่องเปิด (≥ 3 จุด)",
+    "done": "เสร็จสิ้น",
+    "doneTitle": "ตรวจสอบว่าเส้นขอบปิดแล้ว วาดลายเส้น และออกจากโหมด (Enter)",
+    "cancelTitle": "ยกเลิก (Esc)",
+    "outerClosed": "เส้นขอบด้านนอกปิดแล้ว ✓ · ช่องเปิด: {{count}}",
+    "drawingHole": " · กำลังวาดช่องเปิด ({{count}} จุด)",
+    "outerOpenClosable": "เส้นขอบด้านนอกเปิดอยู่ — {{count}} จุด (ปิดได้)",
+    "outerOpen": "เส้นขอบด้านนอกเปิดอยู่ — {{count}} จุด"
+  },
+  "boxWidthAbbr": "ก",
+  "boxHeightAbbr": "ส"
 }

--- a/open-pdf-studio/js/i18n/locales/tr/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/tr/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Noktayı geri al",
+    "undoPointTitle": "Son noktayı kaldır (Backspace)",
+    "holesPhaseHint": "Açıklık için tıklayın · Enter veya sağ tık = bitti",
+    "line": "Çizgi",
+    "lineTitle": "Düz segment",
+    "arc": "Yay",
+    "arcTitle": "Yay segmenti (A tuşu, fare tekerleği = bombe)",
+    "closeOuter": "Konturu kapat",
+    "closeOuterTitle": "Dış konturu kapat (≥ 3 nokta) — ardından açıklık (donut) çizebilirsiniz",
+    "closeHole": "Açıklığı kapat",
+    "closeHoleTitle": "Açıklığı kapat (≥ 3 nokta)",
+    "done": "Bitti",
+    "doneTitle": "Konturların kapalı olup olmadığını kontrol eder, taramayı çizer ve moddan çıkar (Enter)",
+    "cancelTitle": "İptal (Esc)",
+    "outerClosed": "Dış kontur kapalı ✓ · açıklıklar: {{count}}",
+    "drawingHole": " · açıklık çiziliyor ({{count}} nokta)",
+    "outerOpenClosable": "Dış kontur açık — {{count}} nokta (kapatılabilir)",
+    "outerOpen": "Dış kontur açık — {{count}} nokta"
+  },
+  "boxWidthAbbr": "G",
+  "boxHeightAbbr": "Y"
 }

--- a/open-pdf-studio/js/i18n/locales/uk/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/uk/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Скасувати точку",
+    "undoPointTitle": "Видалити останню точку (Backspace)",
+    "holesPhaseHint": "Клацніть для отвору · Enter або права кнопка = готово",
+    "line": "Лінія",
+    "lineTitle": "Прямий сегмент",
+    "arc": "Дуга",
+    "arcTitle": "Сегмент дуги (клавіша A, коліщатко миші = випуклість)",
+    "closeOuter": "Замкнути контур",
+    "closeOuterTitle": "Замкнути зовнішній контур (≥ 3 точки) — потім можна малювати отвори (бублик)",
+    "closeHole": "Замкнути отвір",
+    "closeHoleTitle": "Замкнути отвір (≥ 3 точки)",
+    "done": "Готово",
+    "doneTitle": "Перевіряє, чи контури замкнені, малює штрихування і виходить із режиму (Enter)",
+    "cancelTitle": "Скасувати (Esc)",
+    "outerClosed": "Зовнішній контур замкнено ✓ · отвори: {{count}}",
+    "drawingHole": " · малювання отвору ({{count}} точ.)",
+    "outerOpenClosable": "Зовнішній контур відкрито — {{count}} точок (можна замкнути)",
+    "outerOpen": "Зовнішній контур відкрито — {{count}} точ."
+  },
+  "boxWidthAbbr": "Ш",
+  "boxHeightAbbr": "В"
 }

--- a/open-pdf-studio/js/i18n/locales/ur/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/ur/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "نقطہ واپس لیں",
+    "undoPointTitle": "آخری نقطہ ہٹائیں (Backspace)",
+    "holesPhaseHint": "سوراخ کے لیے کلک کریں · Enter یا دائیں کلک = مکمل",
+    "line": "لائن",
+    "lineTitle": "سیدھا حصہ",
+    "arc": "آرک",
+    "arcTitle": "آرک حصہ (کلید A، ماؤس وہیل = ابھار)",
+    "closeOuter": "خاکہ بند کریں",
+    "closeOuterTitle": "بیرونی خاکہ بند کریں (≥ 3 پوائنٹس) — پھر آپ سوراخ بنا سکتے ہیں",
+    "closeHole": "سوراخ بند کریں",
+    "closeHoleTitle": "سوراخ بند کریں (≥ 3 پوائنٹس)",
+    "done": "مکمل",
+    "doneTitle": "جانچتا ہے کہ خاکے بند ہیں، ہیچنگ بناتا ہے اور موڈ سے نکل جاتا ہے (Enter)",
+    "cancelTitle": "منسوخ کریں (Esc)",
+    "outerClosed": "بیرونی خاکہ بند ✓ · سوراخ: {{count}}",
+    "drawingHole": " · سوراخ بن رہا ہے ({{count}} پوائنٹس)",
+    "outerOpenClosable": "بیرونی خاکہ کھلا ہے — {{count}} پوائنٹس (بند کیا جا سکتا ہے)",
+    "outerOpen": "بیرونی خاکہ کھلا ہے — {{count}} پوائنٹس"
+  },
+  "boxWidthAbbr": "چ",
+  "boxHeightAbbr": "ا"
 }

--- a/open-pdf-studio/js/i18n/locales/vi/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/vi/statusbar.json
@@ -58,5 +58,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "Hoàn tác điểm",
+    "undoPointTitle": "Xóa điểm cuối cùng (Backspace)",
+    "holesPhaseHint": "Nhấp để tạo lỗ mở · Enter hoặc chuột phải = xong",
+    "line": "Đường thẳng",
+    "lineTitle": "Đoạn thẳng",
+    "arc": "Cung",
+    "arcTitle": "Đoạn cung (phím A, con lăn chuột = độ phồng)",
+    "closeOuter": "Đóng đường viền",
+    "closeOuterTitle": "Đóng đường viền ngoài (≥ 3 điểm) — sau đó bạn có thể vẽ lỗ mở",
+    "closeHole": "Đóng lỗ mở",
+    "closeHoleTitle": "Đóng lỗ mở (≥ 3 điểm)",
+    "done": "Xong",
+    "doneTitle": "Kiểm tra các đường viền đã đóng, vẽ nét gạch và thoát chế độ (Enter)",
+    "cancelTitle": "Hủy (Esc)",
+    "outerClosed": "Đường viền ngoài đã đóng ✓ · lỗ mở: {{count}}",
+    "drawingHole": " · đang vẽ lỗ mở ({{count}} điểm)",
+    "outerOpenClosable": "Đường viền ngoài đang mở — {{count}} điểm (có thể đóng)",
+    "outerOpen": "Đường viền ngoài đang mở — {{count}} điểm"
+  },
+  "boxWidthAbbr": "R",
+  "boxHeightAbbr": "C"
 }

--- a/open-pdf-studio/js/i18n/locales/zh/statusbar.json
+++ b/open-pdf-studio/js/i18n/locales/zh/statusbar.json
@@ -57,5 +57,27 @@
   "viewSingle": "Single Page",
   "viewContinuous": "Continuous",
   "viewBook": "Two Pages",
-  "viewFacing": "Two Pages Side by Side"
+  "viewFacing": "Two Pages Side by Side",
+  "filledAreaSketch": {
+    "undoPoint": "撤销点",
+    "undoPointTitle": "删除最后一个点（退格键）",
+    "holesPhaseHint": "点击添加开孔 · 回车或右键 = 完成",
+    "line": "直线",
+    "lineTitle": "直线段",
+    "arc": "圆弧",
+    "arcTitle": "圆弧段（按键 A，鼠标滚轮 = 弧度）",
+    "closeOuter": "闭合轮廓",
+    "closeOuterTitle": "闭合外轮廓（≥ 3 个点）— 之后可以绘制开孔（环形）",
+    "closeHole": "闭合开孔",
+    "closeHoleTitle": "闭合开孔（≥ 3 个点）",
+    "done": "完成",
+    "doneTitle": "检查轮廓是否闭合，绘制填充线并退出该模式（回车）",
+    "cancelTitle": "取消（Esc）",
+    "outerClosed": "外轮廓已闭合 ✓ · 开孔：{{count}}",
+    "drawingHole": " · 正在绘制开孔（{{count}} 个点）",
+    "outerOpenClosable": "外轮廓未闭合 — {{count}} 个点（可闭合）",
+    "outerOpen": "外轮廓未闭合 — {{count}} 个点"
+  },
+  "boxWidthAbbr": "宽",
+  "boxHeightAbbr": "高"
 }

--- a/open-pdf-studio/js/solid/components/SketchModeBar.jsx
+++ b/open-pdf-studio/js/solid/components/SketchModeBar.jsx
@@ -1,17 +1,20 @@
 import { Show, createSignal, onMount, onCleanup } from 'solid-js';
 import { state } from '../../core/state.js';
 import { filledAreaSketch } from '../../tools/tools/filled-area-tool.js';
+import { useTranslation } from '../../i18n/useTranslation.js';
 
-// Floating sketch toolbar for the filled-area (arcering) tool — makes the
-// existing sketch machinery VISIBLE: line/arc segments, close-contour with
-// the >=3-points check, donut openings (holes phase) and an explicit
-// "Gereed" that commits and leaves the mode. Mirrors the keyboard flow
-// ('A' = boog, klik bij beginpunt = sluiten, Enter = gereed, Esc = annuleren).
+// Floating sketch toolbar for the filled-area tool — makes the existing
+// sketch machinery VISIBLE: line/arc segments, close-contour with the
+// >=3-points check, donut openings (holes phase), undo the last point, and
+// an explicit "Done" that commits and leaves the mode. Mirrors the keyboard
+// flow ('A' = arc, Backspace = undo point, click near start point = close,
+// Enter = done, Esc = cancel).
 
 const BTN = 'padding:3px 10px;font-size:11px;font-family:inherit;border:1px solid var(--theme-border,#888);background:var(--theme-surface,#fff);color:var(--theme-text,#333);cursor:pointer;border-radius:0';
 const BTN_ACTIVE = BTN + ';background:var(--theme-accent-soft,#cce4f7);box-shadow:inset 0 0 0 1px var(--theme-active,#0078d7)';
 
 export default function SketchModeBar() {
+  const { t } = useTranslation('statusbar');
   const [snap, setSnap] = createSignal({ visible: false });
 
   // Poll tool state (same pattern as BoxSizeOverlay) — the drawing state
@@ -28,15 +31,16 @@ export default function SketchModeBar() {
   const s = () => snap();
   const closeEnabled = () => (s().points || 0) >= 3;
   const finishEnabled = () => s().outerClosed || (s().points || 0) >= 3;
+  const undoEnabled = () => (s().points || 0) > 0;
   const statusText = () => {
     const st = s();
     if (st.phase === 'holes') {
-      const cur = st.points > 0 ? ` · bezig met opening (${st.points} ${st.points === 1 ? 'punt' : 'punten'})` : '';
-      return `Buitenrand gesloten ✓ · openingen: ${st.holes}${cur}`;
+      const cur = st.points > 0 ? t('filledAreaSketch.drawingHole', { count: st.points }) : '';
+      return t('filledAreaSketch.outerClosed', { count: st.holes }) + cur;
     }
     return st.points >= 3
-      ? `Buitenrand open — ${st.points} punten (sluitbaar)`
-      : `Buitenrand open — ${st.points} ${st.points === 1 ? 'punt' : 'punten'}`;
+      ? t('filledAreaSketch.outerOpenClosable', { count: st.points })
+      : t('filledAreaSketch.outerOpen', { count: st.points });
   };
 
   return (
@@ -59,23 +63,29 @@ export default function SketchModeBar() {
         'user-select': 'none',
       }}>
         <span style={{ opacity: 0.8, 'margin-right': '4px', 'white-space': 'nowrap' }}>{statusText()}</span>
-        <button style={!s().arcMode ? BTN_ACTIVE : BTN} title="Recht segment"
+        <button style={!s().arcMode ? BTN_ACTIVE : BTN} title={t('filledAreaSketch.lineTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => filledAreaSketch.setArcMode(false)}>Lijn</button>
-        <button style={s().arcMode ? BTN_ACTIVE : BTN} title="Boogsegment (sneltoets A, muiswiel = bolling)"
+          onClick={() => filledAreaSketch.setArcMode(false)}>{t('filledAreaSketch.line')}</button>
+        <button style={s().arcMode ? BTN_ACTIVE : BTN} title={t('filledAreaSketch.arcTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => filledAreaSketch.setArcMode(true)}>Boog</button>
+          onClick={() => filledAreaSketch.setArcMode(true)}>{t('filledAreaSketch.arc')}</button>
+        <button style={BTN + (undoEnabled() ? '' : ';opacity:0.45;cursor:default')}
+          title={t('filledAreaSketch.undoPointTitle')}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => undoEnabled() && filledAreaSketch.undoLastPoint()}>
+          ↩ {t('filledAreaSketch.undoPoint')}
+        </button>
         <button style={BTN + (closeEnabled() ? '' : ';opacity:0.45;cursor:default')}
-          title={s().phase === 'holes' ? 'Opening sluiten (≥ 3 punten)' : 'Buitenrand sluiten (≥ 3 punten) — daarna kun je openingen (donut) tekenen'}
+          title={s().phase === 'holes' ? t('filledAreaSketch.closeHoleTitle') : t('filledAreaSketch.closeOuterTitle')}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => closeEnabled() && filledAreaSketch.closeLoop()}>
-          {s().phase === 'holes' ? 'Opening sluiten' : 'Sluit contour'}
+          {s().phase === 'holes' ? t('filledAreaSketch.closeHole') : t('filledAreaSketch.closeOuter')}
         </button>
         <button style={BTN + (finishEnabled() ? ';font-weight:600' : ';opacity:0.45;cursor:default')}
-          title="Controleert of de contouren gesloten zijn, tekent de arcering en verlaat de modus (Enter)"
+          title={t('filledAreaSketch.doneTitle')}
           onMouseDown={(e) => e.preventDefault()}
-          onClick={() => finishEnabled() && filledAreaSketch.finish()}>✓ Gereed</button>
-        <button style={BTN} title="Annuleren (Esc)"
+          onClick={() => finishEnabled() && filledAreaSketch.finish()}>✓ {t('filledAreaSketch.done')}</button>
+        <button style={BTN} title={t('filledAreaSketch.cancelTitle')}
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => filledAreaSketch.cancel()}>✕</button>
       </div>

--- a/open-pdf-studio/js/tools/tools/filled-area-tool.js
+++ b/open-pdf-studio/js/tools/tools/filled-area-tool.js
@@ -20,6 +20,7 @@ import { state, getActiveDocument } from '../../core/state.js';
 import { applyToolTransform } from '../tool-context.js';
 import { createAnnotation } from '../../annotations/factory.js';
 import { recordAdd } from '../../core/undo-manager.js';
+import i18next from '../../i18n/config.js';
 import { redrawAnnotations, redrawContinuous } from '../../annotations/rendering.js';
 import { getRegionScaleFactor } from '../../annotations/scale-region.js';
 import {
@@ -298,6 +299,9 @@ export const filledAreaTool = {
       e.preventDefault();
       arcState.active = !arcState.active;
       ctx.redraw();
+    } else if (e.key === 'Backspace' && state.filledAreaPoints && state.filledAreaPoints.length > 0) {
+      e.preventDefault();
+      _undoLastPoint(ctx);
     } else if (e.key === 'Enter') {
       e.preventDefault();
       if (state.filledAreaPhase === 'holes') {
@@ -415,6 +419,15 @@ export const filledAreaSketch = {
     _resetState();
     ctx.redraw();
   },
+  // Remove the most recently placed point of the CURRENT contour (outer
+  // or the hole being drawn) without discarding the rest of the sketch —
+  // a misclick shouldn't force starting over.
+  undoLastPoint() {
+    return _undoLastPoint(_apiCtx());
+  },
+  canUndoPoint() {
+    return !!(state.filledAreaPoints && state.filledAreaPoints.length > 0);
+  },
 };
 
 function _getAllInProgressPoints() {
@@ -425,6 +438,24 @@ function _getAllInProgressPoints() {
     for (const h of (state.filledAreaHoles || [])) pts.push(...h);
   }
   return pts;
+}
+
+// Backspace / the toolbar's "Undo point" button: drop the last vertex of
+// whichever contour is currently being drawn. No-op with zero points —
+// the outer contour's first click stays a hard commitment (use Cancel/
+// Escape to abandon it entirely).
+function _undoLastPoint(ctx) {
+  if (!state.filledAreaPoints || state.filledAreaPoints.length === 0) return false;
+  state.filledAreaPoints.pop();
+  if (state.filledAreaPoints.length === 0) {
+    // Re-arm type-length capture from scratch, same as the very first click.
+    exitTypeLengthMode();
+    state._typeLengthCommit = null;
+  }
+  arcState.active = false;
+  ctx.redraw();
+  _drawInProgress(ctx);
+  return true;
 }
 
 function _resetState() {
@@ -573,7 +604,7 @@ function _drawHolesPhasePreview(ctx, cursorX, cursorY) {
   canvasCtx.font = '10px Arial';
   canvasCtx.fillStyle = strokeColor;
   canvasCtx.globalAlpha = 0.7;
-  canvasCtx.fillText('Klik voor een opening · Enter of rechtermuisklik = gereed', cursorX + 12 / scale, cursorY - 4 / scale);
+  canvasCtx.fillText(i18next.t('statusbar:filledAreaSketch.holesPhaseHint'), cursorX + 12 / scale, cursorY - 4 / scale);
   canvasCtx.globalAlpha = 1;
   canvasCtx.restore();
 }


### PR DESCRIPTION
Fixes #366.

Misclicking a point while drawing a Filled Area contour previously forced either committing the shape early or cancelling the whole sketch — no way to just remove the wrong point and continue.

## Changes
- `filled-area-tool.js`: new `_undoLastPoint()` helper wired to Backspace in `onKeyDown`, and exposed as `filledAreaSketch.undoLastPoint()` / `canUndoPoint()` for the toolbar
- `SketchModeBar.jsx`: new "Undo point" button, disabled when there's nothing to undo for the current contour (outer or the active hole)
- Bonus fix: a hardcoded Dutch canvas-drawn hint text in the holes phase (`'Klik voor een opening...'`) now goes through `i18next.t('statusbar:filledAreaSketch.holesPhaseHint')`
- Note: this branch forked from `main` before #365 merged, so `SketchModeBar.jsx` re-applies that PR's i18n wiring plus the 3 new keys here — expect overlap/conflict with #365 if both are merged as-is; recommend merging #365 first, this should then rebase cleanly since the additions are additive

## Testing
- `npm run typecheck` passes
- Verified live in `npm run tauri:dev`: placed points, confirmed status text reads "Outer contour open — N point(s)", clicked "Undo point" and confirmed the count decremented (2 → 1) and the button is styled disabled at 0 points
- Backspace itself uses the identical `onKeyDown` pattern as the existing, already-working 'A' (arc toggle) and 'Enter' handlers in the same function, but I wasn't able to independently confirm the raw keystroke in my automated browser test harness (a focus-routing quirk of the test tool, not the app) — worth a quick manual check